### PR TITLE
Refactor some of the code in #404

### DIFF
--- a/lfs/ssh.go
+++ b/lfs/ssh.go
@@ -55,16 +55,20 @@ func sshGetExeAndArgs(endpoint Endpoint) (exe string, baseargs []string) {
 		return "", nil
 	}
 
+	isPlink := false
+	isTortoise := false
+
 	ssh := Config.Getenv("GIT_SSH")
-	basessh := filepath.Base(ssh)
-	// Strip extension for easier comparison
-	if ext := filepath.Ext(basessh); len(ext) > 0 {
-		basessh = basessh[:len(basessh)-len(ext)]
-	}
-	isPlink := strings.EqualFold(basessh, "plink")
-	isTortoise := strings.EqualFold(basessh, "tortoiseplink")
 	if ssh == "" {
 		ssh = "ssh"
+	} else {
+		basessh := filepath.Base(ssh)
+		// Strip extension for easier comparison
+		if ext := filepath.Ext(basessh); len(ext) > 0 {
+			basessh = basessh[:len(basessh)-len(ext)]
+		}
+		isPlink = strings.EqualFold(basessh, "plink")
+		isTortoise = strings.EqualFold(basessh, "tortoiseplink")
 	}
 
 	args := make([]string, 0, 4)


### PR DESCRIPTION
Some small changes to #404:

1. Implemented @michael-k's suggestion in https://github.com/github/git-lfs/pull/404#discussion-diff-32717780. It's more clear where and how both `isPlink` and `isTortoise` are set.
2. Removed any ssh stuff from `NewEndpoint()`. It now returns the correct `Endpoint` based on the url scheme. I really hope we don't try to support any other strings without a uri scheme ;)

/cc @sinbad