### PR TITLE
Correct lfs url git config sample.

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -62,11 +62,11 @@ configuration options:
 [core]
   repositoryformatversion = 0
 [lfs]
-  endpoint = "https://github.com/github/git-lfs.git/info/lfs"
+  url = "https://github.com/github/git-lfs.git/info/lfs"
 [remote "origin"]
   url = https://github.com/github/git-lfs
   fetch = +refs/heads/*:refs/remotes/origin/*
-  lfs = "https://github.com/github/git-lfs.git/info/lfs"
+  lfs_url = "https://github.com/github/git-lfs.git/info/lfs"
 ```
 
 Git LFS uses `git credential` to fetch credentials for HTTPS requests.  Setup


### PR DESCRIPTION
`lfs.endpoint` and `remote.NAME.lfs` are not used, `lfs.url` and `remote.NAME.lfs_url` are.

See [the spec](https://github.com/github/git-lfs/blob/master/docs/spec.md#the-server).