### PR TITLE
Fix charset http Content-Type header

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	mediaType = "application/vnd.git-lfs+json; charset-utf-8"
+	mediaType = "application/vnd.git-lfs+json; charset=utf-8"
 )
 
 // The apiEvent* statuses (and the apiEvent channel) are used by


### PR DESCRIPTION
I tried implementing an LFS Server in JAVA and came up with this issue. According to https://tools.ietf.org/html/rfc5987, it has to always be "key = value". I also tried this change and my implementation now works (or at least I am one small step further).