### PR TITLE
Return a non-zero exit status if build fails

### DIFF
--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -104,7 +104,9 @@ setup() {
 
   if [ -z "$SKIPCOMPILE" ]; then
     echo "compile git-lfs for $0"
-    script/bootstrap
+    script/bootstrap || {
+      return $?
+    }
   fi
 
   echo "Git LFS: $(which git-lfs)"

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -49,7 +49,10 @@ GITSERVER=undefined
 if [ -s $LFS_URL_FILE ]; then
   SHUTDOWN_LFS=no
 else
-  setup
+  setup || {
+    failures=$(( failures + 1 ))
+    exit $?
+  }
 fi
 
 GITSERVER=$(cat "$LFS_URL_FILE")


### PR DESCRIPTION
When running test scripts and the build fails, the tests are running anyway.  This obscures the build error in case an old executable is still present.

- Return a non-zero exit status if one or more builds fail.
- Exit test with a non-zero exit status if build fails, i.e. fail test.