### PR TITLE
Setup GOPATH if it isn't already set.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ obj-*
 
 rpm/BUILD*
 rpm/*RPMS
+
+src

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 script/fmt
 rm -rf `pwd`/bin/*

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,6 +1,13 @@
 #!/bin/sh
 set -e
 
+if [ -z "$GOPATH" ]; then
+  export GOPATH="$(pwd)"
+  mkdir -p src/github.com/github
+  [ -h src/github.com/github/git-lfs ] ||
+    ln -s "$GOPATH" src/github.com/github/git-lfs
+fi
+
 script/fmt
 rm -rf bin/*
 go run script/*.go -cmd build "$@"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -e
 
-if [ -z "$GOPATH" ]; then
+# Only set GOPATH on non-Windows platforms as Windows can't do the symlinking
+# that we need.
+if [ -z "$GOPATH" ] && [ uname -s | grep -vq "_NT-" ]; then
   export GOPATH="$(pwd)"
   mkdir -p src/github.com/github
   [ -h src/github.com/github/git-lfs ] ||

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,5 +2,5 @@
 set -e
 
 script/fmt
-rm -rf `pwd`/bin/*
+rm -rf bin/*
 go run script/*.go -cmd build "$@"


### PR DESCRIPTION
This variable is a bit of a mystery to non-Go developers and it's unclear how you set it up properly. As a result, if it's not set let's set everything up how Go likes it.

Also:
- This will also help keep the Homebrew formula simpler.
- Ignore the `src` directory that we're creating now.
- script/bootstrap: exit on any errors (to be more consistent with other scripts and safer).
- script/bootstrap: remove unneeded `pwd` (the rest of this script assumes it's already in the root of the repository anyway)

Closes #388.