### PR TITLE
fix the progress bar output by calling Finish()

### DIFF
--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"github.com/cheggaaa/pb"
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/pointer"
@@ -138,11 +137,6 @@ func pushAsset(oid, filename string, index, totalFiles int) *lfs.WrappedError {
 		return lfs.Errorf(err, "Error uploading file %s (%s)", filename, oid)
 	}
 
-	stat, err := os.Stat(filename)
-	if err != nil {
-		return lfs.Errorf(err, "Error uploading file %s (%s)", filename, oid)
-	}
-
 	cb, file, cbErr := lfs.CopyCallbackFile("push", filename, index, totalFiles)
 	if cbErr != nil {
 		Error(cbErr.Error())
@@ -152,7 +146,7 @@ func pushAsset(oid, filename string, index, totalFiles int) *lfs.WrappedError {
 		defer file.Close()
 	}
 
-	fmt.Fprintf(os.Stderr, "Uploading %s (%s)\n", filename, pb.FormatBytes(stat.Size()))
+	fmt.Fprintf(os.Stderr, "Uploading %s\n", filename)
 	return lfs.Upload(path, filename, cb)
 }
 

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"github.com/cheggaaa/pb"
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/pointer"
@@ -137,6 +138,11 @@ func pushAsset(oid, filename string, index, totalFiles int) *lfs.WrappedError {
 		return lfs.Errorf(err, "Error uploading file %s (%s)", filename, oid)
 	}
 
+	stat, err := os.Stat(filename)
+	if err != nil {
+		return lfs.Errorf(err, "Error uploading file %s (%s)", filename, oid)
+	}
+
 	cb, file, cbErr := lfs.CopyCallbackFile("push", filename, index, totalFiles)
 	if cbErr != nil {
 		Error(cbErr.Error())
@@ -146,6 +152,7 @@ func pushAsset(oid, filename string, index, totalFiles int) *lfs.WrappedError {
 		defer file.Close()
 	}
 
+	fmt.Fprintf(os.Stderr, "Uploading %s (%s)\n", filename, pb.FormatBytes(stat.Size()))
 	return lfs.Upload(path, filename, cb)
 }
 

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -192,6 +192,7 @@ func Upload(oidPath, filename string, cb CopyCallback) *WrappedError {
 	req.Body = ioutil.NopCloser(bar.NewProxyReader(reader))
 
 	res, wErr = doHttpRequest(req, creds)
+	bar.Finish()
 	if wErr != nil {
 		return wErr
 	}


### PR DESCRIPTION
Somehow left this `Finish()` call out in the client rewrite for v0.5.x.  

```
[master 6bc3a3b] booya
 1 file changed, 1 insertion(+), 1 deletion(-)
Uploading test1.dat
19.07 MB / 19.07 MB  100.00 %
Counting objects: 3, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 363 bytes | 0 bytes/s, done.
Total 3 (delta 1), reused 0 (delta 0)
```