### PR TITLE
Spec: clarify that filepath sharding is used in .git/lfs/objects/

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -81,6 +81,11 @@ global filters can be set up with `git lfs init`:
 $ git lfs init
 ```
 
+These filters ensure that large files aren't written into the repository proper,
+instead being stored locally at `.git/lfs/objects/{OID-PATH}` (where `{OID-PATH}`
+is a sharded filepath of the form `OID[0:2]/OID[2:4]/OID`), synchronized with
+the remote LFS server as necessary.
+
 The `clean` filter runs as files are added to repositories.  Git sends the
 content of the file being added as STDIN, and expects the content to write
 to Git as STDOUT.
@@ -93,8 +98,6 @@ signature.
   * Move the temp file to `.git/lfs/objects/{OID-PATH}`.
 * Delete the temp file.
 * Write the pointer file to STDOUT.
-
-`{OID-PATH}` is a sharded filepath of the form `OID[0:2]/OID[2:4]/OID`.
 
 Note that the `clean` filter does not push the file to the server.  Use the
 `git lfs sync` command to do that.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -87,12 +87,14 @@ to Git as STDOUT.
 
 * Stream binary content from STDIN to a temp file, while calculating its SHA-256
 signature.
-* Check for the file at `.git/lfs/objects/{OID}`.
+* Check for the file at `.git/lfs/objects/{OID-PATH}`.
 * If it does not exist:
   * Queue the OID to be uploaded.
-  * Move the temp file to `.git/lfs/objects/{OID}`.
+  * Move the temp file to `.git/lfs/objects/{OID-PATH}`.
 * Delete the temp file.
 * Write the pointer file to STDOUT.
+
+`{OID-PATH}` is a sharded filepath of the form `OID[0:2]/OID[2:4]/OID`.
 
 Note that the `clean` filter does not push the file to the server.  Use the
 `git lfs sync` command to do that.
@@ -103,7 +105,7 @@ expects the content to write to the working directory as STDOUT.
 
 * Read 100 bytes.
 * If the content is ASCII and matches the pointer file format:
-  * Look for the file in `.git/lfs/objects/{OID}`.
+  * Look for the file in `.git/lfs/objects/{OID-PATH}`.
   * If it's not there, download it from the server.
   * Read its contents to STDOUT
 * Otherwise, simply pass the STDIN out through STDOUT.


### PR DESCRIPTION
I'd only read the LFS spec, and not the code - thanks to @mhagger for setting me straight last night at the Git Birthday Party! The support I'm trying to put into the [BFG](https://rtyley.github.io/bfg-repo-cleaner/) has to put files in the same place as the Git LFS client, obviously - I got it [wrong](https://github.com/rtyley/bfg-repo-cleaner/blob/git-lfs-alpha/bfg-library/src/main/scala/com/madgag/git/bfg/cleaner/LfsBlobConverter.scala#L78) because I didn't check the implementation:

https://github.com/github/git-lfs/blob/a0d389385/lfs/lfs.go#L44
https://github.com/github/git-lfs/blob/a0d389385/commands/smudge_test.go#L54-L55
