### PR TITLE
use remote.{name}.lfsurl to specify an endpoint per remote

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -52,7 +52,7 @@ can have different Git LFS endpoints for different remotes.  Here is the list
 of rules that Git LFS uses to determine a repository's Git LFS server:
 
 1. The `lfs.url` string.
-2. The `remote.{name}.lfs_url` string.
+2. The `remote.{name}.lfsurl` string.
 3. Append `/info/lfs` to the remote URL.  Only works with HTTPS URLs.
 
 Here's a sample Git config file with the optional remote and Git LFS

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -72,7 +72,7 @@ func (c *Configuration) RemoteEndpoint(remote string) Endpoint {
 		remote = defaultRemote
 	}
 
-	if url, ok := c.GitConfig("remote." + remote + ".lfs_url"); ok {
+	if url, ok := c.GitConfig("remote." + remote + ".lfsurl"); ok {
 		return Endpoint{Url: url}
 	}
 

--- a/lfs/config_test.go
+++ b/lfs/config_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestEndpointDefaultsToOrigin(t *testing.T) {
 	config := &Configuration{
-		gitConfig: map[string]string{"remote.origin.lfs_url": "abc"},
+		gitConfig: map[string]string{"remote.origin.lfsurl": "abc"},
 		remotes:   []string{},
 	}
 
@@ -20,8 +20,8 @@ func TestEndpointDefaultsToOrigin(t *testing.T) {
 func TestEndpointOverridesOrigin(t *testing.T) {
 	config := &Configuration{
 		gitConfig: map[string]string{
-			"lfs.url":               "abc",
-			"remote.origin.lfs_url": "def",
+			"lfs.url":              "abc",
+			"remote.origin.lfsurl": "def",
 		},
 		remotes: []string{},
 	}
@@ -35,8 +35,8 @@ func TestEndpointOverridesOrigin(t *testing.T) {
 func TestEndpointNoOverrideDefaultRemote(t *testing.T) {
 	config := &Configuration{
 		gitConfig: map[string]string{
-			"remote.origin.lfs_url": "abc",
-			"remote.other.lfs_url":  "def",
+			"remote.origin.lfsurl": "abc",
+			"remote.other.lfsurl":  "def",
 		},
 		remotes: []string{},
 	}
@@ -50,8 +50,8 @@ func TestEndpointNoOverrideDefaultRemote(t *testing.T) {
 func TestEndpointUseAlternateRemote(t *testing.T) {
 	config := &Configuration{
 		gitConfig: map[string]string{
-			"remote.origin.lfs_url": "abc",
-			"remote.other.lfs_url":  "def",
+			"remote.origin.lfsurl": "abc",
+			"remote.other.lfsurl":  "def",
 		},
 		remotes: []string{},
 	}
@@ -91,8 +91,8 @@ func TestBareEndpointAddsLfsSuffix(t *testing.T) {
 func TestSSHEndpointOverridden(t *testing.T) {
 	config := &Configuration{
 		gitConfig: map[string]string{
-			"remote.origin.url":     "git@example.com:foo/bar",
-			"remote.origin.lfs_url": "lfs",
+			"remote.origin.url":    "git@example.com:foo/bar",
+			"remote.origin.lfsurl": "lfs",
 		},
 		remotes: []string{},
 	}


### PR DESCRIPTION
Fixes #206

```
$ git config remote.master.lfs_url whatever
error: invalid key: remote.master.lfs_url
```