### PR TITLE
Fully re-submit batch requests on 401

### DIFF
--- a/lfs/config.go
+++ b/lfs/config.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/github/git-lfs/git"
+	"github.com/rubyist/tracerx"
 )
 
 var (
@@ -134,6 +135,7 @@ func (c *Configuration) PrivateAccess() bool {
 
 // SetPrivateAccess will set the private access flag in .git/config.
 func (c *Configuration) SetPrivateAccess() {
+	tracerx.Printf("setting repository access to private")
 	key := fmt.Sprintf("lfs.%s.access", c.Endpoint().Url)
 	configFile := filepath.Join(LocalGitDir, "config")
 	git.Config.SetLocal(configFile, key, "private")

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 
 	"github.com/github/git-lfs/git"
-	"github.com/rubyist/tracerx"
+	"github.com/github/git-lfs/vendor/_nuts/github.com/rubyist/tracerx"
 )
 
 var (


### PR DESCRIPTION
When a batch request received a 401, the request was re-run without resetting the Body, causing the request to error and fall back to individual processing. This just reruns the `Batch()` function.