### PR TITLE
Add a link to the CLA to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ help is essential for keeping it great.
 0. Create a new branch: `git checkout -b my-branch-name`
 0. Make your change, add tests, and make sure the tests still pass
 0. Push to your fork and [submit a pull request][pr]
+0. Accept the [GitHub CLA][cla]
 0. Pat your self on the back and wait for your pull request to be reviewed.
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
@@ -57,3 +58,4 @@ release.
 [fork]: https://github.com/github/git-lfs/fork
 [pr]: https://github.com/github/git-lfs/compare
 [style]: https://github.com/golang/go/wiki/CodeReviewComments
+[cla]: https://cla.github.com/github/git-lfs/accept


### PR DESCRIPTION
Add a note in CONTRIBUTING about accepting the CLA.

:warning: This cannot be merged yet :warning:

@bkeepers is going to add an appropriate route to the CLA app, once that's done we can merge this.