### PR TITLE
Fixed api.md not containing the correct information about href

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -32,8 +32,8 @@ $ ssh git@github.com git-lfs-authenticate user/repo.git download {oid}
   }
   // OPTIONAL key only needed if the Git LFS server is not hosted at the default
   // URL from the Git remote:
-  //   https://github.com/user/repo.git/info/lfs/
-  "href": "https://other-server.com/user/repo/",
+  //   https://github.com/user/repo.git/info/lfs
+  "href": "https://other-server.com/user/repo",
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,8 +32,8 @@ $ ssh git@github.com git-lfs-authenticate user/repo.git download {oid}
   }
   // OPTIONAL key only needed if the Git LFS server is not hosted at the default
   // URL from the Git remote:
-  //   https://github.com/user/repo.git/info/lfs/objects
-  "href": "https://other-server.com/user/repo/objects",
+  //   https://github.com/user/repo.git/info/lfs/
+  "href": "https://other-server.com/user/repo/",
 }
 ```
 


### PR DESCRIPTION
While playing with https://github.com/ddanier/django-git-lfs I noticed the documentation for the href attribute is a bit off. If you point git-lfs to /objects it will produce /objects/objects. So the correct URL may not contain "objects". This commit fixes this documentation issue.