### PR TITLE
Windows: hide git application window.

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -118,7 +118,7 @@ func (c *gitConfig) Version() (string, error) {
 // simpleExec is a small wrapper around os/exec.Command.
 func simpleExec(name string, args ...string) (string, error) {
 	tracerx.Printf("run_command: '%s' %s", name, strings.Join(args, " "))
-	cmd := exec.Command(name, args...)
+	cmd := execCommand(name, args...)
 
 	output, err := cmd.Output()
 	if _, ok := err.(*exec.ExitError); ok {

--- a/git/git_nix.go
+++ b/git/git_nix.go
@@ -1,0 +1,13 @@
+// +build !windows
+
+// Package git contains various commands that shell out to git
+package git
+
+import (
+	"os/exec"
+)
+
+// execCommand is a small platform specific wrapper around os/exec.Command
+func execCommand(name string, arg ...string) *exec.Cmd {
+	return exec.Command(name, arg...)
+}

--- a/git/git_win.go
+++ b/git/git_win.go
@@ -1,0 +1,16 @@
+// +build windows
+
+// Package git contains various commands that shell out to git
+package git
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// execCommand is a small platform specific wrapper around os/exec.Command
+func execCommand(name string, arg ...string) *exec.Cmd {
+	cmd := exec.Command(name, arg...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	return cmd
+}


### PR DESCRIPTION
Original problem (https://code.google.com/p/tortoisegit/issues/detail?id=2518):

 1. Install Git LFS (https://git-lfs.github.com/)
   * Download and unpack archive;
   * Put git-lfs.exe on any avaialble in PATH directory;
   * Run "git lfs init"
 2. Clone repository from: https://github.com/bozaro/test
 3. Change image "tux.png"
 4. Show "Git Commit" window

On showing "Git Commit" window you will see black window blink for each changed LFS file (twice in this case).

You also will see black window blink on refreshing change list by F5 key.