### PR TITLE
Support concurrent transfers when outputting progress for desktop apps

### DIFF
--- a/lfs/download_queue.go
+++ b/lfs/download_queue.go
@@ -33,6 +33,10 @@ func (d *Downloadable) Size() int64 {
 	return d.Pointer.Size
 }
 
+func (d *Downloadable) Name() string {
+	return d.Pointer.Name
+}
+
 func (d *Downloadable) SetObject(o *objectResource) {
 	d.object = o
 }

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -307,7 +307,6 @@ func (l *progressLogger) Close() error {
 // be used when writing causes an error.
 func (l *progressLogger) Shutdown() {
 	l.writeData = false
-	l.Close()
 }
 
 // newProgressLogger creates a progressLogger based on the presence of

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -297,7 +297,7 @@ func (l *progressLogger) Write(b []byte) error {
 
 // Close will call Close() on the underlying file
 func (l *progressLogger) Close() error {
-	if l.writeData {
+	if l.log != nil {
 		return l.log.Close()
 	}
 	return nil
@@ -307,6 +307,7 @@ func (l *progressLogger) Close() error {
 // be used when writing causes an error.
 func (l *progressLogger) Shutdown() {
 	l.writeData = false
+	l.Close()
 }
 
 // newProgressLogger creates a progressLogger based on the presence of

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -292,7 +292,7 @@ func (l *progressLogger) Write(b []byte) error {
 		}
 		return l.log.Sync()
 	}
-	return 0, nil
+	return nil
 }
 
 // Close will call Close() on the underlying file


### PR DESCRIPTION
This is a fix for a bug in the handling of the `GIT_LFS_PROGRESS` file which is used by desktop apps, or other things integrating with the git-lfs binary.

At a later point, we should move toward a more unified progress tracking which supports this file as well as the pb progress bars via a single API. This file, the pb output, and possibly the `watchers` channel could be unified into a single event stream, cleaning up some of this code.