### PR TITLE
Split push cmd

### DIFF
--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -1,56 +1,37 @@
 package commands
 
 import (
-	"fmt"
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
-	"github.com/github/git-lfs/pointer"
 	"github.com/github/git-lfs/scanner"
-	"github.com/rubyist/tracerx"
 	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 )
 
 var (
 	pushCmd = &cobra.Command{
 		Use:   "push",
-		Short: "Push files to the Git LFS endpoint",
+		Short: "Push files to the Git LFS server",
 		Run:   pushCommand,
 	}
-	dryRun       = false
-	useStdin     = false
-	deleteBranch = "(delete)"
+	pushDryRun       = false
+	pushDeleteBranch = "(delete)"
+	useStdin         = false
+
+	// shares some global vars and functions with commmands_pre_push.go
 )
 
-// pushCommand is the command that's run via `git lfs push`. It has two modes
-// of operation. The primary mode is run via the git pre-push hook. The pre-push
-// hook passes two arguments on the command line:
-//   1. Name of the remote to which the push is being done
-//   2. URL to which the push is being done
+// pushCommand pushes local objects to a Git LFS server.  It takes two
+// arguments:
 //
-// The hook receives commit information on stdin in the form:
-//   <local ref> <local sha1> <remote ref> <remote sha1>
+//   `<remote> <remote ref>`
 //
-// In the typical case, pushCommand will get a list of git objects being pushed
-// by using the following:
-//    git rev-list --objects <local sha1> ^<remote sha1>
+// Both a remote name ("origin") or a remote URL are accepted.
 //
-// If any of those git objects are associated with Git LFS objects, those
-// objects will be pushed to the Git LFS API.
-//
-// In the case of pushing a new branch, the list of git objects will be all of
-// the git objects in this branch.
-//
-// In the case of deleting a branch, no attempts to push Git LFS objects will be
-// made.
-//
-// The other mode of operation is the dry run mode. In this mode, the repo
-// and refspec are passed on the command line. pushCommand will calculate the
-// git objects that would be pushed in a similar manner as above and will print
-// out each file name.
+// pushCommand calculates the git objects to send by looking comparing the range
+// of commits between the local and remote git servers.
 func pushCommand(cmd *cobra.Command, args []string) {
 	var left, right string
 
@@ -72,20 +53,20 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		}
 
 		left, right = decodeRefs(string(refsData))
-		if left == deleteBranch {
+		if left == pushDeleteBranch {
 			return
 		}
 	} else {
-		var repo, refspec string
+		var remoteArg, refArg string
 
 		if len(args) < 1 {
-			Print("Usage: git lfs push --dry-run <repo> [refspec]")
+			Print("Usage: git lfs push --dry-run <remote> [ref]")
 			return
 		}
 
-		repo = args[0]
+		remoteArg = args[0]
 		if len(args) == 2 {
-			refspec = args[1]
+			refArg = args[1]
 		}
 
 		localRef, err := git.CurrentRef()
@@ -94,7 +75,7 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		}
 		left = localRef
 
-		remoteRef, err := git.LsRemote(repo, refspec)
+		remoteRef, err := git.LsRemote(remoteArg, refArg)
 		if err != nil {
 			Panic(err, "Error getting remote ref")
 		}
@@ -111,7 +92,7 @@ func pushCommand(cmd *cobra.Command, args []string) {
 	}
 
 	for i, pointer := range pointers {
-		if dryRun {
+		if pushDryRun {
 			Print("push %s", pointer.Name)
 			continue
 		}
@@ -125,85 +106,8 @@ func pushCommand(cmd *cobra.Command, args []string) {
 	}
 }
 
-// pushAsset pushes the asset with the given oid to the Git LFS API.
-func pushAsset(oid, filename string, index, totalFiles int) *lfs.WrappedError {
-	tracerx.Printf("checking_asset: %s %s %d/%d", oid, filename, index, totalFiles)
-	path, err := lfs.LocalMediaPath(oid)
-	if err != nil {
-		return lfs.Errorf(err, "Error uploading file %s (%s)", filename, oid)
-	}
-
-	if err := ensureFile(filename, path); err != nil {
-		return lfs.Errorf(err, "Error uploading file %s (%s)", filename, oid)
-	}
-
-	cb, file, cbErr := lfs.CopyCallbackFile("push", filename, index, totalFiles)
-	if cbErr != nil {
-		Error(cbErr.Error())
-	}
-
-	if file != nil {
-		defer file.Close()
-	}
-
-	fmt.Fprintf(os.Stderr, "Uploading %s\n", filename)
-	return lfs.Upload(path, filename, cb)
-}
-
-// ensureFile makes sure that the cleanPath exists before pushing it.  If it
-// does not exist, it attempts to clean it by reading the file at smudgePath.
-func ensureFile(smudgePath, cleanPath string) error {
-	if _, err := os.Stat(cleanPath); err == nil {
-		return nil
-	}
-
-	expectedOid := filepath.Base(cleanPath)
-	localPath := filepath.Join(lfs.LocalWorkingDir, smudgePath)
-	file, err := os.Open(localPath)
-	if err != nil {
-		return err
-	}
-
-	defer file.Close()
-
-	stat, err := file.Stat()
-	if err != nil {
-		return err
-	}
-
-	cleaned, err := pointer.Clean(file, stat.Size(), nil)
-	if err != nil {
-		return err
-	}
-
-	cleaned.Close()
-
-	if expectedOid != cleaned.Oid {
-		return fmt.Errorf("Expected %s to have an OID of %s, got %s", smudgePath, expectedOid, cleaned.Oid)
-	}
-
-	return nil
-}
-
-// decodeRefs pulls the sha1s out of the line read from the pre-push
-// hook's stdin.
-func decodeRefs(input string) (string, string) {
-	refs := strings.Split(strings.TrimSpace(input), " ")
-	var left, right string
-
-	if len(refs) > 1 {
-		left = refs[1]
-	}
-
-	if len(refs) > 3 {
-		right = "^" + refs[3]
-	}
-
-	return left, right
-}
-
 func init() {
-	pushCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "Do everything except actually send the updates")
+	pushCmd.Flags().BoolVarP(&pushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")
 	pushCmd.Flags().BoolVarP(&useStdin, "stdin", "s", false, "Take refs on stdin (for pre-push hook)")
 	RootCmd.AddCommand(pushCmd)
 }

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -36,7 +36,7 @@ func pushCommand(cmd *cobra.Command, args []string) {
 	var left, right string
 
 	if len(args) == 0 {
-		Print("The git lfs pre-push hook is out of date. Please run `git lfs update`")
+		Print("Specify a remote and a remote branch name (`git lfs push origin master`)")
 		os.Exit(1)
 	}
 

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -43,6 +43,10 @@ func pushCommand(cmd *cobra.Command, args []string) {
 	lfs.Config.CurrentRemote = args[0]
 
 	if useStdin {
+		// called from a pre-push hook!  Update the existing pre-push hook if it's
+		// one that git-lfs set.
+		lfs.InstallHooks(false)
+
 		refsData, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
 			Panic(err, "Error reading refs on stdin")

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -11,6 +11,8 @@ var (
 		Short: "Update local Git LFS configuration",
 		Run:   updateCommand,
 	}
+
+	updateForce = false
 )
 
 // updateCommand is used for updating parts of Git LFS that reside under
@@ -21,10 +23,16 @@ func updateCommand(cmd *cobra.Command, args []string) {
 
 // updatePrePushHook will force an update of the pre-push hook.
 func updatePrePushHook() {
-	lfs.InstallHooks(true)
-	Print("Updated pre-push hook")
+	if err := lfs.InstallHooks(updateForce); err != nil {
+		Error(err.Error())
+		Print("Run `git lfs update --force` to overwrite this hook.")
+	} else {
+		Print("Updated pre-push hook")
+	}
+
 }
 
 func init() {
+	updateCmd.Flags().BoolVarP(&updateForce, "force", "f", false, "Overwrite hooks.")
 	RootCmd.AddCommand(updateCmd)
 }

--- a/commands/commands_pre_push.go
+++ b/commands/commands_pre_push.go
@@ -1,0 +1,174 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/github/git-lfs/lfs"
+	"github.com/github/git-lfs/pointer"
+	"github.com/github/git-lfs/scanner"
+	"github.com/rubyist/tracerx"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	prePushCmd = &cobra.Command{
+		Use:   "pre-push",
+		Short: "Implements the Git pre-push hook",
+		Run:   prePushCommand,
+	}
+	prePushDryRun       = false
+	prePushDeleteBranch = "(delete)"
+)
+
+// prePushCommand is run through Git's pre-push hook. The pre-push hook passes
+// two arguments on the command line:
+//
+//   1. Name of the remote to which the push is being done
+//   2. URL to which the push is being done
+//
+// The hook receives commit information on stdin in the form:
+//   <local ref> <local sha1> <remote ref> <remote sha1>
+//
+// In the typical case, prePushCommand will get a list of git objects being
+// pushed by using the following:
+//
+//    git rev-list --objects <local sha1> ^<remote sha1>
+//
+// If any of those git objects are associated with Git LFS objects, those
+// objects will be pushed to the Git LFS API.
+//
+// In the case of pushing a new branch, the list of git objects will be all of
+// the git objects in this branch.
+//
+// In the case of deleting a branch, no attempts to push Git LFS objects will be
+// made.
+func prePushCommand(cmd *cobra.Command, args []string) {
+	var left, right string
+
+	if len(args) == 0 {
+		Print("This should be run through Git's pre-push hook.  Run `git lfs update` to install it.")
+		os.Exit(1)
+	}
+
+	lfs.Config.CurrentRemote = args[0]
+
+	refsData, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		Panic(err, "Error reading refs on stdin")
+	}
+
+	if len(refsData) == 0 {
+		return
+	}
+
+	left, right = decodeRefs(string(refsData))
+	if left == prePushDeleteBranch {
+		return
+	}
+
+	// Just use scanner here
+	pointers, err := scanner.Scan(left, right)
+	if err != nil {
+		Panic(err, "Error scanning for Git LFS files")
+	}
+
+	for i, pointer := range pointers {
+		if prePushDryRun {
+			Print("push %s", pointer.Name)
+			continue
+		}
+
+		if wErr := pushAsset(pointer.Oid, pointer.Name, i+1, len(pointers)); wErr != nil {
+			if Debugging || wErr.Panic {
+				Panic(wErr.Err, wErr.Error())
+			} else {
+				Exit(wErr.Error())
+			}
+		}
+	}
+}
+
+// pushAsset pushes the asset with the given oid to the Git LFS API.
+func pushAsset(oid, filename string, index, totalFiles int) *lfs.WrappedError {
+	tracerx.Printf("checking_asset: %s %s %d/%d", oid, filename, index, totalFiles)
+	path, err := lfs.LocalMediaPath(oid)
+	if err != nil {
+		return lfs.Errorf(err, "Error uploading file %s (%s)", filename, oid)
+	}
+
+	if err := ensureFile(filename, path); err != nil {
+		return lfs.Errorf(err, "Error uploading file %s (%s)", filename, oid)
+	}
+
+	cb, file, cbErr := lfs.CopyCallbackFile("push", filename, index, totalFiles)
+	if cbErr != nil {
+		Error(cbErr.Error())
+	}
+
+	if file != nil {
+		defer file.Close()
+	}
+
+	fmt.Fprintf(os.Stderr, "Uploading %s\n", filename)
+	return lfs.Upload(path, filename, cb)
+}
+
+// ensureFile makes sure that the cleanPath exists before pushing it.  If it
+// does not exist, it attempts to clean it by reading the file at smudgePath.
+func ensureFile(smudgePath, cleanPath string) error {
+	if _, err := os.Stat(cleanPath); err == nil {
+		return nil
+	}
+
+	expectedOid := filepath.Base(cleanPath)
+	localPath := filepath.Join(lfs.LocalWorkingDir, smudgePath)
+	file, err := os.Open(localPath)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	stat, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	cleaned, err := pointer.Clean(file, stat.Size(), nil)
+	if err != nil {
+		return err
+	}
+
+	cleaned.Close()
+
+	if expectedOid != cleaned.Oid {
+		return fmt.Errorf("Expected %s to have an OID of %s, got %s", smudgePath, expectedOid, cleaned.Oid)
+	}
+
+	return nil
+}
+
+// decodeRefs pulls the sha1s out of the line read from the pre-push
+// hook's stdin.
+func decodeRefs(input string) (string, string) {
+	refs := strings.Split(strings.TrimSpace(input), " ")
+	var left, right string
+
+	if len(refs) > 1 {
+		left = refs[1]
+	}
+
+	if len(refs) > 3 {
+		right = "^" + refs[3]
+	}
+
+	return left, right
+}
+
+func init() {
+	prePushCmd.Flags().BoolVarP(&prePushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")
+	RootCmd.AddCommand(prePushCmd)
+}

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -47,7 +47,7 @@ func TestInit(t *testing.T) {
 	})
 
 	cmd = repo.Command("init")
-	cmd.Output = "Hook already exists: pre-push\ngit lfs initialized"
+	cmd.Output = "Hook already exists: pre-push\n\necho 'yo'\n\ngit lfs initialized"
 
 	customHook := []byte("echo 'yo'")
 	cmd.Before(func() {

--- a/commands/pre_push_test.go
+++ b/commands/pre_push_test.go
@@ -1,0 +1,41 @@
+package commands
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrePushWithEmptyQueue(t *testing.T) {
+	repo := NewRepository(t, "empty")
+	defer repo.Test()
+
+	cmd := repo.Command("pre-push", "--dry-run", "origin", "https://git-remote.com")
+	cmd.Input = strings.NewReader("refs/heads/master master refs/heads/master 2206c37dddba83f58b1ada72709a6b60cf8b058e")
+	cmd.Output = ""
+}
+
+func TestPrePushToMaster(t *testing.T) {
+	repo := NewRepository(t, "empty")
+	defer repo.Test()
+
+	cmd := repo.Command("pre-push", "--dry-run", "origin", "https://git-remote.com")
+	cmd.Input = strings.NewReader("refs/heads/master master refs/heads/master 2206c37dddba83f58b1ada72709a6b60cf8b058e")
+	cmd.Output = "push a.dat"
+
+	cmd.Before(func() {
+		repo.GitCmd("remote", "remove", "origin")
+
+		originPath := filepath.Join(Root, "commands", "repos", "empty.git")
+		repo.GitCmd("remote", "add", "origin", originPath)
+
+		repo.GitCmd("fetch")
+
+		repo.WriteFile(filepath.Join(repo.Path, ".gitattributes"), "*.dat filter=lfs -crlf\n")
+
+		// Add a Git LFS file
+		repo.WriteFile(filepath.Join(repo.Path, "a.dat"), "some data")
+		repo.GitCmd("add", "a.dat")
+		repo.GitCmd("commit", "-m", "a")
+	})
+}

--- a/commands/update_test.go
+++ b/commands/update_test.go
@@ -1,0 +1,188 @@
+package commands
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+)
+
+func TestUpdateWithoutPrePushHook(t *testing.T) {
+	repo := NewRepository(t, "empty")
+	defer repo.Test()
+
+	repo.AddPath(repo.Path, ".git")
+	repo.AddPath(repo.Path, "subdir")
+
+	cmd := repo.Command("update")
+	cmd.Output = "Updated pre-push hook"
+
+	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
+
+	cmd.After(func() {
+		by, err := ioutil.ReadFile(prePushHookFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if string(by) != "#!/bin/sh\ngit lfs pre-push \"$@\"\n" {
+			t.Errorf("Unexpected pre-push hook:\n%s", string(by))
+		}
+	})
+}
+
+func TestUpdateWithLatestPrePushHook(t *testing.T) {
+	repo := NewRepository(t, "empty")
+	defer repo.Test()
+
+	repo.AddPath(repo.Path, ".git")
+	repo.AddPath(repo.Path, "subdir")
+
+	cmd := repo.Command("update")
+	cmd.Output = "Updated pre-push hook"
+
+	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
+
+	cmd.Before(func() {
+		err := ioutil.WriteFile(prePushHookFile, []byte("#!/bin/sh\ngit lfs pre-push \"$@\"\n"), 0755)
+		if err != nil {
+			t.Fatalf("Error writing pre-push in Before(): %s", err)
+		}
+	})
+
+	cmd.After(func() {
+		by, err := ioutil.ReadFile(prePushHookFile)
+		if err != nil {
+			t.Fatalf("Error writing pre-push in After(): %s", err)
+		}
+
+		if string(by) != "#!/bin/sh\ngit lfs pre-push \"$@\"\n" {
+			t.Errorf("Unexpected pre-push hook:\n%s", string(by))
+		}
+	})
+}
+
+func TestUpdateForce(t *testing.T) {
+	repo := NewRepository(t, "empty")
+	defer repo.Test()
+
+	repo.AddPath(repo.Path, ".git")
+	repo.AddPath(repo.Path, "subdir")
+
+	cmd := repo.Command("update", "--force")
+	cmd.Output = "Updated pre-push hook"
+
+	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
+
+	cmd.Before(func() {
+		err := ioutil.WriteFile(prePushHookFile, []byte("sup\n"), 0755)
+		if err != nil {
+			t.Fatalf("Error writing pre-push in Before(): %s", err)
+		}
+	})
+
+	cmd.After(func() {
+		by, err := ioutil.ReadFile(prePushHookFile)
+		if err != nil {
+			t.Fatalf("Error writing pre-push in After(): %s", err)
+		}
+
+		if string(by) != "#!/bin/sh\ngit lfs pre-push \"$@\"\n" {
+			t.Errorf("Unexpected pre-push hook:\n%s", string(by))
+		}
+	})
+}
+
+func TestUpdateWithUnexpectedPrePushHook(t *testing.T) {
+	repo := NewRepository(t, "empty")
+	defer repo.Test()
+
+	repo.AddPath(repo.Path, ".git")
+	repo.AddPath(repo.Path, "subdir")
+
+	cmd := repo.Command("update")
+	cmd.Output = "Hook already exists: pre-push\n\n" +
+		"test\n\n" +
+		"Run `git lfs update --force` to overwrite this hook."
+
+	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
+
+	cmd.Before(func() {
+		err := ioutil.WriteFile(prePushHookFile, []byte("test\n"), 0755)
+		if err != nil {
+			t.Fatalf("Error writing pre-push in Before(): %s", err)
+		}
+	})
+
+	cmd.After(func() {
+		by, err := ioutil.ReadFile(prePushHookFile)
+		if err != nil {
+			t.Fatalf("Error writing pre-push in After(): %s", err)
+		}
+
+		if string(by) != "test\n" {
+			t.Errorf("Unexpected pre-push hook:\n%s", string(by))
+		}
+	})
+}
+
+func TestUpdateWithOldPrePushHook_1(t *testing.T) {
+	repo := NewRepository(t, "empty")
+	defer repo.Test()
+
+	repo.AddPath(repo.Path, ".git")
+	repo.AddPath(repo.Path, "subdir")
+
+	cmd := repo.Command("update")
+	cmd.Output = "Updated pre-push hook"
+
+	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
+
+	cmd.Before(func() {
+		err := ioutil.WriteFile(prePushHookFile, []byte("#!/bin/sh\ngit lfs push --stdin $*\n"), 0755)
+		if err != nil {
+			t.Fatalf("Error writing pre-push in Before(): %s", err)
+		}
+	})
+
+	cmd.After(func() {
+		by, err := ioutil.ReadFile(prePushHookFile)
+		if err != nil {
+			t.Fatalf("Error writing pre-push in After(): %s", err)
+		}
+
+		if string(by) != "#!/bin/sh\ngit lfs pre-push \"$@\"\n" {
+			t.Errorf("Unexpected pre-push hook:\n%s", string(by))
+		}
+	})
+}
+
+func TestUpdateWithOldPrePushHook_2(t *testing.T) {
+	repo := NewRepository(t, "empty")
+	defer repo.Test()
+
+	repo.AddPath(repo.Path, ".git")
+	repo.AddPath(repo.Path, "subdir")
+
+	cmd := repo.Command("update")
+	cmd.Output = "Updated pre-push hook"
+
+	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
+
+	cmd.Before(func() {
+		err := ioutil.WriteFile(prePushHookFile, []byte("#!/bin/sh\ngit lfs push --stdin \"$@\"\n"), 0755)
+		if err != nil {
+			t.Fatalf("Error writing pre-push in Before(): %s", err)
+		}
+	})
+
+	cmd.After(func() {
+		by, err := ioutil.ReadFile(prePushHookFile)
+		if err != nil {
+			t.Fatalf("Error writing pre-push in After(): %s", err)
+		}
+
+		if string(by) != "#!/bin/sh\ngit lfs pre-push \"$@\"\n" {
+			t.Errorf("Unexpected pre-push hook:\n%s", string(by))
+		}
+	})
+}

--- a/docs/man/git-lfs-ls-files.1.ronn
+++ b/docs/man/git-lfs-ls-files.1.ronn
@@ -7,8 +7,8 @@ git-lfs-ls-files(1) -- Show information about git lfs files in the index and wor
 
 ## DESCRIPTION
 
-Display paths of Git LFS files that are found in the given reference.  If no reference is 
-given, scan the currently checked-out branch.
+Display paths of Git LFS files that are found in the given reference.  If no
+reference is given, scan the currently checked-out branch.
 
 ## SEE ALSO
 

--- a/docs/man/git-lfs-pre-push.1.ronn
+++ b/docs/man/git-lfs-pre-push.1.ronn
@@ -1,0 +1,21 @@
+git-lfs-pre-push(1) -- Git pre-push hook implementation
+=======================================================
+
+## SYNOPSIS
+
+`git lfs pre-push` <remote> [remoteurl]
+
+## DESCRIPTION
+
+Responds to Git pre-hook events. It reads the range of commits from STDIN, in
+the following format:
+
+    <local-ref> SP <local-sha1> SP <remote-ref> SP <remote-sha1> \n
+
+It also takes the remote name and URL as arguments.
+
+## SEE ALSO
+
+git-lfs-clean(1), git-lfs-push(1).
+
+Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-push.1.ronn
+++ b/docs/man/git-lfs-push.1.ronn
@@ -3,7 +3,7 @@ git-lfs-push(1) -- Push queued large files to the Git LFS endpoint
 
 ## SYNOPSIS
 
-`git lfs push` <repo> [refspec]
+`git lfs push` <remote> [branch]
 
 ## DESCRIPTION
 
@@ -25,6 +25,6 @@ Push is typically run by Git's pre-push hook.
 
 ## SEE ALSO
 
-git-lfs-clean(1).
+git-lfs-clean(1), git-lfs-pre-push(1).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-push.1.ronn
+++ b/docs/man/git-lfs-push.1.ronn
@@ -16,8 +16,8 @@ Git remote.
     Print the files that would be pushed, without actually pushing them.
 
 * `--stdin`:
-    Read the repo and refspec on stdin. This is used in conjunction with
-    the pre-push hook and must be in the format used by the pre-push hook:
+    Read the remote and branch on stdin. This is used in conjunction with the
+    pre-push hook and must be in the format used by the pre-push hook:
     <local-ref> <local-sha1> <remote-ref> <remote-sha1>. If --stdin is used
     the command line arguments are ignored.  NOTE: This is deprecated in favor
     of the `pre-push` command.

--- a/docs/man/git-lfs-push.1.ronn
+++ b/docs/man/git-lfs-push.1.ronn
@@ -10,8 +10,6 @@ git-lfs-push(1) -- Push queued large files to the Git LFS endpoint
 Upload Git LFS files to the configured endpoint for the current
 Git remote.
 
-Push is typically run by Git's pre-push hook.
-
 ## OPTIONS
 
 * `--dry-run`:
@@ -21,7 +19,8 @@ Push is typically run by Git's pre-push hook.
     Read the repo and refspec on stdin. This is used in conjunction with
     the pre-push hook and must be in the format used by the pre-push hook:
     <local-ref> <local-sha1> <remote-ref> <remote-sha1>. If --stdin is used
-    the command line arguments are ignored.
+    the command line arguments are ignored.  NOTE: This is deprecated in favor
+    of the `pre-push` command.
 
 ## SEE ALSO
 

--- a/docs/man/git-lfs-update.1.ronn
+++ b/docs/man/git-lfs-update.1.ronn
@@ -1,0 +1,15 @@
+git-lfs-update(1) -- Update Git hooks
+=====================================
+
+## SYNOPSIS
+
+`git lfs update` [--force]
+
+## DESCRIPTION
+
+Updates the Git hooks used by Git LFS. Silently upgrades known hook contents.
+Pass `--force` to upgrade the hooks, clobbering any existing contents.
+
+## SEE ALSO
+
+Part of the git-lfs(1) suite.

--- a/git/git.go
+++ b/git/git.go
@@ -10,15 +10,15 @@ import (
 	"strings"
 )
 
-func LsRemote(repo, refspec string) (string, error) {
-	if repo == "" {
-		return "", errors.New("repo required")
+func LsRemote(remote, remoteRef string) (string, error) {
+	if remote == "" {
+		return "", errors.New("remote required")
 	}
-	if refspec == "" {
-		return simpleExec(nil, "git", "ls-remote", repo)
+	if remoteRef == "" {
+		return simpleExec(nil, "git", "ls-remote", remote)
 
 	}
-	return simpleExec(nil, "git", "ls-remote", repo, refspec)
+	return simpleExec(nil, "git", "ls-remote", remote, remoteRef)
 }
 
 func CurrentRef() (string, error) {


### PR DESCRIPTION
As discussed in https://github.com/github/git-lfs/pull/228, the push command actually has two modes:

```
# run by a user
$ git lfs push origin master

# run by pre-push hook
$ echo "refs/heads/master {local-sha1} refs/heads/master {remote-sha1}" | git lfs push origin https://github.com/some/repo
```

This PR splits them apart into separate commands, and updates the docs.  The old functionality in `push` is kept, until we can safely roll pre-push updates out.