### PR TITLE
Remove trailing period when printing log file location

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -65,7 +65,7 @@ func LoggedError(err error, format string, args ...interface{}) {
 	file := handlePanic(err)
 
 	if len(file) > 0 {
-		fmt.Fprintf(os.Stderr, "\nErrors logged to %s.\nUse `git lfs logs last` to view the log.\n", file)
+		fmt.Fprintf(os.Stderr, "\nErrors logged to %s\nUse `git lfs logs last` to view the log.\n", file)
 	}
 }
 


### PR DESCRIPTION
Trailing periods after filenames cause copy-paste annoyance. Please consider removing this or reformatting the message.

Apologies in advance if I'm ignoring a practise that exists throughout the rest of Git.