### PR TITLE
Check doHttpRequest() error in UploadObject()

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -341,8 +341,11 @@ func UploadObject(o *objectResource, cb CopyCallback) *WrappedError {
 	req.ContentLength = int64(len(by))
 	req.Body = ioutil.NopCloser(bytes.NewReader(by))
 	res, wErr = doHttpRequest(req, creds)
-	LogTransfer("lfs.data.verify", res)
+	if wErr != nil {
+		return wErr
+	}
 
+	LogTransfer("lfs.data.verify", res)
 	io.Copy(ioutil.Discard, res.Body)
 	res.Body.Close()
 


### PR DESCRIPTION
This method was not checking the error from doHttpRequest() yet still manipulating the reponse object and body. In some scenarios this can cause a panic when trying to read from the nil reponse body.

Fixes #462