### PR TITLE
Traced performance in case of error too

### DIFF
--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -52,7 +52,11 @@ var z40 = regexp.MustCompile(`\^?0{40}`)
 // for all Git LFS pointers it finds for that ref.
 func ScanRefs(refLeft, refRight string) ([]*wrappedPointer, error) {
 	nameMap := make(map[string]string, 0)
+
 	start := time.Now()
+	defer func() {
+		tracerx.PerformanceSince("scan", start)
+	}()
 
 	revs, err := revListShas(refLeft, refRight, refLeft == "", nameMap)
 	if err != nil {
@@ -77,8 +81,6 @@ func ScanRefs(refLeft, refRight string) ([]*wrappedPointer, error) {
 		pointers = append(pointers, p)
 	}
 
-	tracerx.PerformanceSince("scan", start)
-
 	return pointers, nil
 }
 
@@ -86,7 +88,11 @@ func ScanRefs(refLeft, refRight string) ([]*wrappedPointer, error) {
 // Git LFS pointers it finds in the index.
 func ScanIndex() ([]*wrappedPointer, error) {
 	nameMap := make(map[string]*indexFile, 0)
+
 	start := time.Now()
+	defer func() {
+		tracerx.PerformanceSince("scan-staging", start)
+	}()
 
 	revs, err := revListIndex(false, nameMap)
 	if err != nil {
@@ -134,8 +140,6 @@ func ScanIndex() ([]*wrappedPointer, error) {
 		}
 		pointers = append(pointers, p)
 	}
-
-	tracerx.PerformanceSince("scan-staging", start)
 
 	return pointers, nil
 


### PR DESCRIPTION
This also keeps the usages of variable 'start' close together.