### PR TITLE
Use goimports instead of gofmt

### DIFF
--- a/commands/command_clean.go
+++ b/commands/command_clean.go
@@ -1,9 +1,10 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/github/git-lfs/lfs"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var (

--- a/commands/command_logs.go
+++ b/commands/command_logs.go
@@ -2,11 +2,12 @@ package commands
 
 import (
 	"errors"
-	"github.com/github/git-lfs/lfs"
-	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/github/git-lfs/lfs"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/commands/command_pointer.go
+++ b/commands/command_pointer.go
@@ -6,11 +6,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/github/git-lfs/lfs"
-	"github.com/spf13/cobra"
 	"io"
 	"os"
 	"os/exec"
+
+	"github.com/github/git-lfs/lfs"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -1,13 +1,14 @@
 package commands
 
 import (
+	"io/ioutil"
+	"os"
+	"strings"
+
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/rubyist/tracerx"
 	"github.com/spf13/cobra"
-	"io/ioutil"
-	"os"
-	"strings"
 )
 
 var (

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -2,11 +2,12 @@ package commands
 
 import (
 	"bytes"
-	"github.com/github/git-lfs/lfs"
-	"github.com/spf13/cobra"
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/github/git-lfs/lfs"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/spf13/cobra"

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -3,12 +3,13 @@ package commands
 import (
 	"bufio"
 	"fmt"
-	"github.com/github/git-lfs/lfs"
-	"github.com/spf13/cobra"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/github/git-lfs/lfs"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/commands/command_untrack.go
+++ b/commands/command_untrack.go
@@ -2,11 +2,12 @@ package commands
 
 import (
 	"bufio"
-	"github.com/github/git-lfs/lfs"
-	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/github/git-lfs/lfs"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -3,8 +3,6 @@ package commands
 import (
 	"bytes"
 	"fmt"
-	"github.com/github/git-lfs/lfs"
-	"github.com/spf13/cobra"
 	"io"
 	"log"
 	"os"
@@ -12,6 +10,9 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/github/git-lfs/lfs"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/commands/commands_pre_push.go
+++ b/commands/commands_pre_push.go
@@ -1,11 +1,12 @@
 package commands
 
 import (
-	"github.com/github/git-lfs/lfs"
-	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/github/git-lfs/lfs"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"errors"
 	"fmt"
-	"github.com/bmizerany/assert"
 	"io"
 	"io/ioutil"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/bmizerany/assert"
 )
 
 var (

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -1,12 +1,13 @@
 package commands
 
 import (
-	"github.com/bmizerany/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/bmizerany/assert"
 )
 
 func TestInit(t *testing.T) {

--- a/commands/pointer_test.go
+++ b/commands/pointer_test.go
@@ -1,12 +1,13 @@
 package commands
 
 import (
-	"github.com/bmizerany/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/bmizerany/assert"
 )
 
 func TestPointerWithBuildAndCompareStdinMismatch(t *testing.T) {

--- a/commands/smudge_test.go
+++ b/commands/smudge_test.go
@@ -2,11 +2,12 @@ package commands
 
 import (
 	"bytes"
-	"github.com/bmizerany/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/bmizerany/assert"
 )
 
 func TestSmudge(t *testing.T) {

--- a/commands/track_test.go
+++ b/commands/track_test.go
@@ -1,11 +1,12 @@
 package commands
 
 import (
-	"github.com/bmizerany/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/bmizerany/assert"
 )
 
 func TestTrack(t *testing.T) {

--- a/commands/version_test.go
+++ b/commands/version_test.go
@@ -2,8 +2,9 @@ package commands
 
 import (
 	"fmt"
-	"github.com/github/git-lfs/lfs"
 	"testing"
+
+	"github.com/github/git-lfs/lfs"
 )
 
 func TestVersionOnEmptyRepository(t *testing.T) {

--- a/git/git.go
+++ b/git/git.go
@@ -4,10 +4,11 @@ package git
 import (
 	"errors"
 	"fmt"
-	"github.com/rubyist/tracerx"
 	"io"
 	"os/exec"
 	"strings"
+
+	"github.com/rubyist/tracerx"
 )
 
 func LsRemote(remote, remoteRef string) (string, error) {

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/rubyist/tracerx"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -14,6 +13,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+
+	"github.com/rubyist/tracerx"
 )
 
 const (

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -2,7 +2,6 @@ package lfs
 
 import (
 	"fmt"
-	"github.com/github/git-lfs/git"
 	"net/http"
 	"net/url"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/github/git-lfs/git"
 )
 
 type Configuration struct {

--- a/lfs/config_test.go
+++ b/lfs/config_test.go
@@ -1,8 +1,9 @@
 package lfs
 
 import (
-	"github.com/bmizerany/assert"
 	"testing"
+
+	"github.com/bmizerany/assert"
 )
 
 func TestEndpointDefaultsToOrigin(t *testing.T) {

--- a/lfs/http.go
+++ b/lfs/http.go
@@ -4,13 +4,14 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/rubyist/tracerx"
 	"io"
 	"net"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/rubyist/tracerx"
 )
 
 func DoHTTP(c *Configuration, req *http.Request) (*http.Response, error) {

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -2,13 +2,14 @@ package lfs
 
 import (
 	"fmt"
-	"github.com/github/git-lfs/git"
-	"github.com/rubyist/tracerx"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/github/git-lfs/git"
+	"github.com/rubyist/tracerx"
 )
 
 const Version = "0.5.1"

--- a/lfs/pointer_smudge.go
+++ b/lfs/pointer_smudge.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cheggaaa/pb"
 	"github.com/rubyist/tracerx"
+	contentaddressable "github.com/technoweenie/go-contentaddressable"
 )
 
 func PointerSmudge(writer io.Writer, ptr *Pointer, workingfile string, cb CopyCallback) error {

--- a/lfs/pointer_smudge.go
+++ b/lfs/pointer_smudge.go
@@ -2,12 +2,12 @@ package lfs
 
 import (
 	"fmt"
-	"github.com/cheggaaa/pb"
-	"github.com/rubyist/tracerx"
-	"github.com/technoweenie/go-contentaddressable"
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/cheggaaa/pb"
+	"github.com/rubyist/tracerx"
 )
 
 func PointerSmudge(writer io.Writer, ptr *Pointer, workingfile string, cb CopyCallback) error {

--- a/lfs/pointer_test.go
+++ b/lfs/pointer_test.go
@@ -3,9 +3,10 @@ package lfs
 import (
 	"bufio"
 	"bytes"
-	"github.com/bmizerany/assert"
 	"strings"
 	"testing"
+
+	"github.com/bmizerany/assert"
 )
 
 func TestEncode(t *testing.T) {

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -3,13 +3,14 @@ package lfs
 import (
 	"bufio"
 	"bytes"
-	"github.com/rubyist/tracerx"
 	"io"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/rubyist/tracerx"
 )
 
 const (

--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -3,13 +3,14 @@ package lfs
 import (
 	"errors"
 	"fmt"
-	"github.com/github/git-lfs/git"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/github/git-lfs/git"
 )
 
 var (

--- a/lfs/ssh.go
+++ b/lfs/ssh.go
@@ -2,8 +2,9 @@ package lfs
 
 import (
 	"encoding/json"
-	"github.com/rubyist/tracerx"
 	"os/exec"
+
+	"github.com/rubyist/tracerx"
 )
 
 type sshAuthResponse struct {

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -2,11 +2,12 @@ package lfs
 
 import (
 	"fmt"
-	"github.com/cheggaaa/pb"
 	"os"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+
+	"github.com/cheggaaa/pb"
 )
 
 var (

--- a/lfs/util_test.go
+++ b/lfs/util_test.go
@@ -2,9 +2,10 @@ package lfs
 
 import (
 	"bytes"
-	"github.com/bmizerany/assert"
 	"io/ioutil"
 	"testing"
+
+	"github.com/bmizerany/assert"
 )
 
 func TestWriterWithCallback(t *testing.T) {

--- a/script/build.go
+++ b/script/build.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/github/git-lfs/lfs"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/github/git-lfs/lfs"
 )
 
 var (

--- a/script/fmt
+++ b/script/fmt
@@ -1,10 +1,16 @@
 #!/bin/bash
 
+hash goimports 2>/dev/null || {
+  echo "Installing goimports"
+  echo "go get golang.org/x/tools/cmd/goimports"
+  go get golang.org/x/tools/cmd/goimports
+}
+
 # don't run gofmt in these directories
 ignored=(/bin/ /docs/ /log/ /man/ /tmp/ .vendor)
 for i in */ ; do
   if [[ ! ${ignored[*]} =~ "/$i" ]]; then
-    gofmt -w -l "$@" "${i%?}"
+    goimports -w -l "$@" "${i%?}"
   fi
 done
 

--- a/script/fmt
+++ b/script/fmt
@@ -1,16 +1,15 @@
 #!/bin/bash
 
-hash goimports 2>/dev/null || {
-  echo "Installing goimports"
-  echo "go get golang.org/x/tools/cmd/goimports"
-  go get golang.org/x/tools/cmd/goimports
+formatter=gofmt
+hash goimports 2>/dev/null && {
+  formatter=goimports
 }
 
 # don't run gofmt in these directories
 ignored=(/bin/ /docs/ /log/ /man/ /tmp/ .vendor)
 for i in */ ; do
   if [[ ! ${ignored[*]} =~ "/$i" ]]; then
-    goimports -w -l "$@" "${i%?}"
+    $formatter -w -l "$@" "${i%?}"
   fi
 done
 


### PR DESCRIPTION
This updates `script/fmt` to use `goimports` instead of the built-in `gofmt`.  The main benefit here is that it organizes the import statements with stdlib packages above the 3rd party libs.  The main change is in [`script/fmt`](https://github.com/github/git-lfs/compare/goimports?expand=1#diff-f9a8d86d11fc6a80a862480ab36f3941) itself:

```diff
+hash goimports 2>/dev/null || {
+  echo "Installing goimports"
+  echo "go get golang.org/x/tools/cmd/goimports"
+  go get golang.org/x/tools/cmd/goimports
+}
+
 # don't run gofmt in these directories
 ignored=(/bin/ /docs/ /log/ /man/ /tmp/ .vendor)
 for i in */ ; do
   if [[ ! ${ignored[*]} =~ "/$i" ]]; then
-    gofmt -w -l "$@" "${i%?}"
+    goimports -w -l "$@" "${i%?}"
   fi
 done
```

Is this valid, or should this fall back to `gofmt`?  `gofmt` respects the import style that `goimports` forces, so we won't have to worry about competing code formatting tools.