### PR TITLE
Fix the deb package build and bump the version to 0.5.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (0.5.2) stable; urgency=low
+
+  * New upstream version
+
+ -- Stephen Gelman <gelman@getbraintree.com>  Fri, 12 Jun 2015 02:54:01 +0000
+
 git-lfs (0.5.1) stable; urgency=medium
 
   * Initial release.

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,7 @@ export DH_OPTIONS
 
 BUILD_DIR := obj-$(DEB_BUILD_GNU_TYPE)
 export DH_GOPKG := github.com/github/git-lfs
+export DH_GOLANG_EXCLUDES := test
 export PATH := $(CURDIR)/$(BUILD_DIR)/bin:$(PATH)
 
 %:
@@ -15,9 +16,6 @@ override_dh_clean:
 	dh_clean
 
 override_dh_auto_build:
-	for dir in .vendor/src/github.com/*; do \
-		ln -s ../../../$$dir $(BUILD_DIR)/src/github.com/; \
-	done
 	dh_auto_build
 	rm $(BUILD_DIR)/bin/script
 	./script/man


### PR DESCRIPTION
Thanks to the new more standard project layout we no longer need to symlink things.  I also bumped the version in preparation for #281.