### PR TITLE
support tracking paths with spaces in the name

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -64,7 +64,8 @@ func trackCommand(cmd *cobra.Command, args []string) {
 			continue
 		}
 
-		_, err := attributesFile.WriteString(fmt.Sprintf("%s filter=lfs diff=lfs merge=lfs -crlf\n", t))
+		encodedArg := strings.Replace(t, " ", "[[:space:]]", -1)
+		_, err := attributesFile.WriteString(fmt.Sprintf("%s filter=lfs diff=lfs merge=lfs -crlf\n", encodedArg))
 		if err != nil {
 			Print("Error adding path %s", t)
 			continue

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -45,6 +45,25 @@ begin_test "track"
 )
 end_test
 
+begin_test "track directory"
+(
+  set -e
+  mkdir dir
+  cd dir
+  git init
+
+  git lfs track "foo bar/*"
+
+  mkdir "foo bar"
+  echo "a" > "foo bar/a"
+  echo "b" > "foo bar/b"
+  git add foo\ bar
+  git commit -am "add foo bar"
+
+  assert_pointer "master" "foo bar/a" "87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7" 2
+  assert_pointer "master" "foo bar/b" "0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f" 2
+)
+
 begin_test "track without trailing linebreak"
 (
   set -e

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -10,7 +10,8 @@ assert_pointer() {
   local oid=$3
   local size=$4
 
-  gitblob=$(git ls-tree -l $ref | grep $path | cut -f 3 -d " ")
+  tree=$(git ls-tree -lr "$ref")
+  gitblob=$(echo "$tree" | grep "$path" | cut -f 3 -d " ")
   actual=$(git cat-file -p $gitblob)
   expected=$(pointer $oid $size)
 

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -5,10 +5,10 @@
 #
 #   $ assert_pointer "master" "path/to/file" "some-oid" 123
 assert_pointer() {
-  local ref=$1
-  local path=$2
-  local oid=$3
-  local size=$4
+  local ref="$1"
+  local path="$2"
+  local oid="$3"
+  local size="$4"
 
   tree=$(git ls-tree -lr "$ref")
   gitblob=$(echo "$tree" | grep "$path" | cut -f 3 -d " ")
@@ -47,7 +47,7 @@ size %s
 #
 #   $ wait_for_file "path/to/upcoming/file"
 wait_for_file() {
-  local filename=$1
+  local filename="$1"
   n=0
   while [ $n -lt 10 ]; do
     if [ -s $filename ]; then
@@ -70,7 +70,7 @@ wait_for_file() {
 #   $ setup_remote_repo "some-name"
 #
 setup_remote_repo() {
-  local reponame=$1
+  local reponame="$1"
   echo "set up remote git repository: $reponame"
   repodir="$REMOTEDIR/$reponame.git"
   mkdir -p "$repodir"
@@ -99,8 +99,8 @@ setup_remote_repo() {
 clone_repo() {
   cd "$TRASHDIR"
 
-  local reponame=$1
-  local dir=$2
+  local reponame="$1"
+  local dir="$2"
   echo "clone local git repository $reponame to $dir"
   out=$(GIT_CONFIG="$LFS_CONFIG-$reponame" git clone "$GITSERVER/$reponame" "$dir" 2>&1)
   cd "$dir"


### PR DESCRIPTION
.gitattributes needs spaces in paths replaced with `[[:space:]]`

Fixes #298