### PR TITLE
API documentation: removing {oid} from git-lfs-authenticate command

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,14 +18,13 @@ access the API username and password.  If the Git LFS domain matches the Git
 remote's, Git LFS will not prompt you again to enter the password.
 
 If the Git remote is using SSH, Git LFS will execute the `git-lfs-authenticate`
-command.  It passes the SSH path, the Git LFS operation (upload or download),
-and the object OID as arguments. A successful result outputs a JSON link object
+command.  It passes the SSH path, the Git LFS operation (upload or download). A successful result outputs a JSON link object
 to STDOUT.  This is applied to any Git LFS API request before git credentials
 are accessed.
 
 ```
 # remote: git@github.com:user/repo.git
-$ ssh git@github.com git-lfs-authenticate user/repo.git download {oid}
+$ ssh git@github.com git-lfs-authenticate user/repo.git download
 {
   "header": {
     "Authorization": "Basic ..."


### PR DESCRIPTION
Suggestion for #414: I think, the good idea for batch API is removing {oid} from git-lfs-authenticate command:

```
ssh git@github.com git-lfs-authenticate user/repo.git download {oid}
```
The presence of this argument needs to perform this command for each object is sent.