### PR TITLE
better error message if you call git-lfs with GIT_TERMINAL_PROMPT

### DIFF
--- a/lfs/credentials.go
+++ b/lfs/credentials.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -88,6 +89,13 @@ func init() {
 		err := cmd.Start()
 		if err == nil {
 			err = cmd.Wait()
+		}
+
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if exitErr.ProcessState.Success() == false && os.Getenv("GIT_TERMINAL_PROMPT") == "0" {
+				return nil, fmt.Errorf("Change the GIT_TERMINAL_PROMPT env var to be prompted to enter your credentials for %s://%s.",
+					input["protocol"], input["host"])
+			}
 		}
 
 		if err != nil {


### PR DESCRIPTION
This would've made #209 super easy to troubleshoot.

```
$ GIT_TERMINAL_PROMPT=0 git push dev master
Uploading droidtocat.gif
Change the GIT_TERMINAL_PROMPT env var to be prompted to enter your credentials for https://some-git-lfs-server.com
```

/cc @kevinSuttle