### PR TITLE
bring windowless commands to the lfs package

### DIFF
--- a/lfs/credentials.go
+++ b/lfs/credentials.go
@@ -33,7 +33,7 @@ type CredentialCmd struct {
 
 func NewCommand(input Creds, subCommand string) *CredentialCmd {
 	buf1 := new(bytes.Buffer)
-	cmd := exec.Command("git", "credential", subCommand)
+	cmd := execCommand("git", "credential", subCommand)
 
 	cmd.Stdin = input.Buffer()
 	cmd.Stdout = buf1

--- a/lfs/exec_nix.go
+++ b/lfs/exec_nix.go
@@ -1,0 +1,13 @@
+// +build !windows
+
+// Package git contains various commands that shell out to git
+package lfs
+
+import (
+	"os/exec"
+)
+
+// execCommand is a small platform specific wrapper around os/exec.Command
+func execCommand(name string, arg ...string) *exec.Cmd {
+	return exec.Command(name, arg...)
+}

--- a/lfs/exec_win.go
+++ b/lfs/exec_win.go
@@ -1,0 +1,16 @@
+// +build windows
+
+// Package git contains various commands that shell out to git
+package lfs
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// execCommand is a small platform specific wrapper around os/exec.Command
+func execCommand(name string, arg ...string) *exec.Cmd {
+	cmd := exec.Command(name, arg...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	return cmd
+}

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -351,7 +351,7 @@ type wrappedCmd struct {
 // stdout pipe, wrapped in a wrappedCmd. The stdout buffer will be of stdoutBufSize
 // bytes.
 func startCommand(command string, args ...string) (*wrappedCmd, error) {
-	cmd := exec.Command(command, args...)
+	cmd := execCommand(command, args...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err

--- a/lfs/ssh.go
+++ b/lfs/ssh.go
@@ -2,7 +2,6 @@ package lfs
 
 import (
 	"encoding/json"
-	"os/exec"
 
 	"github.com/github/git-lfs/vendor/_nuts/github.com/rubyist/tracerx"
 )
@@ -22,7 +21,7 @@ func sshAuthenticate(endpoint Endpoint, operation, oid string) (sshAuthResponse,
 
 	tracerx.Printf("ssh: %s git-lfs-authenticate %s %s %s",
 		endpoint.SshUserAndHost, endpoint.SshPath, operation, oid)
-	cmd := exec.Command("ssh", endpoint.SshUserAndHost,
+	cmd := execCommand("ssh", endpoint.SshUserAndHost,
 		"git-lfs-authenticate",
 		endpoint.SshPath,
 		operation, oid,


### PR DESCRIPTION
This brings the Windows-specific improvements from #381 to the lfs package. Specifically for the `git-credential` and `ssh` execs.

/cc @bozaro @sinbad