### PR TITLE
add diff/merge properties to gitattributes

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -58,7 +58,7 @@ func trackCommand(cmd *cobra.Command, args []string) {
 			continue
 		}
 
-		_, err := attributesFile.WriteString(fmt.Sprintf("%s filter=lfs -crlf\n", t))
+		_, err := attributesFile.WriteString(fmt.Sprintf("%s filter=lfs diff=lfs merge=lfs -crlf\n", t))
 		if err != nil {
 			Print("Error adding path %s", t)
 			continue

--- a/commands/track_test.go
+++ b/commands/track_test.go
@@ -51,12 +51,12 @@ func TestTrackOnEmptyRepository(t *testing.T) {
 	cmd.Before(func() {
 		// write attributes file in .git
 		path := filepath.Join(".gitattributes")
-		repo.WriteFile(path, "*.mov filter=lfs -crlf\n")
+		repo.WriteFile(path, "*.mov filter=lfs diff=lfs merge=lfs -crlf\n")
 	})
 
 	cmd.After(func() {
 		// assert path was added
-		assert.Equal(t, "*.mov filter=lfs -crlf\n*.gif filter=lfs -crlf\n", repo.ReadFile(".gitattributes"))
+		assert.Equal(t, "*.mov filter=lfs diff=lfs merge=lfs -crlf\n*.gif filter=lfs diff=lfs merge=lfs -crlf\n", repo.ReadFile(".gitattributes"))
 
 		expected := "Listing tracked paths\n    *.mov (.gitattributes)\n    *.gif (.gitattributes)\n"
 
@@ -82,14 +82,12 @@ func TestTrackWithoutTrailingLinebreak(t *testing.T) {
 	cmd.Output = "Tracking *.gif"
 
 	cmd.Before(func() {
-		// write attributes file in .git
-		path := filepath.Join(".gitattributes")
-		repo.WriteFile(path, "*.mov filter=lfs -crlf")
+		repo.WriteFile(".gitattributes", "*.mov filter=lfs -crlf")
 	})
 
 	cmd.After(func() {
 		// assert path was added
-		assert.Equal(t, "*.mov filter=lfs -crlf\n*.gif filter=lfs -crlf\n", repo.ReadFile(".gitattributes"))
+		assert.Equal(t, "*.mov filter=lfs -crlf\n*.gif filter=lfs diff=lfs merge=lfs -crlf\n", repo.ReadFile(".gitattributes"))
 
 		expected := "Listing tracked paths\n    *.mov (.gitattributes)\n    *.gif (.gitattributes)\n"
 


### PR DESCRIPTION
@peff suggested setting diff/merge properties in `.gitattributes`.  This gives us and users a place to set custom Git LFS options for diffing and merging.  Since Git LFS has nothing for this now, it should fall back to the default diffing and merging behavior.

Note: This only affects the `git lfs track` command.  Users can still manually add the lines to `.gitattributes` with their own properties.

/cc @mhagger too.