### PR TITLE
Support environment variables GIT_DIR and GIT_WORK_TREE

### DIFF
--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -113,12 +113,37 @@ func init() {
 }
 
 func resolveGitDir() (string, string, error) {
+	gitDir := Config.Getenv("GIT_DIR")
+	workTree := Config.Getenv("GIT_WORK_TREE")
+
+	if gitDir != "" {
+		return processGitDirVar(gitDir, workTree)
+	}
+
 	wd, err := os.Getwd()
 	if err != nil {
 		return "", "", err
 	}
 
 	return recursiveResolveGitDir(wd)
+}
+
+func processGitDirVar(gitDir, workTree string) (string, string, error) {
+	if workTree != "" {
+		return workTree, gitDir, nil
+	}
+
+	// See `core.worktree` in `man git-config`:
+	// “If --git-dir or GIT_DIR is specified but none of --work-tree, GIT_WORK_TREE and
+	// core.worktree is specified, the current working directory is regarded as the top
+	// level of your working tree.”
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", "", err
+	}
+
+	return wd, gitDir, nil
 }
 
 func recursiveResolveGitDir(dir string) (string, string, error) {

--- a/test/test-env.sh
+++ b/test/test-env.sh
@@ -243,3 +243,85 @@ $(env | grep "^GIT")
   [ "$expected" = "$actual2" ]
 )
 end_test
+
+begin_test "env with environment variables"
+(
+  set -e
+  reponame="env-with-envvars"
+  git init $reponame
+  mkdir -p $reponame/a/b/c
+
+  gitDir=$TRASHDIR/$reponame/.git
+  workTree=$TRASHDIR/$reponame/a/b
+
+  expected=$(printf "LocalWorkingDir=$TRASHDIR/$reponame/a/b
+LocalGitDir=$TRASHDIR/$reponame/.git
+LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
+TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
+ConcurrentTransfers=3
+BatchTransfer=false
+$(GIT_DIR=$gitDir GIT_WORK_TREE=$workTree env | grep "^GIT")
+")
+
+  actual=$(GIT_DIR=$gitDir GIT_WORK_TREE=$workTree git lfs env)
+  [ "$expected" = "$actual" ]
+
+  cd $TRASHDIR/$reponame
+  actual2=$(GIT_DIR=$gitDir GIT_WORK_TREE=$workTree git lfs env)
+  [ "$expected" = "$actual2" ]
+
+  cd $TRASHDIR/$reponame/.git
+  actual3=$(GIT_DIR=$gitDir GIT_WORK_TREE=$workTree git lfs env)
+  [ "$expected" = "$actual3" ]
+
+  cd $TRASHDIR/$reponame/a/b/c
+  actual4=$(GIT_DIR=$gitDir GIT_WORK_TREE=$workTree git lfs env)
+  [ "$expected" = "$actual4" ]
+
+  expected5=$(printf "LocalWorkingDir=$TRASHDIR/$reponame/a/b
+LocalGitDir=$TRASHDIR/$reponame/.git
+LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
+TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
+ConcurrentTransfers=3
+BatchTransfer=false
+$(GIT_DIR=$gitDir GIT_WORK_TREE=a/b env | grep "^GIT")
+")
+  actual5=$(GIT_DIR=$gitDir GIT_WORK_TREE=a/b git lfs env)
+  [ "$expected5" = "$actual5" ]
+
+  expected6=$(printf "LocalWorkingDir=$TRASHDIR/$reponame/a/b
+LocalGitDir=$TRASHDIR/$reponame/.git
+LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
+TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
+ConcurrentTransfers=3
+BatchTransfer=false
+$(GIT_WORK_TREE=a/b env | grep "^GIT")
+")
+  actual6=$(GIT_WORK_TREE=a/b git lfs env)
+  [ "$expected6" = "$actual6" ]
+
+  cd $TRASHDIR/$reponame/a/b
+  expected7=$(printf "LocalWorkingDir=$TRASHDIR/$reponame/a/b
+LocalGitDir=$TRASHDIR/$reponame/.git
+LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
+TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
+ConcurrentTransfers=3
+BatchTransfer=false
+$(GIT_DIR=$gitDir env | grep "^GIT")
+")
+  actual7=$(GIT_DIR=$gitDir git lfs env)
+  [ "$expected7" = "$actual7" ]
+
+  cd $TRASHDIR/$reponame/a
+  expected8=$(printf "LocalWorkingDir=$TRASHDIR/$reponame/a/b
+LocalGitDir=$TRASHDIR/$reponame/.git
+LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
+TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
+ConcurrentTransfers=3
+BatchTransfer=false
+$(GIT_WORK_TREE=$workTree env | grep "^GIT")
+")
+  actual8=$(GIT_WORK_TREE=$workTree git lfs env)
+  [ "$expected8" = "$actual8" ]
+)
+end_test


### PR DESCRIPTION
The support for config option `core.worktree` and command line options `--work-tree` and `--git-dir` is still missing.