### PR TITLE
Fix two bugs in fetch, add tests

### DIFF
--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+. "test/testlib.sh"
+
+begin_test "fetch"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")"
+  setup_remote_repo "$reponame"
+
+  clone_repo "$reponame" clone
+
+  clone_repo "$reponame" repo
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \*.dat" track.log
+
+  contents="a"
+  contents_oid=$(printf "$contents" | shasum -a 256 | cut -f 1 -d " ")
+
+  printf "$contents" > a.dat
+  git add a.dat
+  git add .gitattributes
+  git commit -m "add a.dat" 2>&1 | tee commit.log
+  grep "master (root-commit)" commit.log
+  grep "2 files changed" commit.log
+  grep "create mode 100644 a.dat" commit.log
+  grep "create mode 100644 .gitattributes" commit.log
+
+  [ "a" = "$(cat a.dat)" ]
+
+  assert_pointer "master" "a.dat" "$contents_oid" 1
+
+  refute_server_object "$contents_oid"
+
+  git push origin master 2>&1 | tee push.log
+  grep "(1 of 1 files)" push.log
+  grep "master -> master" push.log
+
+  assert_server_object "$contents_oid" "$contents"
+
+  # Add a file in a different branch
+  git checkout -b newbranch
+  b="b"
+  b_oid=$(printf "$b" | shasum -a 256 | cut -f 1 -d " ")
+  printf "$b" > b.dat
+  git add b.dat
+  git commit -m "add b.dat"
+  assert_pointer "newbranch" "b.dat" "$b_oid" 1
+
+  git push origin newbranch
+  assert_server_object "$b_id" "$b"
+
+  # change to the clone's working directory
+  cd ../clone
+
+  git pull 2>&1 | grep "Downloading a.dat (1 B)"
+
+  [ "a" = "$(cat a.dat)" ]
+
+  assert_pointer "master" "a.dat" "$contents_oid" 1
+
+
+  # Remove the working directory and lfs files
+  rm a.dat
+  rm -rf .git/lfs/objects
+
+  git lfs fetch 2>&1 | grep "(1 of 1 files)"
+
+  [ "a" = "$(cat a.dat)" ]
+
+  git checkout newbranch
+  git checkout master
+  rm -rf .git/lfs/objects
+
+  git lfs fetch newbranch 2>&1 | grep "(2 of 2 files)"
+)
+end_test


### PR DESCRIPTION
This PR fixes two :bug: :beetle: in the `fetch` command.

1. When fetching the not current branch, the queue would not process, nothing would download.
1. When fetching the current branch, the main routine would not wait for the goroutine that copies files into the wd and updates the git index, possibly leaving the wd in an inconsistent state.

Integration tests for fetch are included.