### PR TITLE
Error() can display odd output when % is used with no args

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -33,7 +33,10 @@ var (
 // Error prints a formatted message to Stderr.  It also gets printed to the
 // panic log if one is created for this command.
 func Error(format string, args ...interface{}) {
-	line := fmt.Sprintf(format, args...)
+	line := format
+	if len(args) > 0 {
+		line = fmt.Sprintf(format, args...)
+	}
 	fmt.Fprintln(ErrorWriter, line)
 }
 


### PR DESCRIPTION
Avoids display bugs if '%' are used when formatting isn't intended. e.g.

```
$ git lfs init
The clean filter should be "git-lfs clean %!f(MISSING)" but is "git lfs clean %!f(MISSING)"
```