### PR TITLE
Building on CentOS

### DIFF
--- a/script/centos-build
+++ b/script/centos-build
@@ -1,7 +1,9 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
 #
 # This script works with CentOS 6 or 7
 # The CentOS 5 kernel is too old for go's liking.
+
+set -eu
 
 trap 'echo FAIL' ERR
 
@@ -9,7 +11,7 @@ if grep -q ' 6' /etc/redhat-release; then
   rpm -q epel-release || rpm -Uvh http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 fi
 
-yum install -y bison git golang make man
+yum install -y bison git golang make man which
 cd /tmp
 [ -d git-lfs ] || git clone https://github.com/github/git-lfs
 cd git-lfs
@@ -17,13 +19,32 @@ cd git-lfs
 install -D bin/git-lfs /usr/local/bin
 git lfs init
 
-# I don't know how to install ruby2.0 on CentOS6 yet
-if grep -q ' 7' /etc/redhat-release; then
-  yum install ruby ruby-devel
-  gem install ronn
-  ./script/man
-  install -D man/*.1 /usr/local/share/man/man1
-  git help lfs > /dev/null
+if which ruby > /dev/null 2>&1; then
+  IFS_OLD=${IFS}
+  IFS=.
+  RUBY_VERSION=($(ruby -e "print RUBY_VERSION"))
+  IFS=${IFS_OLD}
+else
+  RUBY_VERSION=(0 0 0) #Thanks -u!
 fi
+
+if [[ ${RUBY_VERSION[0]} < 2 ]]; then
+  if grep -q ' 6' /etc/redhat-release; then
+    yum install -y tar
+    gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+    curl -L get.rvm.io | bash -s stable --ruby
+    set +u
+    source /usr/local/rvm/scripts/rvm
+    rvm use ruby
+    set -u
+  elif grep -q ' 7' /etc/redhat-release; then
+    yum install ruby ruby-devel
+  fi
+fi
+
+gem install ronn
+./script/man
+install -D man/*.1 /usr/local/share/man/man1
+git help lfs > /dev/null
 
 echo SUCCESS

--- a/script/centos-build
+++ b/script/centos-build
@@ -9,7 +9,7 @@ trap 'echo FAIL' ERR
 
 if grep -q ' 5' /etc/redhat-release; then
   pushd /tmp
-  #No clue why rpm -Uvh {url} doesn't work... it doesn't
+  #Don't know why rpm -Uvh {url} doesn't work... Probably 302
   if ! rpm -q epel-release; then
     yum install -y curl.x86_64 #Centos 5 isn't as smart about not downloading 32 bit
     curl -L -O http://download.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm 
@@ -17,12 +17,30 @@ if grep -q ' 5' /etc/redhat-release; then
     rm epel-release-5-4.noarch.rpm
   fi
   yum install -y bison git make man which tar
-  if [ ! -d /tmp/go ]; then
-    curl -L -O http://sourceforge.net/projects/go4centos5/files/go-1.4.2-rhel6.tgz
-    tar -zxf go-1.4.2-rhel6.tgz
+  if [ ! -d /usr/lib/golang ]; then
+    yum install -y rpm-build xz gcc glibc
+    mkdir -p /tmp/go/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+    pushd /tmp/go
+      #Get EPEL full list
+      curl -L -O https://dl.fedoraproject.org/pub/epel/fullfilelist
+      #Get latest golang src rpm
+      curl -L -O https://dl.fedoraproject.org/pub/epel/$(grep '6/SRPMS/golang-[0-9].*src.rpm' fullfilelist)
+      rpm2cpio *.src.rpm | cpio -div
+      #Patch the spec file to patch the build to work on CentOS 5
+      sed -ri 's|(^%build)|\1\nsed -i '"'"'s:.*--build-id.*::'"'"' ./src/cmd/go/build.go|' *.spec
+      #Make SPEC CentOS 5 compliant
+      sed -ri 's|(^Name:.*)|\1\nGroup: Software|' *.spec
+      sed -ri 's|(^%package\s.*)|\1\nGroup: Software|' *.spec
+      #The test WILL fail, so make the rpm not fail
+      sed -ri 's;(.*run.bash.*);\1|true;' *.spec
+      mv *.spec SPECS/
+      mv *.* SOURCES/
+      mv *-* SOURCES/
+      rpmbuild --define "_topdir `pwd`" SPECS/golang.spec -bi
+    popd
   fi
-  export GOROOT=/tmp/go
-  export PATH=${PATH}:${GOROOT}/bin
+  export GOROOT=/usr/lib/golang
+  export PATH=${PATH}:${GOROOT}/bin/linux_amd64
   popd
 else
   if grep -q ' 6' /etc/redhat-release; then

--- a/script/centos-build
+++ b/script/centos-build
@@ -56,7 +56,10 @@ if [[ ${REDHAT_VERSION[0]} == 5 ]]; then
   export PATH=${PATH}:${GOROOT}/bin
 fi
 
-./script/bootstrap
+mkdir -p src/github.com/github
+ln -s $(pwd) src/github.com/github/git-lfs
+GOPATH=`pwd` ./script/bootstrap
+
 install -D bin/git-lfs /usr/local/bin
 git lfs init
 
@@ -90,7 +93,7 @@ if [[ ${RUBY_VERSION[0]} < 2 ]]; then
 fi
 
 gem install ronn
-./script/man
+GOPATH=`pwd` ./script/man
 install -D man/*.1 /usr/local/share/man/man1
 git help lfs > /dev/null
 

--- a/script/centos-build
+++ b/script/centos-build
@@ -7,7 +7,9 @@ set -eu
 
 trap 'echo FAIL' ERR
 
-if grep -q ' 5' /etc/redhat-release; then
+REDHAT_VERSION=($(head -n 1 /etc/redhat-release | \grep -Eo '[0-9]+'))
+
+if [[ ${REDHAT_VERSION[0]} == 5 ]]; then
   pushd /tmp
   #Don't know why rpm -Uvh {url} doesn't work... Probably 302
   if ! rpm -q epel-release; then
@@ -16,34 +18,10 @@ if grep -q ' 5' /etc/redhat-release; then
     rpm -Uvh epel-release-5-4.noarch.rpm
     rm epel-release-5-4.noarch.rpm
   fi
-  yum install -y bison git make man which tar
-  if [ ! -d /usr/lib/golang ]; then
-    yum install -y rpm-build xz gcc glibc
-    mkdir -p /tmp/go/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-    pushd /tmp/go
-      #Get EPEL full list
-      curl -L -O https://dl.fedoraproject.org/pub/epel/fullfilelist
-      #Get latest golang src rpm
-      curl -L -O https://dl.fedoraproject.org/pub/epel/$(grep '6/SRPMS/golang-[0-9].*src.rpm' fullfilelist)
-      rpm2cpio *.src.rpm | cpio -div
-      #Patch the spec file to patch the build to work on CentOS 5
-      sed -ri 's|(^%build)|\1\nsed -i '"'"'s:.*--build-id.*::'"'"' ./src/cmd/go/build.go|' *.spec
-      #Make SPEC CentOS 5 compliant
-      sed -ri 's|(^Name:.*)|\1\nGroup: Software|' *.spec
-      sed -ri 's|(^%package\s.*)|\1\nGroup: Software|' *.spec
-      #The test WILL fail, so make the rpm not fail
-      sed -ri 's;(.*run.bash.*);\1|true;' *.spec
-      mv *.spec SPECS/
-      mv *.* SOURCES/
-      mv *-* SOURCES/
-      rpmbuild --define "_topdir `pwd`" SPECS/golang.spec -bi
-    popd
-  fi
-  export GOROOT=/usr/lib/golang
-  export PATH=${PATH}:${GOROOT}/bin/linux_amd64
   popd
+  yum install -y bison git make man which
 else
-  if grep -q ' 6' /etc/redhat-release; then
+  if [[ ${REDHAT_VERSION[0]} == 6 ]]; then
     rpm -q epel-release || rpm -Uvh http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
   fi
 
@@ -61,6 +39,23 @@ else
   cd git-lfs
 fi
 
+if [[ ${REDHAT_VERSION[0]} == 5 ]]; then
+  if ! env PATH=${PATH}:`pwd`/go/bin which gofmt > /dev/null 2>&1; then
+    yum install -y gcc glibc
+    curl -L -O https://storage.googleapis.com/golang/go1.4.2.src.tar.gz
+    tar -zxvf go1.4.2.src.tar.gz
+    rm go1.4.2.src.tar.gz
+    pushd ./go/src
+      sed -i 's|.*--build-id.*||' ./cmd/go/build.go
+      ./make.bash
+      #This will have a few failures, but that is expected in CentOS 5
+      ./run.bash | true
+    popd
+  fi
+  export GOROOT=`pwd`/go
+  export PATH=${PATH}:${GOROOT}/bin
+fi
+
 ./script/bootstrap
 install -D bin/git-lfs /usr/local/bin
 git lfs init
@@ -75,14 +70,13 @@ else
 fi
 
 if [[ ${RUBY_VERSION[0]} < 2 ]]; then
-  if grep -q ' 6' /etc/redhat-release ||  grep -q ' 5' /etc/redhat-release; then
+  if [[ ${REDHAT_VERSION[0]} < 7 ]]; then
     yum install -y tar
     #if gpg isn't installed, everything actually works. if it is, the key must be added or rvm won't work
-    if grep -q ' 6' /etc/redhat-release; then
-      gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 | true
-    else
-      gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 | true
-    fi
+    which gpg2 > /dev/null 2>&1 && 
+      gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+    which gpg > /dev/null 2>&1 &&
+      gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
     set +e #For CentOS 5
     curl -L get.rvm.io | bash -s stable
     set +u
@@ -91,7 +85,7 @@ if [[ ${RUBY_VERSION[0]} < 2 ]]; then
     rvm use ruby
     set -ue
   elif grep -q ' 7' /etc/redhat-release; then
-    yum install ruby ruby-devel
+    yum install -y ruby ruby-devel
   fi
 fi
 

--- a/script/centos-build
+++ b/script/centos-build
@@ -12,9 +12,16 @@ if grep -q ' 6' /etc/redhat-release; then
 fi
 
 yum install -y bison git golang make man which
-cd /tmp
-[ -d git-lfs ] || git clone https://github.com/github/git-lfs
-cd git-lfs
+
+cd $(dirname ${BASH_SOURCE[0]})
+if git rev-parse; then
+  cd $(git rev-parse --show-toplevel)
+else
+  cd /tmp
+  [ -d git-lfs ] || git clone https://github.com/github/git-lfs
+  cd git-lfs
+fi
+
 ./script/bootstrap
 install -D bin/git-lfs /usr/local/bin
 git lfs init

--- a/script/centos-build
+++ b/script/centos-build
@@ -31,7 +31,7 @@ fi
 cd $(dirname ${BASH_SOURCE[0]})
 if git rev-parse; then
   cd $(git rev-parse --show-toplevel)
-elif [ -d ../docs/man ] && [ -e bootstrap ];then
+elif [ -e bootstrap ];then
   cd ..
 else
   cd /tmp

--- a/script/centos-build
+++ b/script/centos-build
@@ -14,13 +14,12 @@ if grep -q ' 5' /etc/redhat-release; then
     yum install -y curl.x86_64 #Centos 5 isn't as smart about not downloading 32 bit
     curl -L -O http://download.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm 
     rpm -Uvh epel-release-5-4.noarch.rpm
+    rm epel-release-5-4.noarch.rpm
   fi
   yum install -y bison git make man which tar
-  #wget https://storage.googleapis.com/golang/go1.4.2.src.tar.gz --no-check-certificate
-  #wget https://storage.googleapis.com/golang/go1.4.2.linux-386.tar.gz --no-check-certificate
   if [ ! -d /tmp/go ]; then
-    curl -L -O https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz
-    tar -zxf go1.4.2.linux-amd64.tar.gz
+    curl -L -O https://github.com/andyneff/go4cento5/raw/master/go-1.4.2-rhel6.tgz
+    tar -zxf go-1.4.2-rhel6.tgz
   fi
   export GOROOT=/tmp/go
   export PATH=${PATH}:${GOROOT}/bin
@@ -36,7 +35,7 @@ fi
 cd $(dirname ${BASH_SOURCE[0]})
 if git rev-parse; then
   cd $(git rev-parse --show-toplevel)
-elif [ -e ../bin/git-lfs ] && [ -d ../docs/man ] && [ -e bootstrap ];then
+elif [ -d ../docs/man ] && [ -e bootstrap ];then
   cd ..
 else
   cd /tmp
@@ -60,8 +59,11 @@ fi
 if [[ ${RUBY_VERSION[0]} < 2 ]]; then
   if grep -q ' 6' /etc/redhat-release ||  grep -q ' 5' /etc/redhat-release; then
     yum install -y tar
+    #if gpg isn't installed, everything actually works. if it is, the key must be added or rvm won't work
     if grep -q ' 6' /etc/redhat-release; then
-      gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+      gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 | true
+    else
+      gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 | true
     fi
     set +e #For CentOS 5
     curl -L get.rvm.io | bash -s stable

--- a/script/centos-build
+++ b/script/centos-build
@@ -1,17 +1,37 @@
 #!/usr/bin/env bash
 #
 # This script works with CentOS 6 or 7
-# The CentOS 5 kernel is too old for go's liking.
+# The CentOS 5 kernel is too old for go's liking, but this script works on CentOS 5
 
 set -eu
 
 trap 'echo FAIL' ERR
 
-if grep -q ' 6' /etc/redhat-release; then
-  rpm -q epel-release || rpm -Uvh http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
-fi
+if grep -q ' 5' /etc/redhat-release; then
+  pushd /tmp
+  #No clue why rpm -Uvh {url} doesn't work... it doesn't
+  if ! rpm -q epel-release; then
+    yum install -y curl.x86_64 #Centos 5 isn't as smart about not downloading 32 bit
+    curl -L -O http://download.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm 
+    rpm -Uvh epel-release-5-4.noarch.rpm
+  fi
+  yum install -y bison git make man which tar
+  #wget https://storage.googleapis.com/golang/go1.4.2.src.tar.gz --no-check-certificate
+  #wget https://storage.googleapis.com/golang/go1.4.2.linux-386.tar.gz --no-check-certificate
+  if [ ! -d /tmp/go ]; then
+    curl -L -O https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz
+    tar -zxf go1.4.2.linux-amd64.tar.gz
+  fi
+  export GOROOT=/tmp/go
+  export PATH=${PATH}:${GOROOT}/bin
+  popd
+else
+  if grep -q ' 6' /etc/redhat-release; then
+    rpm -q epel-release || rpm -Uvh http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+  fi
 
-yum install -y bison git golang make man which
+  yum install -y bison git golang make man which
+fi
 
 cd $(dirname ${BASH_SOURCE[0]})
 if git rev-parse; then
@@ -38,14 +58,18 @@ else
 fi
 
 if [[ ${RUBY_VERSION[0]} < 2 ]]; then
-  if grep -q ' 6' /etc/redhat-release; then
+  if grep -q ' 6' /etc/redhat-release ||  grep -q ' 5' /etc/redhat-release; then
     yum install -y tar
-    gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
-    curl -L get.rvm.io | bash -s stable --ruby
+    if grep -q ' 6' /etc/redhat-release; then
+      gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+    fi
+    set +e #For CentOS 5
+    curl -L get.rvm.io | bash -s stable
     set +u
     source /usr/local/rvm/scripts/rvm
+    rvm install ruby
     rvm use ruby
-    set -u
+    set -ue
   elif grep -q ' 7' /etc/redhat-release; then
     yum install ruby ruby-devel
   fi

--- a/script/centos-build
+++ b/script/centos-build
@@ -16,6 +16,8 @@ yum install -y bison git golang make man which
 cd $(dirname ${BASH_SOURCE[0]})
 if git rev-parse; then
   cd $(git rev-parse --show-toplevel)
+elif [ -e ../bin/git-lfs ] && [ -d ../docs/man ] && [ -e bootstrap ];then
+  cd ..
 else
   cd /tmp
   [ -d git-lfs ] || git clone https://github.com/github/git-lfs

--- a/script/centos-build
+++ b/script/centos-build
@@ -18,7 +18,7 @@ if grep -q ' 5' /etc/redhat-release; then
   fi
   yum install -y bison git make man which tar
   if [ ! -d /tmp/go ]; then
-    curl -L -O https://github.com/andyneff/go4cento5/raw/master/go-1.4.2-rhel6.tgz
+    curl -L -O http://sourceforge.net/projects/go4centos5/files/go-1.4.2-rhel6.tgz
     tar -zxf go-1.4.2-rhel6.tgz
   fi
   export GOROOT=/tmp/go

--- a/script/debian-build
+++ b/script/debian-build
@@ -21,7 +21,7 @@ fi
 cd $(dirname ${BASH_SOURCE[0]})
 if git rev-parse; then
   cd $(git rev-parse --show-toplevel)
-elif [ -e ../bin/git-lfs ] && [ -d ../docs/man ] && [ -e bootstrap ];then
+elif [ -e bootstrap ];then
   cd ..
 else
   cd /tmp

--- a/script/debian-build
+++ b/script/debian-build
@@ -18,9 +18,15 @@ if [[ $go_version < 1.3.1 ]]; then
   set -u
 fi
 
-cd /tmp
-[ -d git-lfs ] || git clone https://github.com/github/git-lfs
-cd git-lfs
+cd $(dirname ${BASH_SOURCE[0]})
+if git rev-parse; then
+  cd $(git rev-parse --show-toplevel)
+else
+  cd /tmp
+  [ -d git-lfs ] || git clone https://github.com/github/git-lfs
+  cd git-lfs
+fi
+
 ./script/bootstrap
 install -D bin/git-lfs /usr/local/bin
 git lfs init

--- a/script/debian-build
+++ b/script/debian-build
@@ -21,6 +21,8 @@ fi
 cd $(dirname ${BASH_SOURCE[0]})
 if git rev-parse; then
   cd $(git rev-parse --show-toplevel)
+elif [ -e ../bin/git-lfs ] && [ -d ../docs/man ] && [ -e bootstrap ];then
+  cd ..
 else
   cd /tmp
   [ -d git-lfs ] || git clone https://github.com/github/git-lfs


### PR DESCRIPTION
The build script for CentOS could not build the man pages on CentOS 6 since ruby 2 is not available. However, there is a way to get ruby via the RVM. That has been added in so that CentOS 6 can build the man pages using this script

Getting golang on CentOS 5 isn't really a "supported" idea, but I looked into a number of work arounds and settled on the simplest one. I saw it mentioned in the comments and gave it a try. If you would rather say NO to CentOS 5, I can remove that, but I can also say that this will build and run git-lfs on a a CentOS 5 Machine (Tested on a 5.11 VM).

Also add the ability to use a currently cloned version of git-lfs, so it does not always clone into /tmp

