### PR TITLE
Refactored and improved Errorhandling

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -129,8 +129,10 @@ func logPanic(loggedError error, recursive bool) string {
 
 	if file, err := os.Create(full); err != nil {
 		if !recursive {
+			filename := full
+			full = ""
 			defer func() {
-				fmt.Fprintf(fmtWriter, "Unable to log panic to %s\n\n", full)
+				fmt.Fprintf(fmtWriter, "Unable to log panic to %s\n\n", filename)
 				logPanic(err, true)
 			}()
 		}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -109,12 +109,6 @@ func handlePanic(err error) string {
 	return logPanic(err, false)
 }
 
-func logEnv(w io.Writer) {
-	for _, env := range lfs.Environ() {
-		fmt.Fprintln(w, env)
-	}
-}
-
 func logPanic(loggedError error, recursive bool) string {
 	var fmtWriter io.Writer = os.Stderr
 
@@ -166,6 +160,12 @@ func logPanic(loggedError error, recursive bool) string {
 	}
 
 	return full
+}
+
+func logEnv(w io.Writer) {
+	for _, env := range lfs.Environ() {
+		fmt.Fprintln(w, env)
+	}
 }
 
 type ErrorWithStack interface {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -112,16 +112,14 @@ func handlePanic(err error) string {
 func logPanic(loggedError error) string {
 	var fmtWriter io.Writer = os.Stderr
 
-	if err := os.MkdirAll(lfs.LocalLogDir, 0755); err != nil {
-		fmt.Fprintf(fmtWriter, "Unable to log panic to %s: %s\n\n", lfs.LocalLogDir, err.Error())
-		return ""
-	}
-
 	now := time.Now()
 	name := now.Format("20060102T150405.999999999")
 	full := filepath.Join(lfs.LocalLogDir, name+".log")
 
-	if file, err := os.Create(full); err != nil {
+	if err := os.MkdirAll(lfs.LocalLogDir, 0755); err != nil {
+		full = ""
+		fmt.Fprintf(fmtWriter, "Unable to log panic to %s: %s\n\n", lfs.LocalLogDir, err.Error())
+	} else if file, err := os.Create(full); err != nil {
 		filename := full
 		full = ""
 		defer func() {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -135,31 +135,35 @@ func logPanic(loggedError error, recursive bool) string {
 		}
 	}
 
-	fmt.Fprintf(fmtWriter, "> %s", filepath.Base(os.Args[0]))
-	if len(os.Args) > 0 {
-		fmt.Fprintf(fmtWriter, " %s", strings.Join(os.Args[1:], " "))
-	}
-	fmt.Fprintln(fmtWriter)
-
-	logEnv(fmtWriter)
-	fmt.Fprintln(fmtWriter)
-
-	fmtWriter.Write(ErrorBuffer.Bytes())
-	fmt.Fprintln(fmtWriter)
-
-	fmt.Fprintln(fmtWriter, loggedError.Error())
-
-	if wErr, ok := loggedError.(ErrorWithStack); ok {
-		fmt.Fprintln(fmtWriter, wErr.InnerError())
-		for key, value := range wErr.Context() {
-			fmt.Fprintf(fmtWriter, "%s=%s\n", key, value)
-		}
-		fmtWriter.Write(wErr.Stack())
-	} else {
-		fmtWriter.Write(lfs.Stack())
-	}
+	logPanicToWriter(fmtWriter, loggedError)
 
 	return full
+}
+
+func logPanicToWriter(w io.Writer, loggedError error) {
+	fmt.Fprintf(w, "> %s", filepath.Base(os.Args[0]))
+	if len(os.Args) > 0 {
+		fmt.Fprintf(w, " %s", strings.Join(os.Args[1:], " "))
+	}
+	fmt.Fprintln(w)
+
+	logEnv(w)
+	fmt.Fprintln(w)
+
+	w.Write(ErrorBuffer.Bytes())
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, loggedError.Error())
+
+	if wErr, ok := loggedError.(ErrorWithStack); ok {
+		fmt.Fprintln(w, wErr.InnerError())
+		for key, value := range wErr.Context() {
+			fmt.Fprintf(w, "%s=%s\n", key, value)
+		}
+		w.Write(wErr.Stack())
+	} else {
+		w.Write(lfs.Stack())
+	}
 }
 
 func logEnv(w io.Writer) {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -118,27 +118,27 @@ func logEnv(w io.Writer) {
 func logPanic(loggedError error, recursive bool) string {
 	var fmtWriter io.Writer = os.Stderr
 
-	if err := os.MkdirAll(lfs.LocalLogDir, 0755); err != nil {
-		fmt.Fprintf(fmtWriter, "Unable to log panic to %s: %s\n\n", lfs.LocalLogDir, err.Error())
-		return ""
-	}
+	if !recursive {
+		if err := os.MkdirAll(lfs.LocalLogDir, 0755); err != nil {
+			fmt.Fprintf(fmtWriter, "Unable to log panic to %s: %s\n\n", lfs.LocalLogDir, err.Error())
+			return ""
+		}
 
-	now := time.Now()
-	name := now.Format("20060102T150405.999999999")
-	full := filepath.Join(lfs.LocalLogDir, name+".log")
+		now := time.Now()
+		name := now.Format("20060102T150405.999999999")
+		full := filepath.Join(lfs.LocalLogDir, name+".log")
 
-	if file, err := os.Create(full); err != nil {
-		if !recursive {
+		if file, err := os.Create(full); err != nil {
 			filename := full
 			full = ""
 			defer func() {
 				fmt.Fprintf(fmtWriter, "Unable to log panic to %s\n\n", filename)
 				logPanic(err, true)
 			}()
+		} else {
+			fmtWriter = file
+			defer file.Close()
 		}
-	} else {
-		fmtWriter = file
-		defer file.Close()
 	}
 
 	fmt.Fprintf(fmtWriter, "> %s", filepath.Base(os.Args[0]))


### PR DESCRIPTION
My changes are mostly refactoring.  Non-refactoring changes are:

- Don't return a file name we didn't write to eb12f25
- Write error to stderr, even if os.MkdirAll fails e8c6175

The cases where `os.MkdirAll` and `os.Create` fail, are (still) handled differently and I'm not sure if this was intended in the first place. (The previous code didn't make it that obvious.) Please review.