### PR TITLE
Add LFS fsck feature

### DIFF
--- a/commands/clean_test.go
+++ b/commands/clean_test.go
@@ -227,15 +227,12 @@ func TestCleanWithCustomHook(t *testing.T) {
 
 	path := filepath.Join(repo.Path, ".git", "lfs", "objects")
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
-	customHook := []byte("test")
+	customHook := "test"
 
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, customHook, 0755)
-		if err != nil {
-			t.Fatal(err)
-		}
+		repo.WriteFile(prePushHookFile, customHook)
 
-		_, err = os.Open(path)
+		_, err := os.Open(path)
 		if _, ok := err.(*os.PathError); !ok {
 			t.Fatalf("'%s' should not exist", path)
 		}

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -83,7 +83,7 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 
 	err := doFsck(lfs.LocalGitDir)
 	if err != nil {
-		Panic(err, "Could not fsck Git LFS files")
+		Panic(err, "Git LFS fsck failed")
 	}
 	Print("Git LFS fsck OK")
 }

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -61,7 +61,7 @@ func doFsck(localGitDir string) error {
 		if err != nil {
 			return err
 		}
-		_ = f.Close()
+		f.Close()
 
 		recalculatedOid := hex.EncodeToString(oidHash.Sum(nil))
 		if recalculatedOid != p.Pointer.Oid {
@@ -85,7 +85,7 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 	if err != nil {
 		Panic(err, "Could not fsck Git LFS files")
 	}
-	Print("LFS fsck OK")
+	Print("Git LFS fsck OK")
 }
 
 func init() {

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -1,0 +1,93 @@
+package commands
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"github.com/github/git-lfs/git"
+	"github.com/github/git-lfs/lfs"
+	"github.com/spf13/cobra"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type fsckError struct {
+	name, oid string
+}
+
+func (e *fsckError) Error() string {
+	return "Object " + e.name + " (" + e.oid + ") is corrupt"
+}
+
+var (
+	fsckCmd = &cobra.Command{
+		Use:   "fsck",
+		Short: "Verifies validity of Git LFS files",
+		Run:   fsckCommand,
+	}
+)
+
+func doFsck(localGitDir string) error {
+	ref, err := git.CurrentRef()
+	if err != nil {
+		return err
+	}
+
+	pointers, err := lfs.ScanRefs(ref, "")
+	if err != nil {
+		return err
+	}
+
+	// TODO(zeroshirts): do we want to look for LFS stuff in past commits?
+	p2, err := lfs.ScanIndex()
+	if err != nil {
+		return err
+	}
+	// zeroshirts: assuming no duplicates...
+	pointers = append(pointers, p2...)
+
+	for _, p := range pointers {
+		path := filepath.Join(localGitDir, "lfs", "objects", p.Pointer.Oid[0:2], p.Pointer.Oid[2:4], p.Pointer.Oid)
+
+		Debug("Examining %v (%v)", p.Name, path)
+
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+
+		oidHash := sha256.New()
+		_, err = io.Copy(oidHash, f)
+		if err != nil {
+			return err
+		}
+		_ = f.Close()
+
+		recalculatedOid := hex.EncodeToString(oidHash.Sum(nil))
+		if recalculatedOid != p.Pointer.Oid {
+			return &fsckError{p.Name, p.Pointer.Oid}
+		}
+		Debug("%v (%v) intact", p.Name, path)
+	}
+	return nil
+}
+
+// TODO(zeroshirts): 'git fsck' reports status (percentage, current#/total) as
+// it checks... we should do the same, as we are rehashing potentially gigs and
+// gigs of content.
+//
+// NOTE(zeroshirts): Ideally git would have hooks for fsck such that we could
+// chain a lfs-fsck, but I don't think it does.
+func fsckCommand(cmd *cobra.Command, args []string) {
+	lfs.InstallHooks(false)
+
+	err := doFsck(lfs.LocalGitDir)
+	if err != nil {
+		Panic(err, "Could not fsck Git LFS files")
+	}
+	Print("LFS fsck OK")
+}
+
+func init() {
+	RootCmd.AddCommand(fsckCmd)
+}

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -104,7 +104,7 @@ func (r *Repository) ReadFile(paths ...string) string {
 
 func (r *Repository) WriteFile(filename, output string) {
 	if !filepath.IsAbs(filename) {
-		r.T.Fatalf("filename %v must be absolute path")
+		r.T.Fatalf("filename %v must be absolute path", filename)
 	}
 	r.e(os.MkdirAll(filepath.Dir(filename), 0755))
 	r.e(ioutil.WriteFile(filename, []byte(output), 0755))

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -236,7 +236,6 @@ func expand(path string) string {
 
 func clone(t *testing.T, name, path string) {
 	debug.PrintStack()
-	t.Logf("[TMP-DEBUG] removing path %v", path)
 	e(t, os.RemoveAll(path))
 
 	reposPath := filepath.Join(Root, "commands", "repos")

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -235,6 +235,7 @@ func expand(path string) string {
 }
 
 func clone(t *testing.T, name, path string) {
+	debug.PrintStack()
 	t.Logf("[TMP-DEBUG] removing path %v", path)
 	e(t, os.RemoveAll(path))
 

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -235,6 +235,7 @@ func expand(path string) string {
 }
 
 func clone(t *testing.T, name, path string) {
+	t.Logf("[TMP-DEBUG] removing path %v", path)
 	e(t, os.RemoveAll(path))
 
 	reposPath := filepath.Join(Root, "commands", "repos")

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -235,7 +235,6 @@ func expand(path string) string {
 }
 
 func clone(t *testing.T, name, path string) {
-	debug.PrintStack()
 	e(t, os.RemoveAll(path))
 
 	reposPath := filepath.Join(Root, "commands", "repos")

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"testing"
 )
@@ -102,6 +103,10 @@ func (r *Repository) ReadFile(paths ...string) string {
 }
 
 func (r *Repository) WriteFile(filename, output string) {
+	if !filepath.IsAbs(filename) {
+		r.T.Fatalf("filename %v must be absolute path")
+	}
+	r.e(os.MkdirAll(filepath.Dir(filename), 0755))
 	r.e(ioutil.WriteFile(filename, []byte(output), 0755))
 }
 
@@ -203,6 +208,7 @@ func cmd(t *testing.T, name string, args ...string) string {
 	cmd := exec.Command(name, args...)
 	o, err := cmd.CombinedOutput()
 	if err != nil {
+		debug.PrintStack()
 		t.Fatalf(
 			"Error running command:\n$ %s\n\n%s",
 			strings.Join(cmd.Args, " "),
@@ -214,6 +220,7 @@ func cmd(t *testing.T, name string, args ...string) string {
 
 func e(t *testing.T, err error) {
 	if err != nil {
+		debug.PrintStack()
 		t.Fatal(err.Error())
 	}
 }

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -173,6 +173,7 @@ func (c *TestCommand) Run(path string) {
 
 	if exitErr, ok := err.(*exec.ExitError); ok {
 		if exitErr.ProcessState.Success() == c.Unsuccessful {
+			c.T.Log(string(outputBytes))
 			c.e(err)
 		}
 	} else if err == nil {

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -206,6 +206,7 @@ func (c *TestCommand) e(err error) {
 }
 
 func cmd(t *testing.T, name string, args ...string) string {
+	fmt.Printf("  $ %v %v\n", name, strings.Join(args, " "))
 	cmd := exec.Command(name, args...)
 	o, err := cmd.CombinedOutput()
 	if err != nil {

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestFsck(t *testing.T) {
+	repo := NewRepository(t, "empty")
+	defer repo.Test()
+
+	cmd := repo.Command("fsck")
+	cmd.Output = "LFS fsck OK"
+
+	testFileContent := "test data"
+	h := sha256.New()
+	io.WriteString(h, testFileContent)
+	wantOid := hex.EncodeToString(h.Sum(nil))
+
+	cmd.Before(func() {
+		path := filepath.Join(repo.Path, ".git", "info", "attributes")
+		repo.WriteFile(path, "*.dat filter=lfs -crlf\n")
+
+		// Add a Git LFS object
+		repo.WriteFile(filepath.Join(repo.Path, "a.dat"), testFileContent)
+		repo.GitCmd("add", "a.dat")
+		repo.GitCmd("commit", "-m", "a")
+	})
+
+	cmd.After(func() {
+		// Verify test file exists as LFS object
+		lfsObjectPath := filepath.Join(repo.Path, ".git", "lfs", "objects", wantOid[0:2], wantOid[2:4], wantOid)
+		if _, err := os.Stat(lfsObjectPath); err != nil {
+			t.Fatal(err)
+		}
+
+		// Corrupt the LFS object and verify that fsck detects corruption
+		repo.WriteFile(lfsObjectPath, testFileContent+"CORRUPTION")
+		err := doFsck(filepath.Join(repo.Path, ".git"))
+		wantErr := &fsckError{"a.dat", wantOid}
+		if !reflect.DeepEqual(err, wantErr) {
+			t.Fatalf("err = %v, want %v", err, wantErr)
+		}
+	})
+}

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"github.com/github/git-lfs/lfs"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestFsck(t *testing.T) {
+	t.Logf("TestFsck() Git LFS version = %v", lfs.UserAgent)
 	repo := NewRepository(t, "empty")
 	defer repo.Test()
 

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -15,7 +15,7 @@ func TestFsck(t *testing.T) {
 	defer repo.Test()
 
 	cmd := repo.Command("fsck")
-	cmd.Output = "LFS fsck OK"
+	cmd.Output = "Git LFS fsck OK"
 
 	testFileContent := "test data"
 	h := sha256.New()

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -36,6 +36,23 @@ func TestFsck(t *testing.T) {
 		// Verify test file exists as LFS object
 		lfsObjectPath := filepath.Join(repo.Path, ".git", "lfs", "objects", wantOid[0:2], wantOid[2:4], wantOid)
 		if _, err := os.Stat(lfsObjectPath); err != nil {
+			//// DEBUG... recursively print out everything under repo.Path...
+			e2 := filepath.Walk(repo.Path, func(file string, info os.FileInfo, e3 error) error {
+				if e3 != nil {
+					t.Logf("[file=%v] e3 = %v, want %v", file, e3, nil)
+					return e3
+				}
+				if info.IsDir() {
+					t.Logf("[file=%v] IsDirectory==true")
+					// ignore dirs
+					return nil
+				}
+				t.Logf("[file=%v]", file)
+				return nil
+			})
+			if e2 != nil {
+				t.Errorf("e2 = %v, want %v", e2, nil)
+			}
 			t.Fatal(err)
 		}
 

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -47,7 +47,7 @@ func TestFsck(t *testing.T) {
 					// ignore dirs
 					return nil
 				}
-				t.Logf("[file=%v]", file)
+				t.Logf("[file=%v] size=%v", file, info.Size())
 				return nil
 			})
 			if e2 != nil {

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -56,7 +56,7 @@ func TestFsck(t *testing.T) {
 				t.Errorf("e2 = %v, want %v", e2, nil)
 			}
 			// XXX changed this from t.Fatal to t.Error so I can get more debug output
-			////t.Error(err)
+			t.Error(err)
 		} else {
 			// Corrupt the LFS object and verify that fsck detects corruption
 			repo.WriteFile(lfsObjectPath, testFileContent+"CORRUPTION")
@@ -67,8 +67,4 @@ func TestFsck(t *testing.T) {
 			}
 		}
 	})
-}
-
-func TestFsckWillFail(t *testing.T) {
-	t.Fatal("don't integrate pull request yet!")
 }

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -55,15 +55,16 @@ func TestFsck(t *testing.T) {
 			if e2 != nil {
 				t.Errorf("e2 = %v, want %v", e2, nil)
 			}
-			t.Fatal(err)
-		}
-
-		// Corrupt the LFS object and verify that fsck detects corruption
-		repo.WriteFile(lfsObjectPath, testFileContent+"CORRUPTION")
-		err := doFsck(filepath.Join(repo.Path, ".git"))
-		wantErr := &fsckError{"a.dat", wantOid}
-		if !reflect.DeepEqual(err, wantErr) {
-			t.Fatalf("err = %v, want %v", err, wantErr)
+			// XXX changed this from t.Fatal to t.Error so I can get more debug output
+			t.Error(err)
+		} else {
+			// Corrupt the LFS object and verify that fsck detects corruption
+			repo.WriteFile(lfsObjectPath, testFileContent+"CORRUPTION")
+			err := doFsck(filepath.Join(repo.Path, ".git"))
+			wantErr := &fsckError{"a.dat", wantOid}
+			if !reflect.DeepEqual(err, wantErr) {
+				t.Fatalf("err = %v, want %v", err, wantErr)
+			}
 		}
 	})
 }

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -43,7 +43,7 @@ func TestFsck(t *testing.T) {
 					return e3
 				}
 				if info.IsDir() {
-					t.Logf("[file=%v] IsDirectory==true")
+					t.Logf("[file=%v] IsDirectory==true", file)
 					// ignore dirs
 					return nil
 				}

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -56,7 +56,7 @@ func TestFsck(t *testing.T) {
 				t.Errorf("e2 = %v, want %v", e2, nil)
 			}
 			// XXX changed this from t.Fatal to t.Error so I can get more debug output
-			t.Error(err)
+			////t.Error(err)
 		} else {
 			// Corrupt the LFS object and verify that fsck detects corruption
 			repo.WriteFile(lfsObjectPath, testFileContent+"CORRUPTION")
@@ -67,4 +67,8 @@ func TestFsck(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestFsckWillFail(t *testing.T) {
+	t.Fatal("don't integrate pull request yet!")
 }

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"github.com/github/git-lfs/lfs"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,7 +11,6 @@ import (
 )
 
 func TestFsck(t *testing.T) {
-	t.Logf("TestFsck() Git LFS version = %v", lfs.UserAgent)
 	repo := NewRepository(t, "empty")
 	defer repo.Test()
 

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -49,10 +49,9 @@ func TestInit(t *testing.T) {
 	cmd = repo.Command("init")
 	cmd.Output = "Hook already exists: pre-push\n\necho 'yo'\n\ngit lfs initialized"
 
-	customHook := []byte("echo 'yo'")
+	customHook := "echo 'yo'"
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, customHook, 0755)
-		assert.Equal(t, nil, err)
+		repo.WriteFile(prePushHookFile, customHook)
 	})
 
 	cmd.After(func() {

--- a/commands/ls_files_test.go
+++ b/commands/ls_files_test.go
@@ -13,7 +13,7 @@ func TestLsFiles(t *testing.T) {
 	cmd.Output = "a.dat"
 
 	cmd.Before(func() {
-		path := filepath.Join(".git", "info", "attributes")
+		path := filepath.Join(repo.Path, ".git", "info", "attributes")
 		repo.WriteFile(path, "*.dat filter=lfs -crlf\n")
 
 		// Add a Git LFS object

--- a/commands/push_test.go
+++ b/commands/push_test.go
@@ -83,10 +83,7 @@ func TestPushStdin(t *testing.T) {
 
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, []byte("#!/bin/sh\ngit lfs push --stdin \"$@\"\n"), 0755)
-		if err != nil {
-			t.Fatalf("Error writing pre-push in Before(): %s", err)
-		}
+		repo.WriteFile(prePushHookFile, "#!/bin/sh\ngit lfs push --stdin \"$@\"\n")
 	})
 
 	cmd.After(func() {
@@ -111,10 +108,7 @@ func TestPushStdinWithUnexpectedHook(t *testing.T) {
 
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, []byte("sup\n"), 0755)
-		if err != nil {
-			t.Fatalf("Error writing pre-push in Before(): %s", err)
-		}
+		repo.WriteFile(prePushHookFile, "sup\n")
 	})
 
 	cmd.After(func() {

--- a/commands/smudge_test.go
+++ b/commands/smudge_test.go
@@ -48,14 +48,13 @@ func TestSmudge(t *testing.T) {
 	cmd = repo.Command("smudge")
 	cmd.Input = bytes.NewBufferString("version https://git-lfs.github.com/spec/v1\noid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393\nsize 9")
 	cmd.Output = "whatever"
-	customHook := []byte("echo 'yo'")
+	customHook := "echo 'yo'"
 
 	cmd.Before(func() {
 		path := filepath.Join(repo.Path, ".git", "lfs", "objects", "4d", "7a")
 		file := filepath.Join(path, "4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393")
-		assert.Equal(t, nil, os.MkdirAll(path, 0755))
-		assert.Equal(t, nil, ioutil.WriteFile(file, []byte("whatever\n"), 0755))
-		assert.Equal(t, nil, ioutil.WriteFile(prePushHookFile, customHook, 0755))
+		repo.WriteFile(file, "whatever\n")
+		repo.WriteFile(prePushHookFile, customHook)
 	})
 
 	cmd.After(func() {

--- a/commands/status_test.go
+++ b/commands/status_test.go
@@ -13,7 +13,7 @@ func TestStatus(t *testing.T) {
 	cmd.Output = " M file1.dat 9\nA  file2.dat 10\nA  file3.dat 10"
 
 	cmd.Before(func() {
-		path := filepath.Join(".git", "info", "attributes")
+		path := filepath.Join(repo.Path, ".git", "info", "attributes")
 		repo.WriteFile(path, "*.dat filter=lfs -crlf\n")
 
 		// Add a Git LFS file

--- a/commands/track_test.go
+++ b/commands/track_test.go
@@ -13,7 +13,7 @@ func TestTrack(t *testing.T) {
 	defer repo.Test()
 
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
-	customHook := []byte("echo 'yo'")
+	customHook := "echo 'yo'"
 
 	cmd := repo.Command("track")
 	cmd.Output = "Listing tracked paths\n" +
@@ -24,12 +24,11 @@ func TestTrack(t *testing.T) {
 
 	cmd.Before(func() {
 		// write attributes file in .git
-		path := filepath.Join(".git", "info", "attributes")
+		path := filepath.Join(repo.Path, ".git", "info", "attributes")
 		repo.WriteFile(path, "*.mov filter=lfs -crlf\n")
 
 		// add hook
-		err := ioutil.WriteFile(prePushHookFile, customHook, 0755)
-		assert.Equal(t, nil, err)
+		repo.WriteFile(prePushHookFile, customHook)
 	})
 
 	cmd.After(func() {
@@ -50,7 +49,7 @@ func TestTrackOnEmptyRepository(t *testing.T) {
 
 	cmd.Before(func() {
 		// write attributes file in .git
-		path := filepath.Join(".gitattributes")
+		path := filepath.Join(repo.Path, ".gitattributes")
 		repo.WriteFile(path, "*.mov filter=lfs diff=lfs merge=lfs -crlf\n")
 	})
 
@@ -82,7 +81,7 @@ func TestTrackWithoutTrailingLinebreak(t *testing.T) {
 	cmd.Output = "Tracking *.gif"
 
 	cmd.Before(func() {
-		repo.WriteFile(".gitattributes", "*.mov filter=lfs -crlf")
+		repo.WriteFile(filepath.Join(repo.Path, ".gitattributes"), "*.mov filter=lfs -crlf")
 	})
 
 	cmd.After(func() {

--- a/commands/update_test.go
+++ b/commands/update_test.go
@@ -43,10 +43,7 @@ func TestUpdateWithLatestPrePushHook(t *testing.T) {
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
 
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, []byte("#!/bin/sh\ngit lfs pre-push \"$@\"\n"), 0755)
-		if err != nil {
-			t.Fatalf("Error writing pre-push in Before(): %s", err)
-		}
+		repo.WriteFile(prePushHookFile, "#!/bin/sh\ngit lfs pre-push \"$@\"\n")
 	})
 
 	cmd.After(func() {
@@ -74,10 +71,7 @@ func TestUpdateForce(t *testing.T) {
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
 
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, []byte("sup\n"), 0755)
-		if err != nil {
-			t.Fatalf("Error writing pre-push in Before(): %s", err)
-		}
+		repo.WriteFile(prePushHookFile, "sup\n")
 	})
 
 	cmd.After(func() {
@@ -107,10 +101,7 @@ func TestUpdateWithUnexpectedPrePushHook(t *testing.T) {
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
 
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, []byte("test\n"), 0755)
-		if err != nil {
-			t.Fatalf("Error writing pre-push in Before(): %s", err)
-		}
+		repo.WriteFile(prePushHookFile, "test\n")
 	})
 
 	cmd.After(func() {
@@ -138,10 +129,7 @@ func TestUpdateWithOldPrePushHook_1(t *testing.T) {
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
 
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, []byte("#!/bin/sh\ngit lfs push --stdin $*\n"), 0755)
-		if err != nil {
-			t.Fatalf("Error writing pre-push in Before(): %s", err)
-		}
+		repo.WriteFile(prePushHookFile, "#!/bin/sh\ngit lfs push --stdin $*\n")
 	})
 
 	cmd.After(func() {
@@ -169,10 +157,7 @@ func TestUpdateWithOldPrePushHook_2(t *testing.T) {
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
 
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, []byte("#!/bin/sh\ngit lfs push --stdin \"$@\"\n"), 0755)
-		if err != nil {
-			t.Fatalf("Error writing pre-push in Before(): %s", err)
-		}
+		repo.WriteFile(prePushHookFile, "#!/bin/sh\ngit lfs push --stdin \"$@\"\n")
 	})
 
 	cmd.After(func() {

--- a/commands/version_test.go
+++ b/commands/version_test.go
@@ -15,6 +15,7 @@ func TestVersionOnEmptyRepository(t *testing.T) {
 
 	cmd := repo.Command("version")
 	cmd.Output = lfs.UserAgent
+	t.Logf("Git LFS version = %v", lfs.UserAgent)
 
 	cmd = repo.Command("version", "--comics")
 	cmd.Output = fmt.Sprintf("%s\nNothing may see Gah Lak Tus and survive!", lfs.UserAgent)

--- a/commands/version_test.go
+++ b/commands/version_test.go
@@ -15,7 +15,6 @@ func TestVersionOnEmptyRepository(t *testing.T) {
 
 	cmd := repo.Command("version")
 	cmd.Output = lfs.UserAgent
-	t.Logf("Git LFS version = %v", lfs.UserAgent)
 
 	cmd = repo.Command("version", "--comics")
 	cmd.Output = fmt.Sprintf("%s\nNothing may see Gah Lak Tus and survive!", lfs.UserAgent)

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-const Version = "0.5.1"
+const Version = "0.5.1_LFS_FSCK_DEBUG"
 
 var (
 	LargeSizeThreshold = 5 * 1024 * 1024


### PR DESCRIPTION
This is a first-cut of the LFS fsck command to address issue #262.

I wanted to put this out there for review before adding stuff like on-the-fly status completion updates (which would be useful given the possibility of LFS fsck hashing gigs of media content).  I'm curious whether this is a good approach to the fsck problem.

After a fresh git clone and running script/bootstrap, I encountered a ton of errors in the unit tests for the commands package, so the changes you see in the non fsck unit tests were to fix those issues on my machine.

Example of the unit test errors I encountered:
```
--- FAIL: TestUpdateWithOldPrePushHook_2 (0.04s)
	update_test.go:174: Error writing pre-push in Before(): open /private/var/folders/0t/n69_kx414lg481jhdyf8n6xh0000gn/T/git-lfs-tests/empty/.git/hooks/pre-push: no such file or directory
```

