### PR TITLE
Test helper fixes

### DIFF
--- a/test/test-batch-transfer-unsupported.sh
+++ b/test/test-batch-transfer-unsupported.sh
@@ -37,7 +37,7 @@ begin_test "batch transfer unsupported on server"
   # This is a small shell function that runs several git commands together.
   assert_pointer "master" "a.dat" "$contents_oid" 1
 
-  refute_server_object "$contents_oid"
+  refute_server_object "$reponame" "$contents_oid"
 
   # Ensure batch transfer is turned on for this repo
   git config --add --local lfs.batch true
@@ -52,7 +52,7 @@ begin_test "batch transfer unsupported on server"
   grep "(1 of 1 files)" push.log
   grep "master -> master" push.log
 
-  assert_server_object "$contents_oid" "$contents"
+  assert_server_object "$reponame" "$contents_oid"
 
   # Re-enable batch support on the server
   if [ -s "$LFS_URL_FILE" ]; then

--- a/test/test-batch-transfer.sh
+++ b/test/test-batch-transfer.sh
@@ -43,7 +43,7 @@ begin_test "batch transfer"
   # This is a small shell function that runs several git commands together.
   assert_pointer "master" "a.dat" "$contents_oid" 1
 
-  refute_server_object "$contents_oid"
+  refute_server_object "$reponame" "$contents_oid"
 
   # Ensure batch transfer is turned on for this repo
   git config --add --local lfs.batch true
@@ -53,7 +53,7 @@ begin_test "batch transfer"
   grep "(1 of 1 files)" push.log
   grep "master -> master" push.log
 
-  assert_server_object "$contents_oid" "$contents"
+  assert_server_object "$reponame" "$contents_oid"
 
   # change to the clone's working directory
   cd ../clone

--- a/test/test-chunked-transfer-encoding-batched.sh
+++ b/test/test-chunked-transfer-encoding-batched.sh
@@ -43,7 +43,7 @@ begin_test "chunked transfer encoding batched"
   # This is a small shell function that runs several git commands together.
   assert_pointer "master" "a.dat" "$contents_oid" 1
 
-  refute_server_object "$contents_oid"
+  refute_server_object "$reponame" "$contents_oid"
 
   # Ensure batch transfer is turned on for this repo
   git config --add --local lfs.batch true
@@ -53,7 +53,7 @@ begin_test "chunked transfer encoding batched"
   grep "(1 of 1 files)" push.log
   grep "master -> master" push.log
 
-  assert_server_object "$contents_oid" "$contents"
+  assert_server_object "$reponame" "$contents_oid"
 
   # change to the clone's working directory
   cd ../clone

--- a/test/test-chunked-transfer-encoding.sh
+++ b/test/test-chunked-transfer-encoding.sh
@@ -44,14 +44,14 @@ begin_test "chunked transfer encoding"
   # This is a small shell function that runs several git commands together.
   assert_pointer "master" "a.dat" "$contents_oid" 1
 
-  refute_server_object "$contents_oid"
+  refute_server_object "$reponame" "$contents_oid"
 
   # This pushes to the remote repository set up at the top of the test.
   git push origin master 2>&1 | tee push.log
   grep "(1 of 1 files)" push.log
   grep "master -> master" push.log
 
-  assert_server_object "$contents_oid" "$contents"
+  assert_server_object "$reponame" "$contents_oid"
 
   # change to the clone's working directory
   cd ../clone

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -32,13 +32,13 @@ begin_test "fetch"
 
   assert_pointer "master" "a.dat" "$contents_oid" 1
 
-  refute_server_object "$contents_oid"
+  refute_server_object "$reponame" "$contents_oid"
 
   git push origin master 2>&1 | tee push.log
   grep "(1 of 1 files)" push.log
   grep "master -> master" push.log
 
-  assert_server_object "$contents_oid" "$contents"
+  assert_server_object "$reponame" "$contents_oid"
 
   # Add a file in a different branch
   git checkout -b newbranch
@@ -50,7 +50,7 @@ begin_test "fetch"
   assert_pointer "newbranch" "b.dat" "$b_oid" 1
 
   git push origin newbranch
-  assert_server_object "$b_id" "$b"
+  assert_server_object "$reponame" "$b_oid"
 
   # change to the clone's working directory
   cd ../clone

--- a/test/test-happy-path.sh
+++ b/test/test-happy-path.sh
@@ -44,14 +44,14 @@ begin_test "happy path"
   # This is a small shell function that runs several git commands together.
   assert_pointer "master" "a.dat" "$contents_oid" 1
 
-  refute_server_object "$contents_oid"
+  refute_server_object "$reponame" "$contents_oid"
 
   # This pushes to the remote repository set up at the top of the test.
   git push origin master 2>&1 | tee push.log
   grep "(1 of 1 files)" push.log
   grep "master -> master" push.log
 
-  assert_server_object "$contents_oid" "$contents"
+  assert_server_object "$reponame" "$contents_oid"
 
   # change to the clone's working directory
   cd ../clone

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -109,7 +109,7 @@ setup() {
     }
   fi
 
-  echo "Git LFS: ${LFS_BIN:-(which git-lfs)}"
+  echo "Git LFS: ${LFS_BIN:-$(which git-lfs)}"
   git lfs version
   git version
 

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -20,14 +20,38 @@ assert_pointer() {
   fi
 }
 
-# no-op.  check that the object does not exist in the git lfs server
+# check that the object does not exist in the git lfs server. HTTP log is
+# written to http.log. JSON output is written to http.json.
+#
+#   $ refute_server_object "reponame" "oid"
 refute_server_object() {
-  echo "refute server object: no-op"
+  local reponame="$1"
+  local oid="$2"
+  curl -v "$GITSERVER/$reponame.git/info/lfs/objects/$oid" \
+    -u "user:pass" \
+    -o http.json \
+    -H "Accept: application/vnd.git-lfs+json" 2>&1 |
+    tee http.log
+
+  grep "404 Not Found" http.log
 }
 
-# no-op.  check that the object does exist in the git lfs server
+# check that the object does exist in the git lfs server. HTTP log is written
+# to http.log. JSON output is written to http.json.
 assert_server_object() {
-  echo "assert server object: no-op"
+  local reponame="$1"
+  local oid="$2"
+  curl -v "$GITSERVER/$reponame.git/info/lfs/objects/$oid" \
+    -u "user:pass" \
+    -o http.json \
+    -H "Accept: application/vnd.git-lfs+json" 2>&1 |
+    tee http.log
+  grep "200 OK" http.log
+
+  grep "download" http.json || {
+    cat http.json
+    exit 1
+  }
 }
 
 # pointer returns a string Git LFS pointer file.


### PR DESCRIPTION
This replaces the `assert_server_object` and `refute_server_object` helper no-ops with real functions.

This triggered some test failures because the server was tracking just a single set of objects by OID. So `refute_server_object` in one test would fail if another test already pushed it. 

I updated the test server to track unique objects per repo. The mock Git LFS API parses the repo name from a URL like `/{repo}.git/info/lfs/....` and passes it to the mock storage API as a `?r` query param.