### PR TITLE
initial json schemas for batch api

### DIFF
--- a/docs/api/http-v1-batch-request-schema.json
+++ b/docs/api/http-v1-batch-request-schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Git LFS HTTPS Batch API v1 Request",
+  "type": "object",
+  "properties": {
+    "operation": {
+      "type": "string"
+    },
+    "objects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "oid": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/api/http-v1-batch-request-schema.json
+++ b/docs/api/http-v1-batch-request-schema.json
@@ -18,9 +18,11 @@
             "type": "number"
           }
         },
+        "required": ["oid", "size"],
         "additionalProperties": false
       }
     }
   },
+  "required": ["objects", "operation"],
   "additionalProperties": false
 }

--- a/docs/api/http-v1-batch-response-schema.json
+++ b/docs/api/http-v1-batch-response-schema.json
@@ -58,7 +58,7 @@
             "additionalProperties": false
           }
         },
-        "required": ["oid", "size", "actions"],
+        "required": ["oid", "size"],
         "additionalProperties": false
       }
     }

--- a/docs/api/http-v1-batch-response-schema.json
+++ b/docs/api/http-v1-batch-response-schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Git LFS HTTPS Batch API v1 Response",
+  "type": "object",
+  "properties": {
+    "objects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "oid": {
+            "type": "string"
+          },
+          "actions": {
+            "type": "object"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/api/http-v1-batch-response-schema.json
+++ b/docs/api/http-v1-batch-response-schema.json
@@ -12,7 +12,7 @@
             "type": "string"
           },
           "size": {
-            "type": "number",
+            "type": "number"
           },
           "actions": {
             "type": "object"

--- a/docs/api/http-v1-batch-response-schema.json
+++ b/docs/api/http-v1-batch-response-schema.json
@@ -11,6 +11,9 @@
           "oid": {
             "type": "string"
           },
+          "size": {
+            "type": "number",
+          },
           "actions": {
             "type": "object"
           }

--- a/docs/api/http-v1-batch-response-schema.json
+++ b/docs/api/http-v1-batch-response-schema.json
@@ -48,7 +48,7 @@
             "type": "object",
             "properties": {
               "code": {
-                "type": "string"
+                "type": "number"
               },
               "message": {
                 "type": "string"

--- a/docs/api/http-v1-batch-response-schema.json
+++ b/docs/api/http-v1-batch-response-schema.json
@@ -2,6 +2,27 @@
   "$schema": "http://json-schema.org/draft-04/schema",
   "title": "Git LFS HTTPS Batch API v1 Response",
   "type": "object",
+
+  "definitions": {
+    "action": {
+      "type": "object",
+      "properties": {
+        "href": {
+          "type": "string"
+        },
+        "header": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "expires_at": {
+          "type": "string"
+        }
+      },
+      "required": ["href"],
+      "additionalProperties": false
+    }
+  },
+
   "properties": {
     "objects": {
       "type": "array",
@@ -15,12 +36,33 @@
             "type": "number"
           },
           "actions": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+              "download": { "$ref": "#/definitions/action" },
+              "upload": { "$ref": "#/definitions/action" },
+              "verify": { "$ref": "#/definitions/action" }
+            },
+            "additionalProperties": false
+          },
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": ["code", "message"],
+            "additionalProperties": false
           }
         },
+        "required": ["oid", "size", "actions"],
         "additionalProperties": false
       }
     }
   },
+  "required": ["objects"],
   "additionalProperties": false
 }


### PR DESCRIPTION
[JSON Schema](http://json-schema.org) is a pretty good format for defining the schema of a data structure. This is the exact schema that we'll be using to validating requests and responses through GitHub's implementation of the server.

* [x] Change `_links` to `actions`. It accurately describes what they're for. Also, `_links` was only ever used for [HAL](http://stateless.co/hal_specification.html) compatibility. Git LFS has diverged enough that there's no point to maintaining that illusion.
* [x] Specify required attributes
* [x] Validate `href` and optional `header` objects under each action.
* [x] Validate action types? (`download`, `upload, `verify`).
* [x] Define `error` object.
* [x] Add simple json parsing test for the schema files #528

Current example request and response:

```js
// REQUEST
{
  "operation": "upload or download",
  "objects": [
    {
      "oid": "abc123",
      "size": 123
    }
  ]
}

// RESPONSE
{
  "objects": [
    {
      "oid": "abc123",
      "size": 123,

      "actions": {
        // objects will have either a download action,
        // or an upload + verify
        "download": {
          "href": "url",

          // optional
          "header": {
            "Some-Header": "some value"
          },

          // optional UTC timestamp in iso 8601
          "expires_at": "2015-07-20T21:10:55Z"
        }
      },

      // error property is optional
      "error": {
        "code": "fatal",
        "message": "some fatal error occurred"
      }
    }
  ]
}
```

/cc @sinbad: Curious on your thoughts. Ideally the SSH implementation shares the same JSON schema as much as possible.

EDIT: I don't intend to use the json schema files directly in the Git LFS client right now. It's just for API documentation.