### PR TITLE
Sudo is not necessary for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
 script: script/cibuild
-sudo: required
 notifications:
   email: false


### PR DESCRIPTION
The build failures were actually caused by the git config issue that was fixed later in #181.