### PR TITLE
configurable tests

### DIFF
--- a/script/integration
+++ b/script/integration
@@ -41,6 +41,10 @@ fi
 
 setup
 
+parallel=${GIT_LFS_TEST_MAXPROCS:-4}
+
+echo "Running this maxprocs=$parallel"
+
 for file in test/test-*.sh; do
   echo "0$(cat .$(basename $file).time 2>/dev/null || true) $file"
-done | sort -rnk1 | awk '{ print $2 }' | xargs -I % -P 4 -n 1 /bin/sh -c % --batch
+done | sort -rnk1 | awk '{ print $2 }' | xargs -I % -P $parallel -n 1 /bin/sh -c % --batch

--- a/test/README.md
+++ b/test/README.md
@@ -67,6 +67,9 @@ includes stdout, stderr, any log files, and even the OS environment.
 There are a few environment variables that you can set to change the test suite
 behavior:
 
+* `GIT_LFS_TEST_DIR=path` - This sets the directory that is used as the current
+working directory of the tests. By default, this is `.tmp`. It's recommended
+that this is set to a directory outside of any Git repository.
 * `KEEPTRASH=1` - This will leave the local repository data in a `tmp` directory
 and the remote repository data in `test/remote`.
 * `SKIPCOMPILE=1` - This skips the Git LFS compilation step.  Speeds up the

--- a/test/README.md
+++ b/test/README.md
@@ -70,6 +70,8 @@ behavior:
 * `GIT_LFS_TEST_DIR=path` - This sets the directory that is used as the current
 working directory of the tests. By default, this is `.tmp`. It's recommended
 that this is set to a directory outside of any Git repository.
+* `GIT_LFS_TEST_MAXPROCS=N` - This tells `script/integration` how many tests to
+run in parallel.  Default: 4.
 * `KEEPTRASH=1` - This will leave the local repository data in a `tmp` directory
 and the remote repository data in `test/remote`.
 * `SKIPCOMPILE=1` - This skips the Git LFS compilation step.  Speeds up the

--- a/test/testenv.sh
+++ b/test/testenv.sh
@@ -13,7 +13,7 @@ BINPATH="$ROOTDIR/bin"
 PATH="$BINPATH:$PATH"
 
 # create a temporary work space
-TMPDIR="$(cd $(dirname "$0")/.. && pwd)"/tmp
+TMPDIR=${GIT_LFS_TEST_DIR:-"$(cd $(dirname "$0")/.. && pwd)/tmp"}
 
 # This is unique to every test file, and cleared after every test run.
 TRASHDIR="$TMPDIR/$(basename "$0")-$$"

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -128,6 +128,8 @@ setup() {
     done
   fi
 
+  echo "tmp dir: $TMPDIR"
+  echo "remote git dir: $REMOTEDIR"
   echo "LFSTEST_URL=$LFS_URL_FILE LFSTEST_DIR=$REMOTEDIR lfstest-gitserver"
   LFSTEST_URL="$LFS_URL_FILE" LFSTEST_DIR="$REMOTEDIR" lfstest-gitserver > "$REMOTEDIR/gitserver.log" 2>&1 &
   wait_for_file "$LFS_URL_FILE"

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -112,8 +112,8 @@ clone_repo() {
 setup() {
   cd "$ROOTDIR"
 
-  rm -rf "test/remote"
-  mkdir "test/remote"
+  rm -rf "$REMOTEDIR"
+  mkdir "$REMOTEDIR"
 
   if [ -z "$SKIPCOMPILE" ]; then
     echo "compile git-lfs for $0"


### PR DESCRIPTION
This adds a couple new env vars for integration tests:

* `GIT_LFS_TEST_DIR` sets an alternate tmp dir for tests.  Ideally tests run outside of the git-lfs (or any) repository.
* `GIT_LFS_TEST_MAXPROCS` tells `xargs` how many tests to run in parallel.

EDIT: I was unable to get #294 to fail in the new test suite, and realized it was because they were running inside the Git LFS project directory.  Though this is fine for most uses, I think CI systems and possibly core Git LFS devs should export better settings for these env vars.  For instance, it may make sense to turn maxprocs down on Travis, which has just 2 cores. 