### PR TITLE
Prevent to track file outside git repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Git LFS Changelog
 
+## v0.5.1 (30 April, 2015)
+
 * Fix Windows install.bat script.  #223 (@PeterDaveHello)
 
 * Fix bug where `git lfs clean` will clean Git LFS pointers too #271 (@technoweenie)

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-const Version = "0.5.0"
+const Version = "0.5.1"
 
 var (
 	LargeSizeThreshold = 5 * 1024 * 1024


### PR DESCRIPTION
according #293 my report issue, now i already hack code for fixed.
if anybody run `$ git lfs track` outside git repository it's show message "Git LFS cannot perform outside git repository." 