### PR TITLE
streamline the readme/roadmap, add first principles to contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,27 @@
 Hi there! We're thrilled that you'd like to contribute to this project. Your
 help is essential for keeping it great.
 
+## Feature Requests
+
+Feature requests are welcome, but will have a much better chance of being
+accepted if they meet the first principles for the project. Git LFS is intended
+for the end user, not Git experts. It should fit into the standard workflow as
+much as possible, and require little client configuration.
+
+* Large objects are pushed to Git LFS servers during git push.
+* Large objects are downloaded during git checkout.
+* Git LFS servers are linked to Git remotes by default. Git hosts can support
+users without requiring them to set up anything extra. Users can access
+different Git LFS servers like they can with different Git remotes.
+* Upload and download requests should use the same form of authentication built
+into Git: SSH through public keys, and HTTPS through Git credential helpers.
+* Git LFS servers use a JSON API designed around progressive enhancement.
+Servers can simply host off cloud storage, or implement more efficient methods
+of transferring data.
+
+You can see what the Git LFS team is prioritizing work on in the
+[roadmap](./ROADMAP.md).
+
 ## Submitting a pull request
 
 0. [Fork][] and clone the repository
@@ -26,7 +47,7 @@ them as separate pull requests.
 
 ## Updating 3rd party packages
 
-0. Update `Godeps`.
+0. Update `Nut.toml`.
 0. Run `script/vendor` to update the code in the `.vendor/src` directory.
 0. Commit the change.  Git LFS vendors the full source code in the repository.
 0. Submit a pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ help is essential for keeping it great.
 
 Feature requests are welcome, but will have a much better chance of being
 accepted if they meet the first principles for the project. Git LFS is intended
-for the end user, not Git experts. It should fit into the standard workflow as
+for end users, not Git experts. It should fit into the standard workflow as
 much as possible, and require little client configuration.
 
 * Large objects are pushed to Git LFS servers during git push.

--- a/README.md
+++ b/README.md
@@ -2,49 +2,21 @@
 
 Git LFS is a command line extension and [specification](docs/spec.md) for
 managing large files with Git. The client is written in Go, with pre-compiled
-binaries available for Mac, Windows, Linux, and FreeBSD.
+binaries available for Mac, Windows, Linux, and FreeBSD. Check out the
+[Git LFS website][page] for a high level overview of features.
 
-## Features
+See [CONTRIBUTING.md](CONTRIBUTING.md) for info on working on Git LFS and
+sending patches. Related projects are listed on the [Implementations wiki page](https://github.com/github/git-lfs/wiki/Implementations)
 
-By design, every git repository contains every version of every file. But
-for some types of projects, this is not reasonable or even practical.
-Multiple revisions of a large file take up space quickly, slowing down
-repository operations and making fetches unwieldy.
-
-Git LFS overcomes this limitation by storing the metadata for large files in
-Git and syncing the file contents to a configurable [Git LFS
-server](docs/api.md). Some of the key features include:
-
-* Tight integration with Git means you don't have to change your workflow after
-the initial configuration.
-
-* Large files are synced separately to a configurable Git LFS server over HTTPS,
-so you are not limited in where you push your Git repository.
-
-* Large files are only synced from the server when they are checked out, so your
-local repository doesn't carry the weight of every version of every file when it
-is not needed.
-
-* The meta data stored in Git is extensible for future use. It currently
-includes a hash of the contents of the file, and the file size so clients can
-display a progress bar while downloading or opt out of a large download.
-
-* Clients and servers can make use of all the features of HTTPS, such as caching
-content locally on a CDN, resumable uploads and downloads, or performing
-requests in parallel for faster transfers.
-
-See the [ROADMAP](ROADMAP.md) for other planned and desired features.
-
-## Known Implementations
-
-- [GitHub.com](https://github.com/early_access/large_file_storage) (support coming soon!)
-- [github/lfs-test-server](https://github.com/github/lfs-test-server) (reference server implementation)
+[page]: https://git-lfs.github.com/
 
 ## Getting Started
 
 Download the [latest client][rel] and run the included install script.  The
 installer should run `git lfs init` for you, which sets up Git's global
 configuration settings for Git LFS.
+
+Note: Git LFS requires Git v1.8.2 or higher.
 
 [rel]: https://github.com/github/git-lfs/releases
 
@@ -104,8 +76,3 @@ Once you've made your commits, push your files to the Git remote:
 
 See the [Git LFS overview](https://github.com/github/git-lfs/tree/master/docs)
 and [man pages](https://github.com/github/git-lfs/tree/master/docs/man).
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for info on working on Git LFS and
-sending patches.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,20 +1,15 @@
 # Git LFS Roadmap
 
 This is a high level overview of some of the big changes we want to make for
-Git LFS. Nothing here is final. Anything can be added or moved around at any
-time. Also, the items will be annotated with issue references to show the
-current state of the feature.
+Git LFS. If you have an idea for a new feature, open an issue for discussion.
 
 ## v1.0
 
 These are the features that we feel are important for a v1 release of Git LFS,
 and we have a good idea how they could work.
 
-* Resumable, chunked downloads
-* Resumable, chunked uploads
-* Concurrent uploads. Though chunking may take care of this.
-* New command for replacing pointers with large files outside of the Git smudge
-and clean filters (`git lfs get path/to/file`).
+* Fast, efficient uploading and downloading.
+* `git lfs fetch` command for downloading large files.
 * Automatic GC for the `.git/lfs/objects` directory.
 * Client side metrics reporting, so the Git LFS server can optionally track
 how clients are performing.
@@ -29,12 +24,14 @@ these can make it in for v1.0 if there's a great proposal.
 automatically.
 * File locking
 * Binary diffing - reduce the amount of content sent over the wire.
-* Concurrent downloads - Difficult to implement due to how git smudge is used.
 
 ## Project Related
 
 These are items that don't affect Git LFS end users.
 
-* Cross platform integration tests in shell.
-* Build and CI servers for Linux, Windows, and Mac.
-* Automatic updates for the `git-lfs` client.
+* Releases through common package repositories: RPM, Apt, Chocolatey, Homebrew.
+* CI builds for Windows.
+* Automated build servers that build Git LFS on native platforms.
+* Automated QA test suite for running release candidates through a gauntlet of
+open source and proprietary Git LFS environments.
+* Automatic updates of the Git LFS client.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ Git LFS. If you have an idea for a new feature, open an issue for discussion.
 These are the features that we feel are important for a v1 release of Git LFS,
 and we have a good idea how they could work.
 
-* Fast, efficient uploading and downloading.
+* Fast, efficient uploading and downloading ([#414](https://github.com/github/git-lfs/issues/414)).
 * `git lfs fetch` command for downloading large files.
 * Automatic GC for the `.git/lfs/objects` directory.
 * Client side metrics reporting, so the Git LFS server can optionally track


### PR DESCRIPTION
This streamlines the readme a bit. The contributing link is moved up. The high level feature descriptions are delegated to the feature page. The roadmap is also streamlined, so we can use issues to discuss details of the roadmap. The main addition is a section on the first principles behind the tool at the top of the contributing doc.