### PR TITLE
Test tweaks

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -1,8 +1,4 @@
 #!/bin/sh
 set -e
-
-git config user.name || git config --global user.name "Git LFS Tests"
-git config user.email || git config --global user.email "git-lfs@example.com"
-
 script/test
 script/integration

--- a/script/test
+++ b/script/test
@@ -3,7 +3,6 @@
 #/        script/test <subdir> # run just a package's tests
 
 script/fmt
-script/bootstrap
 
 export LOCALSRCDIR=`pwd`/.vendor/src/github.com/github/git-lfs
 mkdir -p `dirname $LOCALSRCDIR`
@@ -15,5 +14,4 @@ SUITE="./${1:-"lfs"}"
 if [ $# -gt 0 ]; then
   shift
 fi
-PATH=$LOCALSRCDIR/bin:$PATH GOPATH=$GOPATH go test $SUITE -i "$@"
 PATH=$LOCALSRCDIR/bin:$PATH GOPATH=$GOPATH go test $SUITE "$@"

--- a/test/test-happy-path.sh
+++ b/test/test-happy-path.sh
@@ -23,8 +23,8 @@ begin_test "happy path"
   clone_repo "$reponame" repo
 
   # This executes Git LFS from the local repo that was just cloned.
-  out=$(git lfs track "*.dat" 2>&1)
-  echo "$out" | grep "Tracking \*.dat"
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \*.dat" track.log
 
   contents="a"
   contents_oid=$(printf "$contents" | shasum -a 256 | cut -f 1 -d " ")
@@ -39,10 +39,7 @@ begin_test "happy path"
   grep "create mode 100644 a.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
 
-  out=$(cat a.dat)
-  if [ "$out" != "a" ]; then
-    exit 1
-  fi
+  [ "a" = "$(cat a.dat)" ]
 
   # This is a small shell function that runs several git commands together.
   assert_pointer "master" "a.dat" "$contents_oid" 1
@@ -61,10 +58,7 @@ begin_test "happy path"
 
   git pull 2>&1 | grep "Downloading a.dat (1 B)"
 
-  out=$(cat a.dat)
-  if [ "$out" != "a" ]; then
-    exit 1
-  fi
+  [ "a" = "$(cat a.dat)" ]
 
   assert_pointer "master" "a.dat" "$contents_oid" 1
 )


### PR DESCRIPTION
Some minor things I missed from #336:


* [x] speed up `script/test`.  The old command tests are gone in favor of the shell tests, so we don't have to compile again.
* [x] Do we need to run the global `git config` commands anymore? I don't think so...
* [x] minor tweaks to `test-happy-path.sh`