### PR TITLE
teach script/integration how to run against a specific git-lfs build

### DIFF
--- a/test/testenv.sh
+++ b/test/testenv.sh
@@ -3,8 +3,10 @@
 
 set -e
 
-# The root directory for the git-lfs repository
-ROOTDIR=$(cd $(dirname "$0")/.. && pwd)
+# The root directory for the git-lfs repository by default.
+if [ -z "$ROOTDIR" ]; then
+  ROOTDIR=$(cd $(dirname "$0")/.. && pwd)
+fi
 
 # Where Git LFS outputs the compiled binaries
 BINPATH="$ROOTDIR/bin"
@@ -13,7 +15,7 @@ BINPATH="$ROOTDIR/bin"
 PATH="$BINPATH:$PATH"
 
 # create a temporary work space
-TMPDIR=${GIT_LFS_TEST_DIR:-"$(cd $(dirname "$0")/.. && pwd)/tmp"}
+TMPDIR=${GIT_LFS_TEST_DIR:-"$ROOTDIR/tmp"}
 
 # This is unique to every test file, and cleared after every test run.
 TRASHDIR="$TMPDIR/$(basename "$0")-$$"

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -111,6 +111,7 @@ setup() {
 
   echo "Git LFS: ${LFS_BIN:-(which git-lfs)}"
   git lfs version
+  git version
 
   if [ -z "$SKIPCOMPILE" ]; then
     for go in test/cmd/*.go; do
@@ -121,6 +122,7 @@ setup() {
   echo "tmp dir: $TMPDIR"
   echo "remote git dir: $REMOTEDIR"
   echo "LFSTEST_URL=$LFS_URL_FILE LFSTEST_DIR=$REMOTEDIR lfstest-gitserver"
+  echo
   LFSTEST_URL="$LFS_URL_FILE" LFSTEST_DIR="$REMOTEDIR" lfstest-gitserver > "$REMOTEDIR/gitserver.log" 2>&1 &
 
   mkdir $HOME

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -102,14 +102,14 @@ setup() {
   rm -rf "$REMOTEDIR"
   mkdir "$REMOTEDIR"
 
-  if [ -z "$SKIPCOMPILE" ]; then
+  if [ -z "$SKIPCOMPILE" ] && [ -z "$LFS_BIN" ]; then
     echo "compile git-lfs for $0"
     script/bootstrap || {
       return $?
     }
   fi
 
-  echo "Git LFS: $(which git-lfs)"
+  echo "Git LFS: ${LFS_BIN:-(which git-lfs)}"
   git lfs version
 
   if [ -z "$SKIPCOMPILE" ]; then


### PR DESCRIPTION
This is useful if you want to run the existing tests against a specific git-lfs binary.