### PR TITLE
update build scripts

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -15,9 +15,6 @@ override_dh_clean:
 	dh_clean
 
 override_dh_auto_build:
-	for dir in .vendor/src/github.com/*; do \
-		ln -s ../../../$$dir $(BUILD_DIR)/src/github.com/; \
-	done
 	dh_auto_build
 	rm $(BUILD_DIR)/bin/script
 	./script/man


### PR DESCRIPTION
We've changed how go dependencies are managed in Git LFS (#331). Hopefully the various build scripts still work ;) Two main differences:

* `script/bootstrap` no longer symlinks the root dir into `.vendor/src/github/git-lfs`.
* The main entry point is now `./git-lfs.go`, not `cmd/git-lfs/git-lfs.go`.

@ssgelm: I removed the symlinking from the debian package rules. 

@jsh: Since the `script/debian-build` and `script/centos-build` both use `script/bootstrap`, I think they're good to go.