### PR TITLE
Do not defer close in loop

### DIFF
--- a/lfs/download_test.go
+++ b/lfs/download_test.go
@@ -226,13 +226,13 @@ func TestSuccessfulDownloadWithRedirects(t *testing.T) {
 		if wErr != nil {
 			t.Fatalf("unexpected error for %d status: %s", redirect, wErr)
 		}
-		defer reader.Close()
 
 		if size != 4 {
 			t.Errorf("unexpected size for %d status: %d", redirect, size)
 		}
 
 		by, err := ioutil.ReadAll(reader)
+		reader.Close()
 		if err != nil {
 			t.Fatalf("unexpected error for %d status: %s", redirect, err)
 		}
@@ -568,13 +568,13 @@ func TestSuccessfulDownloadFromSeparateRedirectedHost(t *testing.T) {
 		if wErr != nil {
 			t.Fatalf("unexpected error for %d status: %s", redirect, wErr)
 		}
-		defer reader.Close()
 
 		if size != 4 {
 			t.Errorf("unexpected size for %d status: %d", redirect, size)
 		}
 
 		by, err := ioutil.ReadAll(reader)
+		reader.Close()
 		if err != nil {
 			t.Fatalf("unexpected error for %d status: %s", redirect, err)
 		}


### PR DESCRIPTION
See https://github.com/github/git-lfs/pull/378#issuecomment-111231779:

> There are a couple problems that are causing the tests to deadlock.
>
> The first one is easy, some of the download tests are doing a defer reader.Close() in a loop when it should just be closing them immediately, causing the deadlock: