### PR TITLE
fix smudge attempts from zero len file

### DIFF
--- a/pointer/smudge.go
+++ b/pointer/smudge.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/cheggaaa/pb"
 	"github.com/github/git-lfs/lfs"
+	"github.com/rubyist/tracerx"
 	"github.com/technoweenie/go-contentaddressable"
 	"io"
 	"os"
@@ -16,8 +17,18 @@ func Smudge(writer io.Writer, ptr *Pointer, workingfile string, cb lfs.CopyCallb
 		return err
 	}
 
+	stat, statErr := os.Stat(mediafile)
+	if statErr == nil && stat != nil {
+		fileSize := stat.Size()
+		if fileSize == 0 || fileSize != ptr.Size {
+			tracerx.Printf("Removing %s, size %d is invalid", mediafile, fileSize)
+			os.RemoveAll(mediafile)
+			stat = nil
+		}
+	}
+
 	var wErr *lfs.WrappedError
-	if stat, statErr := os.Stat(mediafile); statErr != nil || stat == nil {
+	if statErr != nil || stat == nil {
 		wErr = downloadFile(writer, ptr, workingfile, mediafile, cb)
 	} else {
 		wErr = readLocalFile(writer, ptr, mediafile, cb)


### PR DESCRIPTION
Quick fix for #266.  It'd be nice if `smudge` could verify files as it's writing them.  But, it simply streams the contents to stdout.  By the time it's realized the file is bad, it's already written to the working directory.  Checking the file before writing to stdout could add significant time when smudging large files.