### PR TITLE
Fixed some (markdown) issues in spec

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -12,7 +12,7 @@ only a pointer file is written.
 * Pointer files are text files which MUST contain only UTF-8 characters.
 * Each line MUST be of the format `{key} {value}\n` (trailing unix newline).
 * Only a single space character between `{key}` and `{value}`.
-* Keys MUST only use the characters `[a-z] [0-9] . -`.  
+* Keys MUST only use the characters `[a-z] [0-9] . -`.
 * The first key is _always_ `version`.
 * Lines of key/value pairs MUST be sorted alphabetically in ascending order
 (with the exception of `version`, which is always first).
@@ -51,62 +51,68 @@ size 12345
 For testing compliance of any tool generating its own pointer files, the
 reference is this official Git LFS tool:
 
-NOTE: exact pointer command behavior TBD!
+**NOTE:** exact pointer command behavior TBD!
 
 * Tools that parse and regenerate pointer files MUST preserve keys that they
 don't know or care about.
 * Run the `pointer` command to generate a pointer file for the given local
 file:
 
-        $ git lfs pointer --file=path/to/file
-        Git LFS pointer for path/to/file:
+    ```
+    $ git lfs pointer --file=path/to/file
+    Git LFS pointer for path/to/file:
 
-        version https://git-lfs.github.com/spec/v1
-        oid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
-        size 12345
+    version https://git-lfs.github.com/spec/v1
+    oid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
+    size 12345
+    ```
 
 * Run `pointer` to compare the blob OID of a pointer file built by Git LFS with
 a pointer built by another tool.
 
   * Write the other implementation's pointer to "other/pointer/file":
 
-        $ git lfs pointer --file=path/to/file --pointer=other/pointer/file
-        Git LFS pointer for path/to/file:
+    ```
+    $ git lfs pointer --file=path/to/file --pointer=other/pointer/file
+    Git LFS pointer for path/to/file:
 
-        version https://git-lfs.github.com/spec/v1
-        oid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
-        size 12345
+    version https://git-lfs.github.com/spec/v1
+    oid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
+    size 12345
 
-        Blob OID: 60c8d8ab2adcf57a391163a7eeb0cdb8bf348e44
+    Blob OID: 60c8d8ab2adcf57a391163a7eeb0cdb8bf348e44
 
-        Pointer from other/pointer/file
-        version https://git-lfs.github.com/spec/v1
-        oid sha256 4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
-        size 12345
+    Pointer from other/pointer/file
+    version https://git-lfs.github.com/spec/v1
+    oid sha256 4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
+    size 12345
 
-        Blob OID: 08e593eeaa1b6032e971684825b4b60517e0638d
+    Blob OID: 08e593eeaa1b6032e971684825b4b60517e0638d
 
-        Pointers do not match!
+    Pointers do not match
+    ```
 
   * It can also read STDIN to get the other implementation's pointer:
 
-        $ cat other/pointer/file | git lfs pointer --file=path/to/file --stdin
-        Git LFS pointer for path/to/file:
+    ```
+    $ cat other/pointer/file | git lfs pointer --file=path/to/file --stdin
+    Git LFS pointer for path/to/file:
 
-        version https://git-lfs.github.com/spec/v1
-        oid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
-        size 12345
+    version https://git-lfs.github.com/spec/v1
+    oid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
+    size 12345
 
-        Blob OID: 60c8d8ab2adcf57a391163a7eeb0cdb8bf348e44
+    Blob OID: 60c8d8ab2adcf57a391163a7eeb0cdb8bf348e44
 
-        Pointer from STDIN
-        version https://git-lfs.github.com/spec/v1
-        oid sha256 4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
-        size 12345
+    Pointer from STDIN
+    version https://git-lfs.github.com/spec/v1
+    oid sha256 4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
+    size 12345
 
-        Blob OID: 08e593eeaa1b6032e971684825b4b60517e0638d
+    Blob OID: 08e593eeaa1b6032e971684825b4b60517e0638d
 
-        Pointers do not match!
+    Pointers do not match
+    ```
 
 ## The Server
 


### PR DESCRIPTION
Indentation is not as robust as ```.  See https://github.com/github/git-lfs/blob/afbc5818a37793ee1ea17202fde66f50975dbcb8/docs/spec.md

See https://github.com/michael-k/git-lfs/blob/spec/docs/spec.md for rendering (without diff).