### PR TITLE
ensure the oid/size are set

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -265,6 +265,13 @@ func UploadCheck(oidPath string) (*objectResource, *WrappedError) {
 		return nil, nil
 	}
 
+	if obj.Oid == "" {
+		obj.Oid = oid
+	}
+	if obj.Size == 0 {
+		obj.Size = reqObj.Size
+	}
+
 	return obj, nil
 }
 


### PR DESCRIPTION
Older versions of the API may not include the oid and size in the json payload for the check POST. If they're blank, set them to what we currently have.