### PR TITLE
Add option to push object ID(s) directly.

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -73,13 +73,13 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 
 	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(pointers))
 
-	for i, pointer := range pointers {
+	for _, pointer := range pointers {
 		if prePushDryRun {
 			Print("push %s", pointer.Name)
 			continue
 		}
 
-		u, wErr := lfs.NewUploadable(pointer.Oid, pointer.Name, i+1, len(pointers))
+		u, wErr := lfs.NewUploadable(pointer.Oid, pointer.Name)
 		if wErr != nil {
 			if Debugging || wErr.Panic {
 				Panic(wErr.Err, wErr.Error())

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -59,7 +59,7 @@ func uploadsWithObjectIDs(oids []string) *lfs.TransferQueue {
 	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(oids))
 
 	for _, oid := range oids {
-		u, wErr := lfs.NewUploadableWithoutFilename(oid)
+		u, wErr := lfs.NewUploadable(oid, "", 0, 0)
 		if wErr != nil {
 			if Debugging || wErr.Panic {
 				Panic(wErr.Err, wErr.Error())

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -59,6 +59,10 @@ func uploadsWithObjectIDs(oids []string) *lfs.TransferQueue {
 	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(oids))
 
 	for i, oid := range oids {
+		if pushDryRun {
+			Print("push object ID %s", oid)
+			continue
+		}
 		tracerx.Printf("prepare upload: %s %d/%d", oid, i+1, len(oids))
 
 		u, wErr := lfs.NewUploadable(oid, "")

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -39,7 +39,7 @@ func uploadsBetweenRefs(left string, right string) *lfs.TransferQueue {
 			Print("push %s", pointer.Name)
 			continue
 		}
-		tracerx.Printf("checking_asset: %s %s %d/%d", pointer.Oid, pointer.Name, i+1, len(pointers))
+		tracerx.Printf("prepare upload: %s %s %d/%d", pointer.Oid, pointer.Name, i+1, len(pointers))
 
 		u, wErr := lfs.NewUploadable(pointer.Oid, pointer.Name)
 		if wErr != nil {

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -41,7 +41,7 @@ func uploadsBetweenRefs(left string, right string) *lfs.TransferQueue {
 		}
 		tracerx.Printf("checking_asset: %s %s %d/%d", pointer.Oid, pointer.Name, i+1, len(pointers))
 
-		u, wErr := lfs.NewUploadable(pointer.Oid, pointer.Name, i+1, len(pointers))
+		u, wErr := lfs.NewUploadable(pointer.Oid, pointer.Name)
 		if wErr != nil {
 			if Debugging || wErr.Panic {
 				Panic(wErr.Err, wErr.Error())
@@ -59,7 +59,7 @@ func uploadsWithObjectIDs(oids []string) *lfs.TransferQueue {
 	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(oids))
 
 	for _, oid := range oids {
-		u, wErr := lfs.NewUploadable(oid, "", 0, 0)
+		u, wErr := lfs.NewUploadable(oid, "")
 		if wErr != nil {
 			if Debugging || wErr.Panic {
 				Panic(wErr.Err, wErr.Error())

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -19,10 +19,59 @@ var (
 	}
 	pushDryRun       = false
 	pushDeleteBranch = "(delete)"
+	pushObjectIDs    = false
 	useStdin         = false
 
 	// shares some global vars and functions with commmands_pre_push.go
 )
+
+func uploadsBetweenRefs(left string, right string) *lfs.TransferQueue {
+	// Just use scanner here
+	pointers, err := lfs.ScanRefs(left, right)
+	if err != nil {
+		Panic(err, "Error scanning for Git LFS files")
+	}
+
+	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(pointers))
+
+	for i, pointer := range pointers {
+		if pushDryRun {
+			Print("push %s", pointer.Name)
+			continue
+		}
+		tracerx.Printf("checking_asset: %s %s %d/%d", pointer.Oid, pointer.Name, i+1, len(pointers))
+
+		u, wErr := lfs.NewUploadable(pointer.Oid, pointer.Name, i+1, len(pointers))
+		if wErr != nil {
+			if Debugging || wErr.Panic {
+				Panic(wErr.Err, wErr.Error())
+			} else {
+				Exit(wErr.Error())
+			}
+		}
+		uploadQueue.Add(u)
+	}
+
+	return uploadQueue
+}
+
+func uploadsWithObjectIDs(oids []string) *lfs.TransferQueue {
+	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(oids))
+
+	for _, oid := range oids {
+		u, wErr := lfs.NewUploadableWithoutFilename(oid)
+		if wErr != nil {
+			if Debugging || wErr.Panic {
+				Panic(wErr.Err, wErr.Error())
+			} else {
+				Exit(wErr.Error())
+			}
+		}
+		uploadQueue.Add(u)
+	}
+
+	return uploadQueue
+}
 
 // pushCommand pushes local objects to a Git LFS server.  It takes two
 // arguments:
@@ -35,6 +84,7 @@ var (
 // of commits between the local and remote git servers.
 func pushCommand(cmd *cobra.Command, args []string) {
 	var left, right string
+	var uploadQueue *lfs.TransferQueue
 
 	if len(args) == 0 {
 		Print("Specify a remote and a remote branch name (`git lfs push origin master`)")
@@ -63,6 +113,15 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		if left == pushDeleteBranch {
 			return
 		}
+
+		uploadQueue = uploadsBetweenRefs(left, right)
+	} else if pushObjectIDs {
+		if len(args) < 2 {
+			Print("Usage: git lfs push --objectid <remote> <lfs-object-id> [lfs-object-id] ...")
+			return
+		}
+
+		uploadQueue = uploadsWithObjectIDs(args[1:])
 	} else {
 		var remoteArg, refArg string
 
@@ -90,32 +149,8 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		if remoteRef != "" {
 			right = "^" + strings.Split(remoteRef, "\t")[0]
 		}
-	}
 
-	// Just use scanner here
-	pointers, err := lfs.ScanRefs(left, right)
-	if err != nil {
-		Panic(err, "Error scanning for Git LFS files")
-	}
-
-	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(pointers))
-
-	for i, pointer := range pointers {
-		if pushDryRun {
-			Print("push %s", pointer.Name)
-			continue
-		}
-		tracerx.Printf("checking_asset: %s %s %d/%d", pointer.Oid, pointer.Name, i+1, len(pointers))
-
-		u, wErr := lfs.NewUploadable(pointer.Oid, pointer.Name, i+1, len(pointers))
-		if wErr != nil {
-			if Debugging || wErr.Panic {
-				Panic(wErr.Err, wErr.Error())
-			} else {
-				Exit(wErr.Error())
-			}
-		}
-		uploadQueue.Add(u)
+		uploadQueue = uploadsBetweenRefs(left, right)
 	}
 
 	if !pushDryRun {
@@ -137,5 +172,6 @@ func pushCommand(cmd *cobra.Command, args []string) {
 func init() {
 	pushCmd.Flags().BoolVarP(&pushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")
 	pushCmd.Flags().BoolVarP(&useStdin, "stdin", "s", false, "Take refs on stdin (for pre-push hook)")
+	pushCmd.Flags().BoolVarP(&pushObjectIDs, "objectid", "o", false, "Push LFS object ID(s)")
 	RootCmd.AddCommand(pushCmd)
 }

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -172,6 +172,6 @@ func pushCommand(cmd *cobra.Command, args []string) {
 func init() {
 	pushCmd.Flags().BoolVarP(&pushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")
 	pushCmd.Flags().BoolVarP(&useStdin, "stdin", "s", false, "Take refs on stdin (for pre-push hook)")
-	pushCmd.Flags().BoolVarP(&pushObjectIDs, "objectid", "o", false, "Push LFS object ID(s)")
+	pushCmd.Flags().BoolVarP(&pushObjectIDs, "object-id", "o", false, "Push LFS object ID(s)")
 	RootCmd.AddCommand(pushCmd)
 }

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -58,7 +58,9 @@ func uploadsBetweenRefs(left string, right string) *lfs.TransferQueue {
 func uploadsWithObjectIDs(oids []string) *lfs.TransferQueue {
 	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(oids))
 
-	for _, oid := range oids {
+	for i, oid := range oids {
+		tracerx.Printf("prepare upload: %s %d/%d", oid, i+1, len(oids))
+
 		u, wErr := lfs.NewUploadable(oid, "")
 		if wErr != nil {
 			if Debugging || wErr.Panic {

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -117,7 +117,7 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		uploadQueue = uploadsBetweenRefs(left, right)
 	} else if pushObjectIDs {
 		if len(args) < 2 {
-			Print("Usage: git lfs push --objectid <remote> <lfs-object-id> [lfs-object-id] ...")
+			Print("Usage: git lfs push --object-id <remote> <lfs-object-id> [lfs-object-id] ...")
 			return
 		}
 

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -23,7 +23,7 @@ func NewUploadable(oid, filename string) (*Uploadable, *WrappedError) {
 		return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)
 	}
 
-	var pathForStats string = localMediaPath
+	pathForStats := localMediaPath
 	if len(filename) > 0 {
 		if err := ensureFile(filename, localMediaPath); err != nil {
 			return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -17,7 +17,7 @@ type Uploadable struct {
 
 // NewUploadable builds the Uploadable from the given information.
 // "filename" can be empty if a raw object is pushed (see "object-id" flag in push command)/
-func NewUploadable(oid, filename string, index, totalFiles int) (*Uploadable, *WrappedError) {
+func NewUploadable(oid, filename string) (*Uploadable, *WrappedError) {
 	localMediaPath, err := LocalMediaPath(oid)
 	if err != nil {
 		return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -23,15 +23,15 @@ func NewUploadable(oid, filename string) (*Uploadable, *WrappedError) {
 		return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)
 	}
 
-	pathForStats := localMediaPath
+	statsPath := localMediaPath
 	if len(filename) > 0 {
 		if err := ensureFile(filename, localMediaPath); err != nil {
 			return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)
 		}
-		pathForStats = filename
+		statsPath = filename
 	}
 
-	fi, err := os.Stat(pathForStats)
+	fi, err := os.Stat(statsPath)
 	if err != nil {
 		return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)
 	}

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -16,36 +16,27 @@ type Uploadable struct {
 }
 
 // NewUploadable builds the Uploadable from the given information.
+// "filename" can be empty if a raw object is pushed (see "object-id" flag in push command)/
 func NewUploadable(oid, filename string, index, totalFiles int) (*Uploadable, *WrappedError) {
-	path, err := LocalMediaPath(oid)
+	localMediaPath, err := LocalMediaPath(oid)
 	if err != nil {
 		return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)
 	}
 
-	if err := ensureFile(filename, path); err != nil {
-		return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)
+	var pathForStats string = localMediaPath
+	if len(filename) > 0 {
+		if err := ensureFile(filename, localMediaPath); err != nil {
+			return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)
+		}
+		pathForStats = filename
 	}
 
-	fi, err := os.Stat(filename)
+	fi, err := os.Stat(pathForStats)
 	if err != nil {
 		return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)
 	}
 
-	return &Uploadable{oid: oid, OidPath: path, Filename: filename, size: fi.Size()}, nil
-}
-
-func NewUploadableWithoutFilename(oid string) (*Uploadable, *WrappedError) {
-	path, err := LocalMediaPath(oid)
-	if err != nil {
-		return nil, Errorf(err, "Error uploading file %s", oid)
-	}
-
-	fi, err := os.Stat(path)
-	if err != nil {
-		return nil, Errorf(err, "Error uploading file %s", oid)
-	}
-
-	return &Uploadable{oid: oid, OidPath: path, Filename: "", size: fi.Size()}, nil
+	return &Uploadable{oid: oid, OidPath: localMediaPath, Filename: filename, size: fi.Size()}, nil
 }
 
 func (u *Uploadable) Check() (*objectResource, *WrappedError) {

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -34,6 +34,20 @@ func NewUploadable(oid, filename string, index, totalFiles int) (*Uploadable, *W
 	return &Uploadable{oid: oid, OidPath: path, Filename: filename, size: fi.Size()}, nil
 }
 
+func NewUploadableWithoutFilename(oid string) (*Uploadable, *WrappedError) {
+	path, err := LocalMediaPath(oid)
+	if err != nil {
+		return nil, Errorf(err, "Error uploading file %s", oid)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, Errorf(err, "Error uploading file %s", oid)
+	}
+
+	return &Uploadable{oid: oid, OidPath: path, Filename: "", size: fi.Size()}, nil
+}
+
 func (u *Uploadable) Check() (*objectResource, *WrappedError) {
 	return UploadCheck(u.OidPath)
 }

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -67,7 +67,7 @@ begin_test "push object id(s)"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  git lfs push --objectid origin \
+  git lfs push --object-id origin \
     4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
     2>&1 | tee push.log
   grep "(1 of 1 files)" push.log
@@ -76,7 +76,7 @@ begin_test "push object id(s)"
   git add b.dat
   git commit -m "add b.dat"
 
-  git lfs push --objectid origin \
+  git lfs push --object-id origin \
     4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
     82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 \
     2>&1 | tee push.log

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -17,7 +17,7 @@ begin_test "push"
 
   git lfs push origin master 2>&1 | tee push.log
   grep "(1 of 1 files)" push.log
-  assert_file_line_count push.log 1
+  [ $(wc -l < push.log) -eq 1 ]
 
   git checkout -b push-b
   echo "push b" > b.dat
@@ -26,7 +26,7 @@ begin_test "push"
 
   git lfs push origin push-b 2>&1 | tee push.log
   grep "(2 of 2 files)" push.log
-  assert_file_line_count push.log 1
+  [ $(wc -l < push.log) -eq 1 ]
 )
 end_test
 
@@ -53,7 +53,7 @@ begin_test "push dry-run"
   git lfs push --dry-run origin push-b 2>&1 | tee push.log
   grep "push a.dat" push.log
   grep "push b.dat" push.log
-  assert_file_line_count push.log 2
+  [ $(wc -l < push.log) -eq 2 ]
 )
 end_test
 
@@ -74,7 +74,7 @@ begin_test "push object id(s)"
     4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
     2>&1 | tee push.log
   grep "(1 of 1 files)" push.log
-  assert_file_line_count push.log 1
+  [ $(wc -l < push.log) -eq 1 ]
 
   echo "push b" > b.dat
   git add b.dat
@@ -85,6 +85,6 @@ begin_test "push object id(s)"
     82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 \
     2>&1 | tee push.log
   grep "(2 of 2 files)" push.log
-  assert_file_line_count push.log 1
+  [ $(wc -l < push.log) -eq 1 ]
 )
 end_test

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -53,3 +53,35 @@ begin_test "push dry-run"
   grep "push b.dat" push.log
 )
 end_test
+
+begin_test "push object id(s)"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" repo2
+
+  git lfs track "*.dat"
+  echo "push a" > a.dat
+  git add .gitattributes a.dat
+  git commit -m "add a.dat"
+
+  git lfs push --objectid origin \
+    4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
+    2>&1 | tee push.log
+  grep "(1 of 1 files)" push.log
+
+  echo "push b" > b.dat
+  git add b.dat
+  git commit -m "add b.dat"
+
+  git lfs push --objectid origin \
+    4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
+    82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 \
+    2>&1 | tee push.log
+
+  git lfs push origin push-b 2>&1 | tee push.log
+  grep "(2 of 2 files)" push.log
+)
+end_test

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -80,8 +80,6 @@ begin_test "push object id(s)"
     4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
     82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 \
     2>&1 | tee push.log
-
-  git lfs push origin push-b 2>&1 | tee push.log
   grep "(2 of 2 files)" push.log
 )
 end_test

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -17,6 +17,7 @@ begin_test "push"
 
   git lfs push origin master 2>&1 | tee push.log
   grep "(1 of 1 files)" push.log
+  assert_file_line_count push.log 1
 
   git checkout -b push-b
   echo "push b" > b.dat
@@ -25,6 +26,7 @@ begin_test "push"
 
   git lfs push origin push-b 2>&1 | tee push.log
   grep "(2 of 2 files)" push.log
+  assert_file_line_count push.log 1
 )
 end_test
 
@@ -51,6 +53,7 @@ begin_test "push dry-run"
   git lfs push --dry-run origin push-b 2>&1 | tee push.log
   grep "push a.dat" push.log
   grep "push b.dat" push.log
+  assert_file_line_count push.log 2
 )
 end_test
 
@@ -71,6 +74,7 @@ begin_test "push object id(s)"
     4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
     2>&1 | tee push.log
   grep "(1 of 1 files)" push.log
+  assert_file_line_count push.log 1
 
   echo "push b" > b.dat
   git add b.dat
@@ -81,5 +85,6 @@ begin_test "push object id(s)"
     82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 \
     2>&1 | tee push.log
   grep "(2 of 2 files)" push.log
+  assert_file_line_count push.log 1
 )
 end_test

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -148,3 +148,9 @@ shutdown() {
     fi
   fi
 }
+
+assert_file_line_count() {
+  local filename="$1"
+  local lines="$2"
+  [ $(wc -l < "$filename") -eq "$lines" ]
+}

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -148,9 +148,3 @@ shutdown() {
     fi
   fi
 }
-
-assert_file_line_count() {
-  local filename="$1"
-  local lines="$2"
-  [ $(wc -l < "$filename") -eq "$lines" ]
-}


### PR DESCRIPTION
Adds a new option "--objectid" to the push command to upload objects generated by [BFG](https://github.com/rtyley/bfg-repo-cleaner/pull/87). Click [here](https://gist.github.com/larsxschneider/a31fb77c7e9a9c9b81da) for an example how to use it with BFG.

*Note:*
I am learning golang. Please point out to me anything that could be improved. Even if pedantic :smile: 