### PR TITLE
set request auth from optional endpoint url username/password

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -345,10 +345,7 @@ func doHttpRequest(req *http.Request, creds Creds) (*http.Response, *WrappedErro
 	if err != nil {
 		wErr = Errorf(err, "Error for %s %s", res.Request.Method, res.Request.URL)
 	} else {
-		if creds != nil {
-			saveCredentials(creds, res)
-		}
-
+		saveCredentials(creds, res)
 		wErr = handleResponse(res)
 	}
 
@@ -573,20 +570,32 @@ func getCreds(req *http.Request) (Creds, error) {
 		return nil, err
 	}
 
-	if req.URL.Scheme == apiUrl.Scheme &&
-		req.URL.Host == apiUrl.Host {
-		creds, err := credentials(req.URL)
-		if err != nil {
-			return nil, err
-		}
-
-		token := fmt.Sprintf("%s:%s", creds["username"], creds["password"])
-		auth := "Basic " + base64.URLEncoding.EncodeToString([]byte(token))
-		req.Header.Set("Authorization", auth)
-		return creds, nil
+	if req.URL.Scheme != apiUrl.Scheme ||
+		req.URL.Host != apiUrl.Host {
+		return nil, nil
 	}
 
-	return nil, nil
+	if apiUrl.User != nil {
+		if pass, ok := apiUrl.User.Password(); ok {
+			fmt.Fprintln(os.Stderr, "warning: configured Git LFS endpoint contains credentials")
+			setRequestAuth(req, apiUrl.User.Username(), pass)
+			return nil, nil
+		}
+	}
+
+	creds, err := credentials(req.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	setRequestAuth(req, creds["username"], creds["password"])
+	return creds, nil
+}
+
+func setRequestAuth(req *http.Request, user, pass string) {
+	token := fmt.Sprintf("%s:%s", user, pass)
+	auth := "Basic " + base64.URLEncoding.EncodeToString([]byte(token))
+	req.Header.Set("Authorization", auth)
 }
 
 func setErrorResponseContext(err *WrappedError, res *http.Response) {

--- a/lfs/credentials_test.go
+++ b/lfs/credentials_test.go
@@ -23,7 +23,7 @@ func TestGetCredentials(t *testing.T) {
 	}
 
 	if value := creds["password"]; value != "monkey" {
-		t.Errorf("bad username: %s", value)
+		t.Errorf("bad password: %s", value)
 	}
 
 	expected := "Basic " + base64.URLEncoding.EncodeToString([]byte("lfs-server.com:monkey"))
@@ -115,6 +115,28 @@ func TestGetCredentialsWithPortMismatch(t *testing.T) {
 
 	if actual := req.Header.Get("Authorization"); actual != "" {
 		t.Errorf("Unexpected Authorization header: %s", actual)
+	}
+}
+
+func TestGetCredentialsWithRfc1738UsernameAndPassword(t *testing.T) {
+	Config.SetConfig("lfs.url", "https://testuser:testpass@lfs-server.com")
+	req, err := http.NewRequest("GET", "https://lfs-server.com/foo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	creds, err := getCreds(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if creds != nil {
+		t.Errorf("unexpected creds: %v", creds)
+	}
+
+	expected := "Basic " + base64.URLEncoding.EncodeToString([]byte("testuser:testpass"))
+	if value := req.Header.Get("Authorization"); value != expected {
+		t.Errorf("Bad Authorization. Expected '%s', got '%s'", expected, value)
 	}
 }
 

--- a/lfs/endpoint.go
+++ b/lfs/endpoint.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const ENDPOINT_URL_UNKNOWN = "<unknown>"
+const EndpointUrlUnknown = "<unknown>"
 
 var httpPrefixRe = regexp.MustCompile("\\Ahttps?://")
 
@@ -23,7 +23,7 @@ type Endpoint struct {
 // "[.git]/info/lfs".
 func NewEndpointFromCloneURL(url string) Endpoint {
 	e := NewEndpoint(url)
-	if e.Url == ENDPOINT_URL_UNKNOWN {
+	if e.Url == EndpointUrlUnknown {
 		return e
 	}
 

--- a/lfs/endpoint.go
+++ b/lfs/endpoint.go
@@ -1,0 +1,68 @@
+package lfs
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+)
+
+const ENDPOINT_URL_UNKNOWN = "<unknown>"
+
+var httpPrefixRe = regexp.MustCompile("\\Ahttps?://")
+
+// An Endpoint describes how to access a Git LFS server.
+type Endpoint struct {
+	Url            string
+	SshUserAndHost string
+	SshPath        string
+}
+
+// NewEndpointFromCloneURL creates an Endpoint from a git clone URL by appending
+// "[.git]/info/lfs".
+func NewEndpointFromCloneURL(url string) Endpoint {
+	e := NewEndpoint(url)
+	if e.Url == ENDPOINT_URL_UNKNOWN {
+		return e
+	}
+
+	// When using main remote URL for HTTP, append info/lfs
+	if path.Ext(url) == ".git" {
+		e.Url += "/info/lfs"
+	} else {
+		e.Url += ".git/info/lfs"
+	}
+	return e
+}
+
+// NewEndpoint initializes a new Endpoint for a given URL.
+func NewEndpoint(url string) Endpoint {
+	e := Endpoint{Url: url}
+
+	if httpPrefixRe.MatchString(url) {
+		return e
+	}
+
+	pieces := strings.SplitN(e.Url, ":", 2)
+	hostPieces := strings.SplitN(pieces[0], "@", 2)
+	if len(hostPieces) == 2 {
+		e.SshUserAndHost = pieces[0]
+		e.SshPath = pieces[1]
+		e.Url = fmt.Sprintf("https://%s/%s", hostPieces[1], pieces[1])
+	}
+	return e
+}
+
+func ObjectUrl(endpoint Endpoint, oid string) (*url.URL, error) {
+	u, err := url.Parse(endpoint.Url)
+	if err != nil {
+		return nil, err
+	}
+
+	u.Path = path.Join(u.Path, "objects")
+	if len(oid) > 0 {
+		u.Path = path.Join(u.Path, oid)
+	}
+	return u, nil
+}


### PR DESCRIPTION
This is another approach at fixing #362, built on #403.

This also reorganizes the `Endpoint` code from #403 into a separate file. It can easily be pulled out into a separate PR if needed.