### PR TITLE
Log connection count and bump MaxIdleConnsPerHost

### DIFF
--- a/lfs/http.go
+++ b/lfs/http.go
@@ -137,6 +137,7 @@ func (c *Configuration) HttpClient() *HttpClient {
 		Proxy:               http.ProxyFromEnvironment,
 		Dial:                (newLfsDialer()).Dial,
 		TLSHandshakeTimeout: 5 * time.Second,
+		MaxIdleConnsPerHost: Config.ConcurrentTransfers() * 2,
 	}
 
 	sslVerify, _ := c.GitConfig("http.sslverify")


### PR DESCRIPTION
This PR adds logs to the stats log for every connection that's made by the HTTP Dialer. With these stats we can learn how to keep these extra connections to a minimum by setting a more appropriate value for `MaxIdleConnsPerHost`.

Some quick tests pushing 25 files to localhost, with the default settings (concurrent transfers = 3, no batch):

MaxIdleConnsPerHost     | # Connections
------------------------|---------------
default (2)             | 25
ConcurrentTransfers     | 12
ConcurrentTransfers * 2 |  5
50 | 5

For the same files on a GitHub hosted repo we have:

MaxIdleConnsPerHost | Host | #Connections
-------------------------------|------|--------------------
default (2) | github.com | 5 
 | api | 3
 | storage | 4
ConcurrentTransfers * 2 | github.com | 3
 | api | 2
 | storage | 3

`ConcurrentTransfers() * 2` seems to be a good starting point. Going any higher than that doesn't have much of an effect.