### PR TITLE
Specify that `size` property is in bytes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -265,7 +265,7 @@ response can potentially return a "verify" link relation.  If given, The Git LFS
 API expects a POST to the href after a successful upload.  Git LFS clients send:
 
 * `oid` - The String OID of the Git LFS object.
-* `size` - The integer size of the Git LFS object.
+* `size` - The integer size of the Git LFS object, in bytes.
 
 ```
 > POST https://git-lfs-server.com/callback


### PR DESCRIPTION
It's not clear from the documentation that `size` is in bytes, since it's only described as "an integer".