### PR TITLE
require stdin content on certain commands

### DIFF
--- a/commands/command_clean.go
+++ b/commands/command_clean.go
@@ -16,6 +16,7 @@ var (
 )
 
 func cleanCommand(cmd *cobra.Command, args []string) {
+	requireStdin("This command should be run by the Git 'clean' filter")
 	lfs.InstallHooks(false)
 
 	var filename string

--- a/commands/command_pointer.go
+++ b/commands/command_pointer.go
@@ -115,6 +115,8 @@ func pointerReader() (io.ReadCloser, error) {
 		return os.Open(pointerCompare)
 	}
 
+	requireStdin("The --stdin flag expects a pointer file from STDIN.")
+
 	return os.Stdin, nil
 }
 

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -62,6 +62,7 @@ func pushCommand(cmd *cobra.Command, args []string) {
 	lfs.Config.CurrentRemote = args[0]
 
 	if useStdin {
+		requireStdin("Run this command from the Git pre-push hook, or leave the --stdin flag off.")
 		refsData, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
 			Panic(err, "Error reading refs on stdin")

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -20,6 +20,7 @@ var (
 )
 
 func smudgeCommand(cmd *cobra.Command, args []string) {
+	requireStdin("This command should be run by the Git 'smudge' filter")
 	lfs.InstallHooks(false)
 
 	b := &bytes.Buffer{}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -92,6 +92,14 @@ func PipeCommand(name string, args ...string) error {
 	return cmd.Run()
 }
 
+func requireStdin(msg string) {
+	stat, _ := os.Stdin.Stat()
+	if (stat.Mode() & os.ModeCharDevice) != 0 {
+		Error("Cannot read from STDIN. %s", msg)
+		os.Exit(1)
+	}
+}
+
 func handlePanic(err error) string {
 	if err == nil {
 		return ""

--- a/commands/pointer_test.go
+++ b/commands/pointer_test.go
@@ -79,7 +79,7 @@ func TestPointerWithInvalidCompareStdin(t *testing.T) {
 	defer repo.Test()
 
 	cmd := repo.Command("pointer", "--stdin")
-	cmd.Output = "Pointer from STDIN\n\nEOF"
+	cmd.Output = "Cannot read from STDIN. The --stdin flag expects a pointer file from STDIN."
 	cmd.Unsuccessful = true
 }
 


### PR DESCRIPTION
This fails fast in a few commands (`clean`, `smudge`, `pointer`, and `push`) if they expect STDIN, but don't get it.  This commonly happens in `clean` and `smudge` commands if users run them interactively.

Fixes #210