### PR TITLE
pre-push hook: properly quote args that are passed along

### DIFF
--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	valueRegexp           = regexp.MustCompile("\\Agit[\\-\\s]media")
-	prePushHook           = []byte("#!/bin/sh\ngit lfs push --stdin $*\n")
+	prePushHook           = []byte("#!/bin/sh\ngit lfs push --stdin \"$@\"\n")
 	NotInARepositoryError = errors.New("Not in a repository")
 )
 


### PR DESCRIPTION
Properly quote the arguments that are passed to `git lfs push --stdin` just in case they contain any shell metacharacters.
