### PR TITLE
Some cleanup to make debian package pass lintian checks

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: vcs
 Priority: optional
 Maintainer: Stephen Gelman <gelman@getbraintree.com>
 Build-Depends: debhelper (>= 9), dh-golang, golang-go (>= 1.3.0), git (>= 1.8.0), ruby-ronn
-Standards-Version: 3.9.4
+Standards-Version: 3.9.6
 
 Package: git-lfs
 Architecture: any

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,1 +1,26 @@
-../LICENSE
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: git-lfs
+Source: https://github.com/github/git-lfs
+
+Files: *
+Copyright: 2013-2015 Github, Inc.
+License: Expat
+ Copyright (c) GitHub, Inc. and Git LFS contributors
+ .
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.

--- a/debian/git-lfs.lintian-overrides
+++ b/debian/git-lfs.lintian-overrides
@@ -1,0 +1,6 @@
+# Go only produces static binaries so read-only relocations aren't possible
+hardening-no-relro usr/bin/git-lfs
+
+# strip disabled as golang upstream doesn't support it and it makes go
+# crash. See https://launchpad.net/bugs/1200255.
+unstripped-binary-or-object usr/bin/git-lfs


### PR DESCRIPTION
There were a few issues when running lintian (the debian deb linter) on the package.  This fixes them.

 - Add the machine-readable license header that debian requires
 - Update to the current standards version (this does not break compiling on older debian releases from what I can tell)
 - Add a lintian-overrides file for a few exceptions because golfing doesn't support a few things debian likes.