### PR TITLE
Support 307 redirects using relative Location headers

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -378,7 +378,6 @@ func doApiRequestWithRedirects(req *http.Request, creds Creds, via []*http.Reque
 		redirectTo := res.Header.Get("Location")
 		locurl, err := url.Parse(redirectTo)
 		if err == nil && !locurl.IsAbs() {
-			// relative Location headers are allowed & should be supported
 			locurl = req.URL.ResolveReference(locurl)
 			redirectTo = locurl.String()
 		}

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -374,7 +375,15 @@ func doApiRequestWithRedirects(req *http.Request, creds Creds, via []*http.Reque
 	}
 
 	if res.StatusCode == 307 {
-		redirectedReq, redirectedCreds, err := newClientRequest(req.Method, res.Header.Get("Location"))
+		redirectTo := res.Header.Get("Location")
+		locurl, err := url.Parse(redirectTo)
+		if err == nil && !locurl.IsAbs() {
+			// relative Location headers are allowed & should be supported
+			locurl = req.URL.ResolveReference(locurl)
+			redirectTo = locurl.String()
+		}
+
+		redirectedReq, redirectedCreds, err := newClientRequest(req.Method, redirectTo)
 		if err != nil {
 			return res, Errorf(err, err.Error())
 		}


### PR DESCRIPTION
Currently if a server responds with a 307 on POST and the Location header is relative, the re-post fails. 

Relative Location headers are valid and are more convenient for some servers which aren't aware of the original request (e.g. load balancers) without checking for other headers which can vary per routing system. git-lfs should just support relative Location responses.