### PR TITLE
Fsck command

### DIFF
--- a/commands/clean_test.go
+++ b/commands/clean_test.go
@@ -227,15 +227,12 @@ func TestCleanWithCustomHook(t *testing.T) {
 
 	path := filepath.Join(repo.Path, ".git", "lfs", "objects")
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
-	customHook := []byte("test")
+	customHook := "test"
 
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, customHook, 0755)
-		if err != nil {
-			t.Fatal(err)
-		}
+		repo.WriteFile(prePushHookFile, customHook)
 
-		_, err = os.Open(path)
+		_, err := os.Open(path)
 		if _, ok := err.(*os.PathError); !ok {
 			t.Fatalf("'%s' should not exist", path)
 		}

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -1,0 +1,93 @@
+package commands
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"github.com/github/git-lfs/git"
+	"github.com/github/git-lfs/lfs"
+	"github.com/spf13/cobra"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type fsckError struct {
+	name, oid string
+}
+
+func (e *fsckError) Error() string {
+	return "Object " + e.name + " (" + e.oid + ") is corrupt"
+}
+
+var (
+	fsckCmd = &cobra.Command{
+		Use:   "fsck",
+		Short: "Verifies validity of Git LFS files",
+		Run:   fsckCommand,
+	}
+)
+
+func doFsck(localGitDir string) error {
+	ref, err := git.CurrentRef()
+	if err != nil {
+		return err
+	}
+
+	pointers, err := lfs.ScanRefs(ref, "")
+	if err != nil {
+		return err
+	}
+
+	// TODO(zeroshirts): do we want to look for LFS stuff in past commits?
+	p2, err := lfs.ScanIndex()
+	if err != nil {
+		return err
+	}
+	// zeroshirts: assuming no duplicates...
+	pointers = append(pointers, p2...)
+
+	for _, p := range pointers {
+		path := filepath.Join(localGitDir, "lfs", "objects", p.Pointer.Oid[0:2], p.Pointer.Oid[2:4], p.Pointer.Oid)
+
+		Debug("Examining %v (%v)", p.Name, path)
+
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+
+		oidHash := sha256.New()
+		_, err = io.Copy(oidHash, f)
+		if err != nil {
+			return err
+		}
+		f.Close()
+
+		recalculatedOid := hex.EncodeToString(oidHash.Sum(nil))
+		if recalculatedOid != p.Pointer.Oid {
+			return &fsckError{p.Name, p.Pointer.Oid}
+		}
+		Debug("%v (%v) intact", p.Name, path)
+	}
+	return nil
+}
+
+// TODO(zeroshirts): 'git fsck' reports status (percentage, current#/total) as
+// it checks... we should do the same, as we are rehashing potentially gigs and
+// gigs of content.
+//
+// NOTE(zeroshirts): Ideally git would have hooks for fsck such that we could
+// chain a lfs-fsck, but I don't think it does.
+func fsckCommand(cmd *cobra.Command, args []string) {
+	lfs.InstallHooks(false)
+
+	err := doFsck(lfs.LocalGitDir)
+	if err != nil {
+		Panic(err, "Could not fsck Git LFS files")
+	}
+	Print("Git LFS fsck OK")
+}
+
+func init() {
+	RootCmd.AddCommand(fsckCmd)
+}

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -12,6 +12,8 @@ import (
 )
 
 var (
+	fsckDryRun bool
+
 	fsckCmd = &cobra.Command{
 		Use:   "fsck",
 		Short: "Verifies validity of Git LFS files",
@@ -62,7 +64,9 @@ func doFsck(localGitDir string) (bool, error) {
 		if recalculatedOid != p.Pointer.Oid {
 			ok = false
 			Print("Object %s (%s) is corrupt", p.Name, p.Oid)
-			os.RemoveAll(path)
+			if !fsckDryRun {
+				os.RemoveAll(path)
+			}
 		}
 	}
 	return ok, nil
@@ -88,5 +92,6 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
+	fsckCmd.Flags().BoolVarP(&fsckDryRun, "dry-run", "d", false, "List corrupt objects without deleting them.")
 	RootCmd.AddCommand(fsckCmd)
 }

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -62,6 +62,7 @@ func doFsck(localGitDir string) (bool, error) {
 		if recalculatedOid != p.Pointer.Oid {
 			ok = false
 			Print("Object %s (%s) is corrupt", p.Name, p.Oid)
+			os.RemoveAll(path)
 		}
 	}
 	return ok, nil

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -43,6 +43,7 @@ func doFsck(localGitDir string) error {
 	if err != nil {
 		return err
 	}
+
 	// zeroshirts: assuming no duplicates...
 	pointers = append(pointers, p2...)
 
@@ -55,13 +56,13 @@ func doFsck(localGitDir string) error {
 		if err != nil {
 			return err
 		}
+		defer f.Close()
 
 		oidHash := sha256.New()
 		_, err = io.Copy(oidHash, f)
 		if err != nil {
 			return err
 		}
-		f.Close()
 
 		recalculatedOid := hex.EncodeToString(oidHash.Sum(nil))
 		if recalculatedOid != p.Pointer.Oid {

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -11,14 +11,6 @@ import (
 	"path/filepath"
 )
 
-type fsckError struct {
-	name, oid string
-}
-
-func (e *fsckError) Error() string {
-	return "Object " + e.name + " (" + e.oid + ") is corrupt"
-}
-
 var (
 	fsckCmd = &cobra.Command{
 		Use:   "fsck",
@@ -27,25 +19,27 @@ var (
 	}
 )
 
-func doFsck(localGitDir string) error {
+func doFsck(localGitDir string) (bool, error) {
 	ref, err := git.CurrentRef()
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	pointers, err := lfs.ScanRefs(ref, "")
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// TODO(zeroshirts): do we want to look for LFS stuff in past commits?
 	p2, err := lfs.ScanIndex()
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// zeroshirts: assuming no duplicates...
 	pointers = append(pointers, p2...)
+
+	ok := true
 
 	for _, p := range pointers {
 		path := filepath.Join(localGitDir, "lfs", "objects", p.Pointer.Oid[0:2], p.Pointer.Oid[2:4], p.Pointer.Oid)
@@ -54,23 +48,23 @@ func doFsck(localGitDir string) error {
 
 		f, err := os.Open(path)
 		if err != nil {
-			return err
+			return false, err
 		}
 		defer f.Close()
 
 		oidHash := sha256.New()
 		_, err = io.Copy(oidHash, f)
 		if err != nil {
-			return err
+			return false, err
 		}
 
 		recalculatedOid := hex.EncodeToString(oidHash.Sum(nil))
 		if recalculatedOid != p.Pointer.Oid {
-			return &fsckError{p.Name, p.Pointer.Oid}
+			ok = false
+			Print("Object %s (%s) is corrupt", p.Name, p.Oid)
 		}
-		Debug("%v (%v) intact", p.Name, path)
 	}
-	return nil
+	return ok, nil
 }
 
 // TODO(zeroshirts): 'git fsck' reports status (percentage, current#/total) as
@@ -82,11 +76,14 @@ func doFsck(localGitDir string) error {
 func fsckCommand(cmd *cobra.Command, args []string) {
 	lfs.InstallHooks(false)
 
-	err := doFsck(lfs.LocalGitDir)
+	ok, err := doFsck(lfs.LocalGitDir)
 	if err != nil {
-		Panic(err, "Could not fsck Git LFS files")
+		Panic(err, "Error checking Git LFS files")
 	}
-	Print("Git LFS fsck OK")
+
+	if ok {
+		Print("Git LFS fsck OK")
+	}
 }
 
 func init() {

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"testing"
 )
@@ -102,6 +103,10 @@ func (r *Repository) ReadFile(paths ...string) string {
 }
 
 func (r *Repository) WriteFile(filename, output string) {
+	if !filepath.IsAbs(filename) {
+		r.T.Fatalf("filename %v must be absolute path", filename)
+	}
+	r.e(os.MkdirAll(filepath.Dir(filename), 0755))
 	r.e(ioutil.WriteFile(filename, []byte(output), 0755))
 }
 
@@ -168,6 +173,7 @@ func (c *TestCommand) Run(path string) {
 
 	if exitErr, ok := err.(*exec.ExitError); ok {
 		if exitErr.ProcessState.Success() == c.Unsuccessful {
+			c.T.Log(string(outputBytes))
 			c.e(err)
 		}
 	} else if err == nil {
@@ -203,6 +209,7 @@ func cmd(t *testing.T, name string, args ...string) string {
 	cmd := exec.Command(name, args...)
 	o, err := cmd.CombinedOutput()
 	if err != nil {
+		debug.PrintStack()
 		t.Fatalf(
 			"Error running command:\n$ %s\n\n%s",
 			strings.Join(cmd.Args, " "),
@@ -214,6 +221,7 @@ func cmd(t *testing.T, name string, args ...string) string {
 
 func e(t *testing.T, err error) {
 	if err != nil {
+		debug.PrintStack()
 		t.Fatal(err.Error())
 	}
 }

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -18,8 +20,14 @@ func TestFsck(t *testing.T) {
 	testFileContent := "test data"
 	h := sha256.New()
 	io.WriteString(h, testFileContent)
-	wantOid := hex.EncodeToString(h.Sum(nil))
-	lfsObjectPath := filepath.Join(repo.Path, ".git", "lfs", "objects", wantOid[0:2], wantOid[2:4], wantOid)
+	oid1 := hex.EncodeToString(h.Sum(nil))
+	lfsObjectPath := filepath.Join(repo.Path, ".git", "lfs", "objects", oid1[0:2], oid1[2:4], oid1)
+
+	testFile2Content := "test data 2"
+	h.Reset()
+	io.WriteString(h, testFile2Content)
+	oid2 := hex.EncodeToString(h.Sum(nil))
+	lfsObject2Path := filepath.Join(repo.Path, ".git", "lfs", "objects", oid2[0:2], oid2[2:4], oid2)
 
 	cmd.Before(func() {
 		path := filepath.Join(repo.Path, ".git", "info", "attributes")
@@ -27,8 +35,28 @@ func TestFsck(t *testing.T) {
 
 		// Add a Git LFS object
 		repo.WriteFile(filepath.Join(repo.Path, "a.dat"), testFileContent)
-		repo.GitCmd("add", "a.dat")
+		repo.WriteFile(filepath.Join(repo.Path, "b.dat"), testFile2Content)
+		repo.GitCmd("add", "*.dat")
 		repo.GitCmd("commit", "-m", "a")
 		repo.WriteFile(lfsObjectPath, testFileContent+"CORRUPTION")
+	})
+
+	cmd.After(func() {
+		by, err := ioutil.ReadFile(lfsObject2Path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		h.Reset()
+		h.Write(by)
+		oid := hex.EncodeToString(h.Sum(nil))
+		if oid != oid2 {
+			t.Errorf("oid for b.dat does not match")
+		}
+
+		_, err = os.Stat(lfsObjectPath)
+		if err == nil {
+			t.Errorf("Expected a.dat to be cleared for being corrupt", lfsObjectPath)
+		}
 	})
 }

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestFsck(t *testing.T) {
+	repo := NewRepository(t, "empty")
+	defer repo.Test()
+
+	cmd := repo.Command("fsck")
+	cmd.Output = "Git LFS fsck OK"
+
+	testFileContent := "test data"
+	h := sha256.New()
+	io.WriteString(h, testFileContent)
+	wantOid := hex.EncodeToString(h.Sum(nil))
+
+	cmd.Before(func() {
+		path := filepath.Join(repo.Path, ".git", "info", "attributes")
+		repo.WriteFile(path, "*.dat filter=lfs -crlf\n")
+
+		// Add a Git LFS object
+		repo.WriteFile(filepath.Join(repo.Path, "a.dat"), testFileContent)
+		repo.GitCmd("add", "a.dat")
+		repo.GitCmd("commit", "-m", "a")
+	})
+
+	cmd.After(func() {
+		// Verify test file exists as LFS object
+		lfsObjectPath := filepath.Join(repo.Path, ".git", "lfs", "objects", wantOid[0:2], wantOid[2:4], wantOid)
+		if _, err := os.Stat(lfsObjectPath); err != nil {
+			t.Fatal(err)
+		}
+
+		// Corrupt the LFS object and verify that fsck detects corruption
+		repo.WriteFile(lfsObjectPath, testFileContent+"CORRUPTION")
+		err := doFsck(filepath.Join(repo.Path, ".git"))
+		wantErr := &fsckError{"a.dat", wantOid}
+		if !reflect.DeepEqual(err, wantErr) {
+			t.Fatalf("err = %v, want %v", err, wantErr)
+		}
+	})
+}

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestFsck(t *testing.T) {
+func TestFsckDefault(t *testing.T) {
 	repo := NewRepository(t, "empty")
 	defer repo.Test()
 
@@ -57,6 +57,121 @@ func TestFsck(t *testing.T) {
 		_, err = os.Stat(lfsObjectPath)
 		if err == nil {
 			t.Errorf("Expected a.dat to be cleared for being corrupt", lfsObjectPath)
+		}
+	})
+}
+
+func TestFsckDryRun(t *testing.T) {
+	repo := NewRepository(t, "empty")
+	defer repo.Test()
+
+	cmd := repo.Command("fsck", "--dry-run")
+	cmd.Output = "Object a.dat (916f0027a575074ce72a331777c3478d6513f786a591bd892da1a577bf2335f9) is corrupt"
+
+	testFileContent := "test data"
+	h := sha256.New()
+	io.WriteString(h, testFileContent)
+	oid1 := hex.EncodeToString(h.Sum(nil))
+	lfsObjectPath := filepath.Join(repo.Path, ".git", "lfs", "objects", oid1[0:2], oid1[2:4], oid1)
+
+	testFile2Content := "test data 2"
+	h.Reset()
+	io.WriteString(h, testFile2Content)
+	oid2 := hex.EncodeToString(h.Sum(nil))
+	lfsObject2Path := filepath.Join(repo.Path, ".git", "lfs", "objects", oid2[0:2], oid2[2:4], oid2)
+
+	cmd.Before(func() {
+		path := filepath.Join(repo.Path, ".git", "info", "attributes")
+		repo.WriteFile(path, "*.dat filter=lfs -crlf\n")
+
+		// Add a Git LFS object
+		repo.WriteFile(filepath.Join(repo.Path, "a.dat"), testFileContent)
+		repo.WriteFile(filepath.Join(repo.Path, "b.dat"), testFile2Content)
+		repo.GitCmd("add", "*.dat")
+		repo.GitCmd("commit", "-m", "a")
+		repo.WriteFile(lfsObjectPath, testFileContent+"CORRUPTION")
+	})
+
+	cmd.After(func() {
+		by, err := ioutil.ReadFile(lfsObject2Path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		h.Reset()
+		h.Write(by)
+		oid := hex.EncodeToString(h.Sum(nil))
+		if oid != oid2 {
+			t.Errorf("oid for b.dat does not match")
+		}
+
+		by, err = ioutil.ReadFile(lfsObjectPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		h.Reset()
+		h.Write(by)
+		oid = hex.EncodeToString(h.Sum(nil))
+		if oid == oid1 {
+			t.Errorf("oid for a.dat still matches")
+		}
+	})
+}
+
+func TestFsckClean(t *testing.T) {
+	repo := NewRepository(t, "empty")
+	defer repo.Test()
+
+	cmd := repo.Command("fsck")
+	cmd.Output = "Git LFS fsck OK"
+
+	testFileContent := "test data"
+	h := sha256.New()
+	io.WriteString(h, testFileContent)
+	oid1 := hex.EncodeToString(h.Sum(nil))
+	lfsObjectPath := filepath.Join(repo.Path, ".git", "lfs", "objects", oid1[0:2], oid1[2:4], oid1)
+
+	testFile2Content := "test data 2"
+	h.Reset()
+	io.WriteString(h, testFile2Content)
+	oid2 := hex.EncodeToString(h.Sum(nil))
+	lfsObject2Path := filepath.Join(repo.Path, ".git", "lfs", "objects", oid2[0:2], oid2[2:4], oid2)
+
+	cmd.Before(func() {
+		path := filepath.Join(repo.Path, ".git", "info", "attributes")
+		repo.WriteFile(path, "*.dat filter=lfs -crlf\n")
+
+		// Add a Git LFS object
+		repo.WriteFile(filepath.Join(repo.Path, "a.dat"), testFileContent)
+		repo.WriteFile(filepath.Join(repo.Path, "b.dat"), testFile2Content)
+		repo.GitCmd("add", "*.dat")
+		repo.GitCmd("commit", "-m", "a")
+	})
+
+	cmd.After(func() {
+		by, err := ioutil.ReadFile(lfsObject2Path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		h.Reset()
+		h.Write(by)
+		oid := hex.EncodeToString(h.Sum(nil))
+		if oid != oid2 {
+			t.Errorf("oid for b.dat does not match")
+		}
+
+		by, err = ioutil.ReadFile(lfsObjectPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		h.Reset()
+		h.Write(by)
+		oid = hex.EncodeToString(h.Sum(nil))
+		if oid != oid1 {
+			t.Errorf("oid for a.dat does not match")
 		}
 	})
 }

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -13,7 +13,7 @@ func TestFsck(t *testing.T) {
 	defer repo.Test()
 
 	cmd := repo.Command("fsck")
-	cmd.Output = "Could not fsck Git LFS files"
+	cmd.Output = "Object a.dat (916f0027a575074ce72a331777c3478d6513f786a591bd892da1a577bf2335f9) is corrupt"
 
 	testFileContent := "test data"
 	h := sha256.New()

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -4,9 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 )
 
@@ -15,12 +13,13 @@ func TestFsck(t *testing.T) {
 	defer repo.Test()
 
 	cmd := repo.Command("fsck")
-	cmd.Output = "Git LFS fsck OK"
+	cmd.Output = "Could not fsck Git LFS files"
 
 	testFileContent := "test data"
 	h := sha256.New()
 	io.WriteString(h, testFileContent)
 	wantOid := hex.EncodeToString(h.Sum(nil))
+	lfsObjectPath := filepath.Join(repo.Path, ".git", "lfs", "objects", wantOid[0:2], wantOid[2:4], wantOid)
 
 	cmd.Before(func() {
 		path := filepath.Join(repo.Path, ".git", "info", "attributes")
@@ -30,21 +29,6 @@ func TestFsck(t *testing.T) {
 		repo.WriteFile(filepath.Join(repo.Path, "a.dat"), testFileContent)
 		repo.GitCmd("add", "a.dat")
 		repo.GitCmd("commit", "-m", "a")
-	})
-
-	cmd.After(func() {
-		// Verify test file exists as LFS object
-		lfsObjectPath := filepath.Join(repo.Path, ".git", "lfs", "objects", wantOid[0:2], wantOid[2:4], wantOid)
-		if _, err := os.Stat(lfsObjectPath); err != nil {
-			t.Fatal(err)
-		}
-
-		// Corrupt the LFS object and verify that fsck detects corruption
 		repo.WriteFile(lfsObjectPath, testFileContent+"CORRUPTION")
-		err := doFsck(filepath.Join(repo.Path, ".git"))
-		wantErr := &fsckError{"a.dat", wantOid}
-		if !reflect.DeepEqual(err, wantErr) {
-			t.Fatalf("err = %v, want %v", err, wantErr)
-		}
 	})
 }

--- a/commands/fsck_test.go
+++ b/commands/fsck_test.go
@@ -39,6 +39,7 @@ func TestFsckDefault(t *testing.T) {
 		repo.GitCmd("add", "*.dat")
 		repo.GitCmd("commit", "-m", "a")
 		repo.WriteFile(lfsObjectPath, testFileContent+"CORRUPTION")
+		repo.WriteFile(lfsObject2Path, testFile2Content)
 	})
 
 	cmd.After(func() {
@@ -90,6 +91,7 @@ func TestFsckDryRun(t *testing.T) {
 		repo.GitCmd("add", "*.dat")
 		repo.GitCmd("commit", "-m", "a")
 		repo.WriteFile(lfsObjectPath, testFileContent+"CORRUPTION")
+		repo.WriteFile(lfsObject2Path, testFile2Content)
 	})
 
 	cmd.After(func() {
@@ -147,6 +149,8 @@ func TestFsckClean(t *testing.T) {
 		repo.WriteFile(filepath.Join(repo.Path, "b.dat"), testFile2Content)
 		repo.GitCmd("add", "*.dat")
 		repo.GitCmd("commit", "-m", "a")
+		repo.WriteFile(lfsObjectPath, testFileContent)
+		repo.WriteFile(lfsObject2Path, testFile2Content)
 	})
 
 	cmd.After(func() {

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -49,10 +49,9 @@ func TestInit(t *testing.T) {
 	cmd = repo.Command("init")
 	cmd.Output = "Hook already exists: pre-push\n\necho 'yo'\n\ngit lfs initialized"
 
-	customHook := []byte("echo 'yo'")
+	customHook := "echo 'yo'"
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, customHook, 0755)
-		assert.Equal(t, nil, err)
+		repo.WriteFile(prePushHookFile, customHook)
 	})
 
 	cmd.After(func() {

--- a/commands/ls_files_test.go
+++ b/commands/ls_files_test.go
@@ -13,7 +13,7 @@ func TestLsFiles(t *testing.T) {
 	cmd.Output = "a.dat"
 
 	cmd.Before(func() {
-		path := filepath.Join(".git", "info", "attributes")
+		path := filepath.Join(repo.Path, ".git", "info", "attributes")
 		repo.WriteFile(path, "*.dat filter=lfs -crlf\n")
 
 		// Add a Git LFS object

--- a/commands/push_test.go
+++ b/commands/push_test.go
@@ -83,10 +83,7 @@ func TestPushStdin(t *testing.T) {
 
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, []byte("#!/bin/sh\ngit lfs push --stdin \"$@\"\n"), 0755)
-		if err != nil {
-			t.Fatalf("Error writing pre-push in Before(): %s", err)
-		}
+		repo.WriteFile(prePushHookFile, "#!/bin/sh\ngit lfs push --stdin \"$@\"\n")
 	})
 
 	cmd.After(func() {
@@ -111,10 +108,7 @@ func TestPushStdinWithUnexpectedHook(t *testing.T) {
 
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, []byte("sup\n"), 0755)
-		if err != nil {
-			t.Fatalf("Error writing pre-push in Before(): %s", err)
-		}
+		repo.WriteFile(prePushHookFile, "sup\n")
 	})
 
 	cmd.After(func() {

--- a/commands/smudge_test.go
+++ b/commands/smudge_test.go
@@ -48,14 +48,13 @@ func TestSmudge(t *testing.T) {
 	cmd = repo.Command("smudge")
 	cmd.Input = bytes.NewBufferString("version https://git-lfs.github.com/spec/v1\noid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393\nsize 9")
 	cmd.Output = "whatever"
-	customHook := []byte("echo 'yo'")
+	customHook := "echo 'yo'"
 
 	cmd.Before(func() {
 		path := filepath.Join(repo.Path, ".git", "lfs", "objects", "4d", "7a")
 		file := filepath.Join(path, "4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393")
-		assert.Equal(t, nil, os.MkdirAll(path, 0755))
-		assert.Equal(t, nil, ioutil.WriteFile(file, []byte("whatever\n"), 0755))
-		assert.Equal(t, nil, ioutil.WriteFile(prePushHookFile, customHook, 0755))
+		repo.WriteFile(file, "whatever\n")
+		repo.WriteFile(prePushHookFile, customHook)
 	})
 
 	cmd.After(func() {

--- a/commands/status_test.go
+++ b/commands/status_test.go
@@ -13,7 +13,7 @@ func TestStatus(t *testing.T) {
 	cmd.Output = " M file1.dat 9\nA  file2.dat 10\nA  file3.dat 10"
 
 	cmd.Before(func() {
-		path := filepath.Join(".git", "info", "attributes")
+		path := filepath.Join(repo.Path, ".git", "info", "attributes")
 		repo.WriteFile(path, "*.dat filter=lfs -crlf\n")
 
 		// Add a Git LFS file

--- a/commands/track_test.go
+++ b/commands/track_test.go
@@ -13,7 +13,7 @@ func TestTrack(t *testing.T) {
 	defer repo.Test()
 
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
-	customHook := []byte("echo 'yo'")
+	customHook := "echo 'yo'"
 
 	cmd := repo.Command("track")
 	cmd.Output = "Listing tracked paths\n" +
@@ -24,12 +24,11 @@ func TestTrack(t *testing.T) {
 
 	cmd.Before(func() {
 		// write attributes file in .git
-		path := filepath.Join(".git", "info", "attributes")
+		path := filepath.Join(repo.Path, ".git", "info", "attributes")
 		repo.WriteFile(path, "*.mov filter=lfs -crlf\n")
 
 		// add hook
-		err := ioutil.WriteFile(prePushHookFile, customHook, 0755)
-		assert.Equal(t, nil, err)
+		repo.WriteFile(prePushHookFile, customHook)
 	})
 
 	cmd.After(func() {
@@ -50,7 +49,7 @@ func TestTrackOnEmptyRepository(t *testing.T) {
 
 	cmd.Before(func() {
 		// write attributes file in .git
-		path := filepath.Join(".gitattributes")
+		path := filepath.Join(repo.Path, ".gitattributes")
 		repo.WriteFile(path, "*.mov filter=lfs diff=lfs merge=lfs -crlf\n")
 	})
 
@@ -82,7 +81,7 @@ func TestTrackWithoutTrailingLinebreak(t *testing.T) {
 	cmd.Output = "Tracking *.gif"
 
 	cmd.Before(func() {
-		repo.WriteFile(".gitattributes", "*.mov filter=lfs -crlf")
+		repo.WriteFile(filepath.Join(repo.Path, ".gitattributes"), "*.mov filter=lfs -crlf")
 	})
 
 	cmd.After(func() {

--- a/commands/update_test.go
+++ b/commands/update_test.go
@@ -43,10 +43,7 @@ func TestUpdateWithLatestPrePushHook(t *testing.T) {
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
 
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, []byte("#!/bin/sh\ngit lfs pre-push \"$@\"\n"), 0755)
-		if err != nil {
-			t.Fatalf("Error writing pre-push in Before(): %s", err)
-		}
+		repo.WriteFile(prePushHookFile, "#!/bin/sh\ngit lfs pre-push \"$@\"\n")
 	})
 
 	cmd.After(func() {
@@ -74,10 +71,7 @@ func TestUpdateForce(t *testing.T) {
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
 
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, []byte("sup\n"), 0755)
-		if err != nil {
-			t.Fatalf("Error writing pre-push in Before(): %s", err)
-		}
+		repo.WriteFile(prePushHookFile, "sup\n")
 	})
 
 	cmd.After(func() {
@@ -107,10 +101,7 @@ func TestUpdateWithUnexpectedPrePushHook(t *testing.T) {
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
 
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, []byte("test\n"), 0755)
-		if err != nil {
-			t.Fatalf("Error writing pre-push in Before(): %s", err)
-		}
+		repo.WriteFile(prePushHookFile, "test\n")
 	})
 
 	cmd.After(func() {
@@ -138,10 +129,7 @@ func TestUpdateWithOldPrePushHook_1(t *testing.T) {
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
 
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, []byte("#!/bin/sh\ngit lfs push --stdin $*\n"), 0755)
-		if err != nil {
-			t.Fatalf("Error writing pre-push in Before(): %s", err)
-		}
+		repo.WriteFile(prePushHookFile, "#!/bin/sh\ngit lfs push --stdin $*\n")
 	})
 
 	cmd.After(func() {
@@ -169,10 +157,7 @@ func TestUpdateWithOldPrePushHook_2(t *testing.T) {
 	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
 
 	cmd.Before(func() {
-		err := ioutil.WriteFile(prePushHookFile, []byte("#!/bin/sh\ngit lfs push --stdin \"$@\"\n"), 0755)
-		if err != nil {
-			t.Fatalf("Error writing pre-push in Before(): %s", err)
-		}
+		repo.WriteFile(prePushHookFile, "#!/bin/sh\ngit lfs push --stdin \"$@\"\n")
 	})
 
 	cmd.After(func() {


### PR DESCRIPTION
This builds on #280 by @zeroshirts, adding an fsck command.  Right now, all it does is makes sure the `.git/lfs/objects` files all match the OID (a sha256 hash of the contents).  By default, it removes any bad files so that Git LFS can re-download them the next time they're referenced.

Questions:

Is `fsck` the right name?  It would be cool to eventually have something like Homebrew's `doctor` command for checking multiple things besides file system stuff.

Is deleting the corrupt objects the right default?  I'm not sure what we could do to fix files.

Observations (not necessarily blockers for this PR):

We should think hard about how `git fsck` decides what Git refs to scan.  It currently only looks in HEAD and the index.  Though I can come up with other useful scenarios:

* Scan a commit by name: `git lfs fsck --commit abcdef`
* Scan everything in `.git/lfs/objects`: `git lfs fsck --all`
* Scan all commits.

It'd also be nice if there was some consistency in how options work with `git lfs fsck` and potentially similar commands like `git lfs get`.

Also, we may want to build a higher level scanner in the `lfs` package, instead of calling `lfs.ScanRefs()` and `lfs.ScanIndex()` directly.  Something that we can re-use in other commands, without having to export internal things like `*lfs.wrappedPointer`.

```golang
cfg := &lfs.ScanConfig{
  StartCommit: "abcdef",
  EndCommit: "ghijkl",
}

err := lfs.Scan(cfg, func(path string, p *lfs.Pointer) error {
  ...
})
```