### PR TITLE
Add support for configured URLs containing credentials per RFC1738

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -552,7 +552,7 @@ func getCreds(req *http.Request) (Creds, error) {
 
 	if req.URL.Scheme == apiUrl.Scheme &&
 		req.URL.Host == apiUrl.Host {
-		creds, err := credentials(req.URL)
+		creds, err := credentials(req.URL, apiUrl)
 		if err != nil {
 			return nil, err
 		}

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -57,7 +57,6 @@ func ObjectUrl(endpoint Endpoint, oid string) (*url.URL, error) {
 	return u, nil
 }
 
-
 func (c *Configuration) Endpoint() Endpoint {
 	if url, ok := c.GitConfig("lfs.url"); ok {
 		return Endpoint{Url: url}.newEndpoint()
@@ -217,11 +216,11 @@ func (c *Configuration) loadGitConfig() {
 }
 
 func (e Endpoint) newEndpoint() Endpoint {
-		if u, err := url.Parse(e.Url); err == nil {
-			if u.User != nil {
-				fmt.Fprintln(os.Stderr, "warning: configured LFS endpoint contains credentials")
-			}
+	if u, err := url.Parse(e.Url); err == nil {
+		if u.User != nil {
+			fmt.Fprintln(os.Stderr, "warning: configured LFS endpoint contains credentials")
 		}
+	}
 
-		return e
+	return e
 }

--- a/lfs/credentials.go
+++ b/lfs/credentials.go
@@ -17,8 +17,16 @@ type credentialFunc func(Creds, string) (credentialFetcher, error)
 
 var execCreds credentialFunc
 
-func credentials(u *url.URL) (Creds, error) {
+func credentials(u *url.URL, apiUrl *url.URL) (Creds, error) {
 	creds := Creds{"protocol": u.Scheme, "host": u.Host}
+	if userInfo := apiUrl.User; userInfo != nil {
+		if password, ok := userInfo.Password(); ok {
+			creds["username"] = userInfo.Username()
+			creds["password"] = password
+			return creds, nil
+		}
+	}
+
 	cmd, err := execCreds(creds, "fill")
 	if err != nil {
 		return nil, err

--- a/lfs/credentials_test.go
+++ b/lfs/credentials_test.go
@@ -23,7 +23,7 @@ func TestGetCredentials(t *testing.T) {
 	}
 
 	if value := creds["password"]; value != "monkey" {
-		t.Errorf("bad username: %s", value)
+		t.Errorf("bad password: %s", value)
 	}
 
 	expected := "Basic " + base64.URLEncoding.EncodeToString([]byte("lfs-server.com:monkey"))
@@ -115,6 +115,32 @@ func TestGetCredentialsWithPortMismatch(t *testing.T) {
 
 	if actual := req.Header.Get("Authorization"); actual != "" {
 		t.Errorf("Unexpected Authorization header: %s", actual)
+	}
+}
+
+func TestGetCredentialsWithRfc1738UsernameAndPassword(t *testing.T) {
+	Config.SetConfig("lfs.url", "https://testuser:testpass@lfs-server.com")
+	req, err := http.NewRequest("GET", "https://lfs-server.com/foo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	creds, err := getCreds(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if value := creds["username"]; value != "testuser" {
+		t.Errorf("bad username: %s", value)
+	}
+
+	if value := creds["password"]; value != "testpass" {
+		t.Errorf("bad password: %s", value)
+	}
+
+	expected := "Basic " + base64.URLEncoding.EncodeToString([]byte("testuser:testpass"))
+	if value := req.Header.Get("Authorization"); value != expected {
+		t.Errorf("Bad Authorization. Expected '%s', got '%s'", expected, value)
 	}
 }
 


### PR DESCRIPTION
This PR adds support for URLs containing credentials per [RFC1738](https://www.ietf.org/rfc/rfc1738.txt) - ```user:pass@host``` - to be configured in the usual places.
Such URLs will trigger a warning.
Any credentials parsed from a configured URL will be saved via ```git credential approve```.