### PR TITLE
Clean fix

### DIFF
--- a/commands/command_clean.go
+++ b/commands/command_clean.go
@@ -46,7 +46,6 @@ func cleanCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if cleaned != nil {
-		cleaned.Close()
 		defer cleaned.Teardown()
 	}
 
@@ -59,7 +58,7 @@ func cleanCommand(cmd *cobra.Command, args []string) {
 		Panic(err, "Error cleaning asset.")
 	}
 
-	tmpfile := cleaned.File.Name()
+	tmpfile := cleaned.Filename
 	mediafile, err := lfs.LocalMediaPath(cleaned.Oid)
 	if err != nil {
 		Panic(err, "Unable to get local media path.")

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -81,7 +81,10 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 
 		u, wErr := lfs.NewUploadable(pointer.Oid, pointer.Name, i+1, len(pointers))
 		if wErr != nil {
-			if Debugging || wErr.Panic {
+			if cleanPointerErr, ok := wErr.Err.(*lfs.CleanedPointerError); ok {
+				Exit("%s is an LFS pointer to %s, which does not exist in .git/lfs/objects.\n\nRun 'git lfs fsck' to verify Git LFS objects.",
+					pointer.Name, cleanPointerErr.Pointer.Oid)
+			} else if Debugging || wErr.Panic {
 				Panic(wErr.Err, wErr.Error())
 			} else {
 				Exit(wErr.Error())

--- a/lfs/pointer_clean.go
+++ b/lfs/pointer_clean.go
@@ -14,7 +14,8 @@ type cleanedAsset struct {
 }
 
 type CleanedPointerError struct {
-	Bytes []byte
+	Pointer *Pointer
+	Bytes   []byte
 }
 
 func (e *CleanedPointerError) Error() string {
@@ -36,9 +37,9 @@ func PointerClean(reader io.Reader, size int64, cb CopyCallback) (*cleanedAsset,
 		cb = nil
 	}
 
-	by, _, err := DecodeFrom(reader)
+	by, ptr, err := DecodeFrom(reader)
 	if err == nil && len(by) < 512 {
-		return nil, &CleanedPointerError{by}
+		return nil, &CleanedPointerError{ptr, by}
 	}
 
 	multi := io.MultiReader(bytes.NewReader(by), reader)

--- a/lfs/pointer_clean.go
+++ b/lfs/pointer_clean.go
@@ -9,8 +9,7 @@ import (
 )
 
 type cleanedAsset struct {
-	File          *os.File
-	mediafilepath string
+	File *os.File
 	*Pointer
 }
 
@@ -44,7 +43,7 @@ func PointerClean(reader io.Reader, size int64, cb CopyCallback) (*cleanedAsset,
 	written, err := CopyWithCallback(writer, multi, size, cb)
 
 	pointer := NewPointer(hex.EncodeToString(oidHash.Sum(nil)), written)
-	return &cleanedAsset{tmp, "", pointer}, err
+	return &cleanedAsset{tmp, pointer}, err
 }
 
 func (a *cleanedAsset) Close() error {

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -18,6 +18,7 @@ type Uploadable struct {
 // NewUploadable builds the Uploadable from the given information.
 func NewUploadable(oid, filename string, index, totalFiles int) (*Uploadable, *WrappedError) {
 	path, err := LocalMediaPath(oid)
+
 	if err != nil {
 		return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)
 	}

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -97,12 +97,12 @@ func ensureFile(smudgePath, cleanPath string) error {
 	}
 
 	cleaned, err := PointerClean(file, stat.Size(), nil)
-	if err != nil {
-		return err
+	if cleaned != nil {
+		cleaned.Teardown()
 	}
 
-	if cleaned != nil {
-		defer cleaned.Teardown()
+	if err != nil {
+		return err
 	}
 
 	if expectedOid != cleaned.Oid {

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -100,7 +100,9 @@ func ensureFile(smudgePath, cleanPath string) error {
 		return err
 	}
 
-	cleaned.Close()
+	if cleaned != nil {
+		defer cleaned.Teardown()
+	}
 
 	if expectedOid != cleaned.Oid {
 		return fmt.Errorf("Expected %s to have an OID of %s, got %s", smudgePath, expectedOid, cleaned.Oid)

--- a/test/test-clean.sh
+++ b/test/test-clean.sh
@@ -2,33 +2,52 @@
 
 . "test/testlib.sh"
 
+clean_setup () {
+  mkdir "$1"
+  cd "$1"
+  git init
+}
 
-begin_test "clean"
+begin_test "clean simple file"
 (
   set -e
+  clean_setup "simple"
 
-  mkdir repo
-  cd repo
-  git init
-
-  # clean a simple file
   echo "whatever" | git lfs clean | tee clean.log
   [ "$(pointer cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411 9)" = "$(cat clean.log)" ]
+)
+end_test
 
-  # clean a git lfs pointer
+begin_test "clean a pointer"
+(
+  set -e
+  clean_setup "pointer"
+
   pointer cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411 9 | git lfs clean | tee clean.log
   [ "$(pointer cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411 9)" = "$(cat clean.log)" ]
+)
+end_test
 
-  # clean a pseudo pointer with extra data
+begin_test "clean pseudo pointer"
+(
+  set -e
+  clean_setup "pseudo"
+
   echo "version https://git-lfs.github.com/spec/v1
 oid sha256:7cd8be1d2cd0dd22cd9d229bb6b5785009a05e8b39d405615d882caac56562b5
 size 1024
 
 This is my test pointer.  There are many like it, but this one is mine." | git lfs clean | tee clean.log
   [ "$(pointer f492acbebb5faa22da4c1501c022af035469f624f426631f31936575873fefe1 202)" = "$(cat clean.log)" ]
+)
+end_test
 
-  # clean a pseudo pointer with extra data separated by enough white space to
-  # fill the 'git lfs clean' buffer
+begin_test "clean pseudo pointer with extra data"
+(
+  set -e
+  clean_setup "extra-data"
+
+  # pointer includes enough extra data to fill the 'git lfs clean' buffer
   echo "version https://git-lfs.github.com/spec/v1
 oid sha256:7cd8be1d2cd0dd22cd9d229bb6b5785009a05e8b39d405615d882caac56562b5
 size 1024

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -24,7 +24,6 @@ begin_test "pre-push"
   git add hi.dat
   git commit -m "add hi.dat"
   git show
-  git lfs env
 
   # file isn't on the git lfs server yet
   curl -v "$GITSERVER/$reponame.git/info/lfs/objects/98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4" \
@@ -78,7 +77,6 @@ begin_test "pre-push dry-run"
   git add hi.dat
   git commit -m "add hi.dat"
   git show
-  git lfs env
 
   # file doesn't exist yet
   curl -v "$GITSERVER/$reponame.git/info/lfs/objects/2840e0eafda1d0760771fe28b91247cf81c76aa888af28a850b5648a338dc15b" \
@@ -98,5 +96,44 @@ begin_test "pre-push dry-run"
     -H "Accept: application/vnd.git-lfs+json" 2>&1 |
     tee http.log
   grep "404 Not Found" http.log
+)
+end_test
+
+begin_test "pre-push with existing file"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")-existing-file"
+  setup_remote_repo "$reponame"
+
+  clone_repo "$reponame" dry-run2
+  echo "existing" > existing.dat
+  git add existing.dat
+  git commit -m "add existing dat"
+
+  git lfs track "*.dat"
+  echo "new" > new.dat
+  git add new.dat
+  git add .gitattributes
+  git commit -m "add new file through git lfs"
+
+  # push file to the git lfs server
+  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+    git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
+    tee push.log
+  grep "(1 of 1 files)" push.log
+
+  # now the file exists
+  curl -v "$GITSERVER/$reponame.git/info/lfs/objects/7aa7a5359173d05b63cfd682e3c38487f3cb4f7f1d60659fe59fab1505977d4c" \
+    -u "user:pass" \
+    -o lfs.json \
+    -H "Accept: application/vnd.git-lfs+json" 2>&1 |
+    tee http.log
+  grep "200 OK" http.log
+
+  grep "download" lfs.json || {
+    cat lfs.json
+    exit 1
+  }
 )
 end_test


### PR DESCRIPTION
`git push` errors if you have Git LFS pointers without an object in `.git/lfs/objects`. This prevents the client from making a successful Git push without a successful Git LFS push. But, the error message is very confusing.

> Cannot clean a Git LFS pointer.  Skipping.

The confusing error message was written to prevent `git add` from turning a Git LFS pointer to _another_ pointer in the clean filter. So here's an attempt at a better error:

> new.dat is an LFS pointer to 7aa7a5359173d05b63cfd682e3c38487f3cb4f7f1d60659fe59fab1505977d4c, which does not exist in .git/lfs/objects.
>    
> Run 'git lfs fsck' to verify Git LFS objects.

This hopefully makes a little more sense. It also points the user to the fsck command, which will show the user all of their missing objects. Thoughts?

The first commits are some light refactoring as I was going over some code. Some properties were no longer used, or could be simplified. For instance, no need to send an `*os.File` in the `*cleanedAsset` object if every caller is going to immediately close it. Just close it and send the filename instead.

Also, the error message change in `commands/command_pre_push.go` is a hack. `lfs.NewUploadable` should return a `*WrappedError` with the `Panic` bool set to false. This way both `push` and `pre-push` get the correct error message for free.