### PR TITLE
Support 401 responses for Batch API

### DIFF
--- a/docs/api/http-v1-batch.md
+++ b/docs/api/http-v1-batch.md
@@ -26,7 +26,8 @@ Git LFS v0.6.0.
 The Batch API authenticates the same as the original v1 API with one exception:
 The client will attempt to make requests without any authentication. This
 slight change allows anonymous access to public Git LFS objects. The client
-stores the result of this in the `lfs.access` config setting.
+stores the result of this in the `lfs.<url>.access` config setting, where <url>
+refers to the endpoint's URL.
 
 ## API Responses
 
@@ -91,16 +92,13 @@ When downloading objects through a command such as `git lfs fetch`, the client
 will initially skip authentication if it doesn't know the access level of the
 repository.
 
-* If `lfs.access` is not set, make an unauthenticated request.
-  1. If it returns 200, set `lfs.access` to `public`.
-  2. If it returns 401, set `lfs.access` to `private`.
-* If `lfs.access` is `public`, don't ask the user for authentication. If
-authentication is available in `git credential`, or through `ssh`, then use it.
-* If `lfs.access` is `private`, always send authentication. Ask the user if
+* If `lfs.<url>.access` is not set, make an unauthenticated request.
+  1. If it returns 401, set `lfs.<url>.access` to `private`.
+* If `lfs.<url>.access` is `private`, always send authentication. Ask the user if
 authentication information is not readily available.
 
 When uploading objects through `git lfs push`, Git LFS will always send
-authentication info, regardless of how `lfs.access` is configured.
+authentication info, regardless of how `lfs.<url>.access` is configured.
 
 ```
 > POST https://git-lfs-server.com/objects/batch HTTP/1.1

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -174,17 +174,12 @@ func (b *byteCloser) Close() error {
 	return nil
 }
 
-type batchRep struct {
-	Objects   []*objectResource `json:"objects"`
-	Operation string            `json:"operation"`
-}
-
 func Batch(objects []*objectResource, operation string) ([]*objectResource, *WrappedError) {
 	if len(objects) == 0 {
 		return nil, nil
 	}
 
-	br := &batchRep{Objects: objects, Operation: operation}
+	br := map[string]interface{}{"objects": objects, "operation": operation}
 
 	by, err := json.Marshal(br)
 	if err != nil {

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -606,12 +606,16 @@ func newBatchClientRequest(method, rawurl string) (*http.Request, Creds, error) 
 	req.Header.Set("User-Agent", UserAgent)
 
 	// Get the creds if we're private
-	/*
+	if Config.PrivateAccess() {
+		// The PrivateAccess() check can be pushed down and this block simplified
+		// once everything goes through the batch endpoint.
 		creds, err := getCreds(req)
 		if err != nil {
 			return nil, nil, err
 		}
-	*/
+
+		return req, creds, nil
+	}
 
 	return req, nil, nil
 }

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -179,9 +179,9 @@ func Batch(objects []*objectResource, operation string) ([]*objectResource, *Wra
 		return nil, nil
 	}
 
-	br := map[string]interface{}{"objects": objects, "operation": operation}
+	o := map[string]interface{}{"objects": objects, "operation": operation}
 
-	by, err := json.Marshal(br)
+	by, err := json.Marshal(o)
 	if err != nil {
 		return nil, Error(err)
 	}

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -431,6 +431,10 @@ func doApiRequest(req *http.Request, creds Creds) (*http.Response, *objectResour
 	return res, obj, nil
 }
 
+// doApiRequest runs the request to the batch API. If the API returns a 401,
+// the repo will be marked as having private access and the request will be
+// re-run. When the repo is marked as having private access, credentials will
+// be retrieved.
 func doApiBatchRequest(req *http.Request, creds Creds) (*http.Response, []*objectResource, *WrappedError) {
 	via := make([]*http.Request, 0, 4)
 	res, wErr := doApiRequestWithRedirects(req, creds, via)

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -201,6 +201,9 @@ func Batch(objects []*objectResource) ([]*objectResource, *WrappedError) {
 	if wErr != nil {
 		if res != nil {
 			switch res.StatusCode {
+			case 401:
+				Config.SetPrivateAccess()
+				return Batch(objects)
 			case 404, 410:
 				tracerx.Printf("api: batch not implemented: %d", res.StatusCode)
 				sendApiEvent(apiEventFail)

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -431,7 +431,7 @@ func doApiRequest(req *http.Request, creds Creds) (*http.Response, *objectResour
 	return res, obj, nil
 }
 
-// doApiRequest runs the request to the batch API. If the API returns a 401,
+// doApiBatchRequest runs the request to the batch API. If the API returns a 401,
 // the repo will be marked as having private access and the request will be
 // re-run. When the repo is marked as having private access, credentials will
 // be retrieved.

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -206,9 +206,6 @@ func Batch(objects []*objectResource, operation string) ([]*objectResource, *Wra
 	if wErr != nil {
 		if res != nil {
 			switch res.StatusCode {
-			case 401:
-				Config.SetPrivateAccess()
-				return Batch(objects, operation)
 			case 404, 410:
 				tracerx.Printf("api: batch not implemented: %d", res.StatusCode)
 				sendApiEvent(apiEventFail)
@@ -433,6 +430,12 @@ func doApiRequest(req *http.Request, creds Creds) (*http.Response, *objectResour
 func doApiBatchRequest(req *http.Request, creds Creds) (*http.Response, []*objectResource, *WrappedError) {
 	via := make([]*http.Request, 0, 4)
 	res, wErr := doApiRequestWithRedirects(req, creds, via)
+
+	if res != nil && res.StatusCode == 401 {
+		Config.SetPrivateAccess()
+		res, wErr = doApiRequestWithRedirects(req, creds, via)
+	}
+
 	if wErr != nil {
 		return res, nil, wErr
 	}

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -131,7 +131,7 @@ func (c *Configuration) SetPrivateAccess() {
 	// Modify the config cache because it's checked again in this process
 	// without being reloaded.
 	c.loading.Lock()
-	c.gitConfig["lfs.access"] = "private"
+	c.gitConfig[key] = "private"
 	c.loading.Unlock()
 }
 

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -108,6 +108,10 @@ func (c *Configuration) BatchTransfer() bool {
 	return false
 }
 
+// PrivateAccess will retrieve the access value and return true if
+// the value is set to private. When a repo is marked as having private
+// access, the http requests for the batch api will fetch the credentials
+// before running, otherwise the request will run without credentials.
 func (c *Configuration) PrivateAccess() bool {
 	if v, ok := c.GitConfig("lfs.access"); ok {
 		if strings.ToLower(v) == "private" {
@@ -117,6 +121,7 @@ func (c *Configuration) PrivateAccess() bool {
 	return false
 }
 
+// SetPrivateAccess will set the private access flag in .git/config.
 func (c *Configuration) SetPrivateAccess() {
 	configFile := filepath.Join(LocalGitDir, "config")
 	git.Config.SetLocal(configFile, "lfs.access", "private")

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -119,7 +119,7 @@ func (c *Configuration) BatchTransfer() bool {
 
 func (c *Configuration) PrivateAccess() bool {
 	if v, ok := c.GitConfig("lfs.access"); ok {
-		if v == "private" || v == "PRIVATE" {
+		if strings.ToLower(v) == "private" {
 			return true
 		}
 	}

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -117,6 +117,15 @@ func (c *Configuration) BatchTransfer() bool {
 	return false
 }
 
+func (c *Configuration) PrivateAccess() bool {
+	if v, ok := c.GitConfig("lfs.access"); ok {
+		if v == "private" || v == "PRIVATE" {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *Configuration) RemoteEndpoint(remote string) Endpoint {
 	if len(remote) == 0 {
 		remote = defaultRemote

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -113,7 +113,8 @@ func (c *Configuration) BatchTransfer() bool {
 // access, the http requests for the batch api will fetch the credentials
 // before running, otherwise the request will run without credentials.
 func (c *Configuration) PrivateAccess() bool {
-	if v, ok := c.GitConfig("lfs.access"); ok {
+	key := fmt.Sprintf("lfs.%s.access", c.Endpoint().Url)
+	if v, ok := c.GitConfig(key); ok {
 		if strings.ToLower(v) == "private" {
 			return true
 		}
@@ -123,8 +124,9 @@ func (c *Configuration) PrivateAccess() bool {
 
 // SetPrivateAccess will set the private access flag in .git/config.
 func (c *Configuration) SetPrivateAccess() {
+	key := fmt.Sprintf("lfs.%s.access", c.Endpoint().Url)
 	configFile := filepath.Join(LocalGitDir, "config")
-	git.Config.SetLocal(configFile, "lfs.access", "private")
+	git.Config.SetLocal(configFile, key, "private")
 
 	// Modify the config cache because it's checked again in this process
 	// without being reloaded.

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -134,7 +134,7 @@ func (q *TransferQueue) processBatch() error {
 		transfers = append(transfers, &objectResource{Oid: t.Oid(), Size: t.Size()})
 	}
 
-	objects, err := Batch(transfers)
+	objects, err := Batch(transfers, q.transferKind)
 	if err != nil {
 		if isNotImplError(err) {
 			tracerx.Printf("queue: batch not implemented, disabling")

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -142,9 +142,9 @@ shutdown() {
   if [ "$SHUTDOWN_LFS" != "no" ]; then
     # only cleanup test/remote after script/integration done OR a single
     # test/test-*.sh file is run manually.
-    [ -z "$KEEPTRASH" ] && rm -rf "$REMOTEDIR"
     if [ -s "$LFS_URL_FILE" ]; then
       curl "$(cat "$LFS_URL_FILE")/shutdown"
     fi
+    [ -z "$KEEPTRASH" ] && rm -rf "$REMOTEDIR"
   fi
 }


### PR DESCRIPTION
This PR adds full 401 support for the Batch API.

- [x] If access is not marked private, request Batch with no creds
- [x] If access is marked private, request Batch with creds
- [x] If a 401 is received, mark private, get creds, and reattempt the request

Related test server PR: https://github.com/github/lfs-test-server/pull/33