### PR TITLE
add the optional HREF key to the SSH output

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19,9 +19,9 @@ remote's, Git LFS will not prompt you again to enter the password.
 
 If the Git remote is using SSH, Git LFS will execute the `git-lfs-authenticate`
 command.  It passes the SSH path, the Git LFS operation (upload or download),
-and the object OID as arguments. A successful result outputs a JSON header
-object to STDOUT.  This is applied to any Git LFS API request before git
-credentials are accessed.
+and the object OID as arguments. A successful result outputs a JSON link object
+to STDOUT.  This is applied to any Git LFS API request before git credentials
+are accessed.
 
 ```
 # remote: git@github.com:user/repo.git
@@ -30,6 +30,10 @@ $ ssh git@github.com git-lfs-authenticate user/repo.git download {oid}
   "header": {
     "Authorization": "Basic ..."
   }
+  // OPTIONAL key only needed if the Git LFS server is not hosted at the default
+  // URL from the Git remote:
+  //   https://github.com/user/repo.git/info/lfs/objects
+  "href": "https://other-server.com/user/repo/objects",
 }
 ```
 

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -376,6 +376,17 @@ func newApiRequest(method, oid string) (*http.Request, Creds, error) {
 		operation = "upload"
 	}
 
+	res, err := sshAuthenticate(endpoint, operation, oid)
+	if err != nil {
+		tracerx.Printf("ssh: attempted with %s.  Error: %s",
+			endpoint.SshUserAndHost, err.Error(),
+		)
+	}
+
+	if len(res.Href) > 0 {
+		endpoint.Url = res.Href
+	}
+
 	u, err := ObjectUrl(endpoint, objectOid)
 	if err != nil {
 		return nil, nil, err
@@ -384,10 +395,10 @@ func newApiRequest(method, oid string) (*http.Request, Creds, error) {
 	req, creds, err := newClientRequest(method, u.String())
 	if err == nil {
 		req.Header.Set("Accept", mediaType)
-		if err := mergeSshHeader(req.Header, endpoint, operation, oid); err != nil {
-			tracerx.Printf("ssh: attempted with %s.  Error: %s",
-				endpoint.SshUserAndHost, err.Error(),
-			)
+		if res.Header != nil {
+			for key, value := range res.Header {
+				req.Header.Set(key, value)
+			}
 		}
 	}
 	return req, creds, err

--- a/lfs/ssh.go
+++ b/lfs/ssh.go
@@ -3,36 +3,22 @@ package lfs
 import (
 	"encoding/json"
 	"github.com/rubyist/tracerx"
-	"net/http"
 	"os/exec"
 )
 
 type sshAuthResponse struct {
 	Message   string            `json:"-"`
+	Href      string            `json:"href"`
 	Header    map[string]string `json:"header"`
 	ExpiresAt string            `json:"expires_at"`
 }
 
-func mergeSshHeader(header http.Header, endpoint Endpoint, operation, oid string) error {
-	if len(endpoint.SshUserAndHost) == 0 {
-		return nil
-	}
-
-	res, err := sshAuthenticate(endpoint, operation, oid)
-	if err != nil {
-		return err
-	}
-
-	if res.Header != nil {
-		for key, value := range res.Header {
-			header.Set(key, value)
-		}
-	}
-
-	return nil
-}
-
 func sshAuthenticate(endpoint Endpoint, operation, oid string) (sshAuthResponse, error) {
+	res := sshAuthResponse{}
+	if len(endpoint.SshUserAndHost) == 0 {
+		return res, nil
+	}
+
 	tracerx.Printf("ssh: %s git-lfs-authenticate %s %s %s",
 		endpoint.SshUserAndHost, endpoint.SshPath, operation, oid)
 	cmd := exec.Command("ssh", endpoint.SshUserAndHost,
@@ -42,7 +28,6 @@ func sshAuthenticate(endpoint Endpoint, operation, oid string) (sshAuthResponse,
 	)
 
 	out, err := cmd.CombinedOutput()
-	res := sshAuthResponse{}
 
 	if err != nil {
 		res.Message = string(out)


### PR DESCRIPTION
/cc #242 @ddanier

I'm keeping the issue open until we can figure out how to securely cache the tokens.

* [x] Update client to look for the `href` property