### PR TITLE
Make it possible to enable Travis on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ install: true
 script: script/cibuild
 notifications:
   email: false
+before_install:
+  - repo=`basename $PWD`; localDir=`dirname $PWD`; cfDir="`dirname $localDir`/github"
+  - if [[ "$localDir" != "$cfDir" ]]; then mv "$localDir" "$cfDir"; cd ../../github/$repo; export TRAVIS_BUILD_DIR=`dirname $TRAVIS_BUILD_DIR`/$repo; fi


### PR DESCRIPTION
I needed this to debug Travis issues, might be useful for someone else. Usually trying to use Travis with a fork of a golang project fails because the clone path is $fork_user/git-lfs instead of github/git-lfs which breaks package references. Note that this code should work on any golang repo owned by github, in case that's useful.