### PR TITLE
Remove unnecessary exec the process by filter wrapper

### DIFF
--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -90,7 +90,7 @@ func InstallFilters() error {
 
 func setFilter(filterName string) error {
 	key := fmt.Sprintf("filter.lfs.%s", filterName)
-	value := fmt.Sprintf("git lfs %s %%f", filterName)
+	value := fmt.Sprintf("git-lfs %s %%f", filterName)
 
 	existing := git.Config.Find(key)
 	if shouldReset(existing) {


### PR DESCRIPTION
This change improve git-lfs performance on Windows, becuase Ms Windows function CreateProcess is too expensive (~0.2 sec per call).
This small change reduce my test repository clone time from 4970 sec to 4352 sec (1.14X faster).
See #376 for more details.