### PR TITLE
Push deleted files

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -33,7 +33,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	pointers, err := lfs.ScanRefs(ref, "")
+	pointers, err := lfs.ScanRefs(ref, "", nil)
 	if err != nil {
 		Panic(err, "Could not scan for Git LFS files")
 	}

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -32,7 +32,7 @@ func doFsck() (bool, error) {
 	// All we care about is the pointer OID and file name
 	pointerIndex := make(map[string]string)
 
-	pointers, err := lfs.ScanRefs(ref, "")
+	pointers, err := lfs.ScanRefs(ref, "", nil)
 	if err != nil {
 		return false, err
 	}

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -27,7 +27,7 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	pointers, err := lfs.ScanRefs(ref, "")
+	pointers, err := lfs.ScanRefs(ref, "", nil)
 	if err != nil {
 		Panic(err, "Could not scan for Git LFS files")
 	}

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -27,7 +27,8 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	pointers, err := lfs.ScanRefs(ref, "", nil)
+	scanOpt := &lfs.ScanRefsOptions{SkipDeletedBlobs: true}
+	pointers, err := lfs.ScanRefs(ref, "", scanOpt)
 	if err != nil {
 		Panic(err, "Could not scan for Git LFS files")
 	}

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -66,7 +66,7 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 	}
 
 	// Just use scanner here
-	pointers, err := lfs.ScanRefs(left, right)
+	pointers, err := lfs.ScanRefs(left, right, nil)
 	if err != nil {
 		Panic(err, "Error scanning for Git LFS files")
 	}

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -93,7 +93,7 @@ func pushCommand(cmd *cobra.Command, args []string) {
 	}
 
 	// Just use scanner here
-	pointers, err := lfs.ScanRefs(left, right)
+	pointers, err := lfs.ScanRefs(left, right, nil)
 	if err != nil {
 		Panic(err, "Error scanning for Git LFS files")
 	}

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -51,7 +51,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 	remoteRef, err := git.CurrentRemoteRef()
 	if err == nil {
 
-		pointers, err := lfs.ScanRefs(ref, "^"+remoteRef)
+		pointers, err := lfs.ScanRefs(ref, "^"+remoteRef, nil)
 		if err != nil {
 			Panic(err, "Could not scan for Git LFS objects")
 		}

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -154,7 +154,7 @@ func revListShas(refLeft, refRight string, all bool, nameMap map[string]string) 
 	if all {
 		refArgs = append(refArgs, "--all")
 	} else {
-		refArgs = append(refArgs, "--no-walk")
+		refArgs = append(refArgs, "--do-walk")
 		refArgs = append(refArgs, refLeft)
 		if refRight != "" && !z40.MatchString(refRight) {
 			refArgs = append(refArgs, refRight)

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -23,15 +23,13 @@ func NewUploadable(oid, filename string) (*Uploadable, *WrappedError) {
 		return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)
 	}
 
-	statsPath := localMediaPath
 	if len(filename) > 0 {
 		if err := ensureFile(filename, localMediaPath); err != nil {
 			return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)
 		}
-		statsPath = filename
 	}
 
-	fi, err := os.Stat(statsPath)
+	fi, err := os.Stat(localMediaPath)
 	if err != nil {
 		return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)
 	}

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -26,7 +26,7 @@ func NewUploadable(oid, filename string, index, totalFiles int) (*Uploadable, *W
 		return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)
 	}
 
-	fi, err := os.Stat(filename)
+	fi, err := os.Stat(path)
 	if err != nil {
 		return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)
 	}

--- a/test/test-commit-delete-push.sh
+++ b/test/test-commit-delete-push.sh
@@ -45,7 +45,7 @@ begin_test "commit, delete, then push"
   }
   grep "(2 of 2 files)" push.log | cat push.log
 
-  assert_server_object "$deleted_oid" "deleted\n"
-  assert_server_object "$added_oid" "added\n"
+  assert_server_object "$reponame" "$deleted_oid"
+  assert_server_object "$reponame" "$added_oid"
 )
 end_test

--- a/test/test-commit-delete-push.sh
+++ b/test/test-commit-delete-push.sh
@@ -38,7 +38,7 @@ begin_test "commit, delete, then push"
   grep "push added.dat" dryrun.log
 
   git log
-  git push origin master 2>&1 > push.log || {
+  GIT_TRACE=1 git push origin master 2>&1 > push.log || {
     cat push.log
     git lfs logs last
     exit 1

--- a/test/test-commit-delete-push.sh
+++ b/test/test-commit-delete-push.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+. "test/testlib.sh"
+
+begin_test "commit, delete, then push"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" repo
+
+  git lfs track "*.dat"
+
+  deleted_oid=$(echo "deleted" | shasum -a 256 | cut -f 1 -d " ")
+  echo "deleted" > deleted.dat
+  git add deleted.dat .gitattributes
+  git commit -m "add deleted file"
+
+  git lfs push origin master --dry-run | grep "push deleted.dat"
+
+  assert_pointer "master" "deleted.dat" "$deleted_oid" 8
+
+  added_oid=$(echo "added" | shasum -a 256 | cut -f 1 -d " ")
+  echo "added" > added.dat
+  git add added.dat
+  git commit -m "add file"
+
+  git lfs push origin master --dry-run | tee dryrun.log
+  grep "push deleted.dat" dryrun.log
+  grep "push added.dat" dryrun.log
+
+  git rm deleted.dat
+  git commit -m "did not need deleted.dat after all"
+
+  GIT_TRACE=1 git lfs push origin master --dry-run 2>&1 | tee dryrun.log
+  grep "push deleted.dat" dryrun.log
+  grep "push added.dat" dryrun.log
+
+  git log
+  git push origin master 2>&1 > push.log || {
+    cat push.log
+    git lfs logs last
+    exit 1
+  }
+  grep "(2 of 2 files)" push.log | cat push.log
+
+  assert_server_object "$deleted_oid" "deleted\n"
+  assert_server_object "$added_oid" "added\n"
+)
+end_test

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -23,6 +23,6 @@ begin_test "ls-files"
 
   git lfs ls-files | tee ls.log
   grep some.dat ls.log
-  grep missing.dat ls.log
+  [ `wc -l < ls.log` = 1 ]
 )
 end_test

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -12,9 +12,17 @@ begin_test "ls-files"
   git lfs track "*.dat" | grep "Tracking \*.dat"
   echo "some data" > some.dat
   echo "some text" > some.txt
-  git add some.dat some.txt
-  git commit -m "added some files"
+  echo "missing" > missing.dat
+  git add missing.dat
+  git commit -m "add missing file"
+  [ "missing.dat" = "$(git lfs ls-files)" ]
 
-  [ "some.dat" = "$(git lfs ls-files)" ]
+  git rm missing.dat
+  git add some.dat some.txt
+  git commit -m "added some files, removed missing one"
+
+  git lfs ls-files | tee ls.log
+  grep some.dat ls.log
+  grep missing.dat ls.log
 )
 end_test


### PR DESCRIPTION
This fixes the scanner to find all objects in a commit range, even if an object was added and deleted in that same range. We want all `git lfs push` commands to push every object so that every individual commit is has all the objects it needs.