### PR TITLE
Batches of n

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -111,7 +111,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 	}
 
 	processQueue := time.Now()
-	q.Process()
+	q.Wait()
 	tracerx.PerformanceSince("process queue", processQueue)
 	wait.Wait()
 }

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -38,7 +38,12 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		Panic(err, "Could not scan for Git LFS files")
 	}
 
-	q := lfs.NewDownloadQueue(lfs.Config.ConcurrentTransfers(), len(pointers))
+	totalSize := int64(0)
+	for _, p := range pointers {
+		totalSize += p.Size
+	}
+
+	q := lfs.NewDownloadQueue(lfs.Config.ConcurrentTransfers(), len(pointers), totalSize)
 
 	for _, p := range pointers {
 		q.Add(lfs.NewDownloadable(p))

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -40,9 +40,14 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 
 	q := lfs.NewDownloadQueue(lfs.Config.ConcurrentTransfers(), len(pointers))
 
+	size := int64(0)
 	for _, p := range pointers {
+		size += p.Size
 		q.Add(lfs.NewDownloadable(p))
 	}
+
+	pb := lfs.NewProgressMeter(len(pointers), size)
+	q.Monitor(pb)
 
 	target, err := git.ResolveRef(ref)
 	if err != nil {

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -40,14 +40,9 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 
 	q := lfs.NewDownloadQueue(lfs.Config.ConcurrentTransfers(), len(pointers))
 
-	size := int64(0)
 	for _, p := range pointers {
-		size += p.Size
 		q.Add(lfs.NewDownloadable(p))
 	}
-
-	pb := lfs.NewProgressMeter(len(pointers), size)
-	q.Monitor(pb)
 
 	target, err := git.ResolveRef(ref)
 	if err != nil {

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -72,11 +71,12 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 		Panic(err, "Error scanning for Git LFS files")
 	}
 
-	if len(pointers) > 0 && !prePushDryRun {
-		fmt.Fprintf(os.Stdout, "Checking %d Git LFS files\n", len(pointers))
+	totalSize := int64(0)
+	for _, p := range pointers {
+		totalSize += p.Size
 	}
 
-	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(pointers))
+	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(pointers), totalSize)
 
 	for _, pointer := range pointers {
 		if prePushDryRun {

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -95,7 +95,7 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if !prePushDryRun {
-		uploadQueue.Process()
+		uploadQueue.Wait()
 		for _, err := range uploadQueue.Errors() {
 			if Debugging || err.Panic {
 				LoggedError(err.Err, err.Error())

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -160,7 +160,7 @@ func pushCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if !pushDryRun {
-		uploadQueue.Process()
+		uploadQueue.Wait()
 		for _, err := range uploadQueue.Errors() {
 			if Debugging || err.Panic {
 				LoggedError(err.Err, err.Error())

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -32,16 +33,17 @@ func uploadsBetweenRefs(left string, right string) *lfs.TransferQueue {
 		Panic(err, "Error scanning for Git LFS files")
 	}
 
+	if len(pointers) > 0 && !pushDryRun {
+		fmt.Fprintf(os.Stdout, "Checking %d Git LFS files\n", len(pointers))
+	}
 	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(pointers))
 
-	size := int64(0)
 	for i, pointer := range pointers {
 		if pushDryRun {
 			Print("push %s", pointer.Name)
 			continue
 		}
 
-		size += pointer.Size
 		tracerx.Printf("prepare upload: %s %s %d/%d", pointer.Oid, pointer.Name, i+1, len(pointers))
 
 		u, wErr := lfs.NewUploadable(pointer.Oid, pointer.Name)
@@ -55,16 +57,14 @@ func uploadsBetweenRefs(left string, right string) *lfs.TransferQueue {
 		uploadQueue.Add(u)
 	}
 
-	pb := lfs.NewProgressMeter(len(pointers), size)
-	uploadQueue.Monitor(pb)
-
 	return uploadQueue
 }
 
 func uploadsWithObjectIDs(oids []string) *lfs.TransferQueue {
+	if len(oids) > 0 && !pushDryRun {
+		fmt.Fprintf(os.Stdout, "Checking %d Git LFS files\n", len(oids))
+	}
 	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(oids))
-
-	size := int64(0)
 
 	for i, oid := range oids {
 		if pushDryRun {
@@ -81,12 +81,8 @@ func uploadsWithObjectIDs(oids []string) *lfs.TransferQueue {
 				Exit(wErr.Error())
 			}
 		}
-		size += u.Size()
 		uploadQueue.Add(u)
 	}
-
-	pb := lfs.NewProgressMeter(len(oids), size)
-	uploadQueue.Monitor(pb)
 
 	return uploadQueue
 }

--- a/lfs/batcher.go
+++ b/lfs/batcher.go
@@ -1,0 +1,83 @@
+package lfs
+
+import "time"
+
+// Batcher provides a way to process a set of items in groups of n. Items can
+// be added to the batcher from multiple goroutines and pulled off in groups
+// when one of the following conditions occurs:
+//   * The batch size is reached
+//   * A timeout (default 250ms) has occurred between calls to Add()
+//   * Flush() is called
+//   * Exit() is called
+// When a timeout, Flush(), or Exit() occurs, the group may be smaller than the
+// batch size.
+type Batcher struct {
+	batchSize  int
+	input      chan Transferable
+	timeout    time.Duration
+	flush      chan interface{}
+	batchReady chan []Transferable
+}
+
+// NewBatcher creates a Batcher with the batchSize.
+func NewBatcher(batchSize int) *Batcher {
+	b := &Batcher{
+		batchSize:  batchSize,
+		input:      make(chan Transferable, batchSize),
+		timeout:    time.Millisecond * 250,
+		flush:      make(chan interface{}),
+		batchReady: make(chan []Transferable),
+	}
+
+	b.run()
+	return b
+}
+
+// Add adds an item to the batcher. Add is safe to call from multiple
+// goroutines.
+func (b *Batcher) Add(t Transferable) {
+	b.input <- t
+}
+
+// Next will wait for the one of the above batch triggers to occur and return
+// the accumulated batch.
+func (b *Batcher) Next() []Transferable {
+	return <-b.batchReady
+}
+
+// Exit stops all batching and allows Next() to return. Calling Add() after
+// calling Exit() will result in a panic.
+func (b *Batcher) Exit() {
+	close(b.input)
+}
+
+func (b *Batcher) run() {
+	go func() {
+		exit := false
+		for {
+			batch := make([]Transferable, 0, b.batchSize)
+		Loop:
+			for i := 0; i < b.batchSize; i++ {
+				select {
+				case t, ok := <-b.input:
+					if ok {
+						batch = append(batch, t)
+					} else {
+						exit = true // input channel was closed by Exit()
+						break Loop
+					}
+				case <-b.flush:
+					break Loop
+				case <-time.After(b.timeout):
+					break Loop
+				}
+			}
+
+			b.batchReady <- batch
+
+			if exit {
+				return
+			}
+		}
+	}()
+}

--- a/lfs/batcher.go
+++ b/lfs/batcher.go
@@ -1,12 +1,9 @@
 package lfs
 
-import "time"
-
 // Batcher provides a way to process a set of items in groups of n. Items can
 // be added to the batcher from multiple goroutines and pulled off in groups
 // when one of the following conditions occurs:
 //   * The batch size is reached
-//   * A timeout (default 250ms) has occurred between calls to Add()
 //   * Flush() is called
 //   * Exit() is called
 // When a timeout, Flush(), or Exit() occurs, the group may be smaller than the
@@ -14,7 +11,6 @@ import "time"
 type Batcher struct {
 	batchSize  int
 	input      chan Transferable
-	timeout    time.Duration
 	flush      chan interface{}
 	batchReady chan []Transferable
 }
@@ -24,7 +20,6 @@ func NewBatcher(batchSize int) *Batcher {
 	b := &Batcher{
 		batchSize:  batchSize,
 		input:      make(chan Transferable, batchSize),
-		timeout:    time.Millisecond * 250,
 		flush:      make(chan interface{}),
 		batchReady: make(chan []Transferable),
 	}
@@ -67,8 +62,6 @@ func (b *Batcher) run() {
 						break Loop
 					}
 				case <-b.flush:
-					break Loop
-				case <-time.After(b.timeout):
 					break Loop
 				}
 			}

--- a/lfs/batcher.go
+++ b/lfs/batcher.go
@@ -11,7 +11,6 @@ package lfs
 type Batcher struct {
 	batchSize  int
 	input      chan Transferable
-	flush      chan interface{}
 	batchReady chan []Transferable
 }
 
@@ -20,7 +19,6 @@ func NewBatcher(batchSize int) *Batcher {
 	b := &Batcher{
 		batchSize:  batchSize,
 		input:      make(chan Transferable, batchSize),
-		flush:      make(chan interface{}),
 		batchReady: make(chan []Transferable),
 	}
 
@@ -61,8 +59,6 @@ func (b *Batcher) run() {
 						exit = true // input channel was closed by Exit()
 						break Loop
 					}
-				case <-b.flush:
-					break Loop
 				}
 			}
 

--- a/lfs/batcher_test.go
+++ b/lfs/batcher_test.go
@@ -1,0 +1,47 @@
+package lfs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bmizerany/assert"
+)
+
+func TestBatcherSizeMet(t *testing.T) {
+	b := NewBatcher(2)
+
+	for i := 0; i < 4; i++ {
+		b.Add(&Downloadable{})
+	}
+
+	group := b.Next()
+	assert.Equal(t, 2, len(group))
+
+	group = b.Next()
+	assert.Equal(t, 2, len(group))
+}
+
+func TestBatcherTimeLimit(t *testing.T) {
+	b := NewBatcher(4)
+
+	for i := 0; i < 2; i++ {
+		b.Add(&Downloadable{})
+	}
+	time.Sleep(time.Millisecond * 251)
+
+	group := b.Next()
+	assert.Equal(t, 2, len(group))
+}
+
+func TestBatcherExit(t *testing.T) {
+	b := NewBatcher(4)
+
+	for i := 0; i < 2; i++ {
+		b.Add(&Downloadable{})
+	}
+
+	b.Exit()
+
+	group := b.Next()
+	assert.Equal(t, 2, len(group))
+}

--- a/lfs/batcher_test.go
+++ b/lfs/batcher_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bmizerany/assert"
+	"github.com/github/git-lfs/vendor/_nuts/github.com/technoweenie/assert"
 )
 
 func TestBatcherSizeMet(t *testing.T) {

--- a/lfs/batcher_test.go
+++ b/lfs/batcher_test.go
@@ -2,7 +2,6 @@ package lfs
 
 import (
 	"testing"
-	"time"
 
 	"github.com/github/git-lfs/vendor/_nuts/github.com/technoweenie/assert"
 )
@@ -18,18 +17,6 @@ func TestBatcherSizeMet(t *testing.T) {
 	assert.Equal(t, 2, len(group))
 
 	group = b.Next()
-	assert.Equal(t, 2, len(group))
-}
-
-func TestBatcherTimeLimit(t *testing.T) {
-	b := NewBatcher(4)
-
-	for i := 0; i < 2; i++ {
-		b.Add(&Downloadable{})
-	}
-	time.Sleep(time.Millisecond * 251)
-
-	group := b.Next()
 	assert.Equal(t, 2, len(group))
 }
 

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -22,13 +22,6 @@ const (
 	mediaType = "application/vnd.git-lfs+json; charset=utf-8"
 )
 
-// The apiEvent* statuses (and the apiEvent channel) are used by
-// UploadQueue to know when it is OK to process uploads concurrently.
-const (
-	apiEventFail = iota
-	apiEventSuccess
-)
-
 var (
 	lfsMediaTypeRE             = regexp.MustCompile(`\Aapplication/vnd\.git\-lfs\+json(;|\z)`)
 	jsonMediaTypeRE            = regexp.MustCompile(`\Aapplication/json(;|\z)`)
@@ -44,8 +37,6 @@ var (
 		404: "Repository or object not found: %s\nCheck that it exists and that you have proper access to it",
 		500: "Server error: %s",
 	}
-
-	apiEvent = make(chan int)
 )
 
 type objectResource struct {
@@ -111,12 +102,9 @@ func Download(oid string) (io.ReadCloser, int64, *WrappedError) {
 
 	res, obj, wErr := doApiRequest(req, creds)
 	if wErr != nil {
-		sendApiEvent(apiEventFail)
 		return nil, 0, wErr
 	}
 	LogTransfer("lfs.api.download", res)
-
-	sendApiEvent(apiEventSuccess)
 
 	req, creds, err = obj.NewRequest("download", "GET")
 	if err != nil {
@@ -201,7 +189,6 @@ func Batch(objects []*objectResource, operation string) ([]*objectResource, *Wra
 	res, objs, wErr := doApiBatchRequest(req, creds)
 	if wErr != nil {
 		if res == nil {
-			sendApiEvent(apiEventFail)
 			return nil, wErr
 		}
 
@@ -212,13 +199,11 @@ func Batch(objects []*objectResource, operation string) ([]*objectResource, *Wra
 			return Batch(objects, operation)
 		case 404, 410:
 			tracerx.Printf("api: batch not implemented: %d", res.StatusCode)
-			sendApiEvent(apiEventFail)
 			return nil, Error(newNotImplError())
 		}
 	}
 	LogTransfer("lfs.api.batch", res)
 
-	sendApiEvent(apiEventSuccess)
 	if res.StatusCode != 200 {
 		return nil, Errorf(nil, "Invalid status for %s %s: %d", req.Method, req.URL, res.StatusCode)
 	}
@@ -231,7 +216,6 @@ func UploadCheck(oidPath string) (*objectResource, *WrappedError) {
 
 	stat, err := os.Stat(oidPath)
 	if err != nil {
-		sendApiEvent(apiEventFail)
 		return nil, Error(err)
 	}
 
@@ -242,13 +226,11 @@ func UploadCheck(oidPath string) (*objectResource, *WrappedError) {
 
 	by, err := json.Marshal(reqObj)
 	if err != nil {
-		sendApiEvent(apiEventFail)
 		return nil, Error(err)
 	}
 
 	req, creds, err := newApiRequest("POST", oid)
 	if err != nil {
-		sendApiEvent(apiEventFail)
 		return nil, Error(err)
 	}
 
@@ -260,12 +242,9 @@ func UploadCheck(oidPath string) (*objectResource, *WrappedError) {
 	tracerx.Printf("api: uploading (%s)", oid)
 	res, obj, wErr := doApiRequest(req, creds)
 	if wErr != nil {
-		sendApiEvent(apiEventFail)
 		return nil, wErr
 	}
 	LogTransfer("lfs.api.upload", res)
-
-	sendApiEvent(apiEventSuccess)
 
 	if res.StatusCode == 200 {
 		return nil, nil
@@ -707,13 +686,6 @@ func setErrorHeaderContext(err *WrappedError, prefix string, head http.Header) {
 		} else {
 			err.Set(contextKey, head.Get(key))
 		}
-	}
-}
-
-func sendApiEvent(event int) {
-	select {
-	case apiEvent <- event:
-	default:
 	}
 }
 

--- a/lfs/download_queue.go
+++ b/lfs/download_queue.go
@@ -43,7 +43,7 @@ func (d *Downloadable) SetObject(o *objectResource) {
 
 // NewDownloadQueue builds a DownloadQueue, allowing `workers` concurrent downloads.
 func NewDownloadQueue(workers, files int) *TransferQueue {
-	q := newTransferQueue(workers, files)
+	q := newTransferQueue(workers)
 	q.transferKind = "download"
 	return q
 }

--- a/lfs/download_queue.go
+++ b/lfs/download_queue.go
@@ -42,8 +42,8 @@ func (d *Downloadable) SetObject(o *objectResource) {
 }
 
 // NewDownloadQueue builds a DownloadQueue, allowing `workers` concurrent downloads.
-func NewDownloadQueue(workers, files int) *TransferQueue {
-	q := newTransferQueue(workers)
+func NewDownloadQueue(workers, files int, size int64) *TransferQueue {
+	q := newTransferQueue(workers, files, size)
 	q.transferKind = "download"
 	return q
 }

--- a/lfs/pointer_smudge.go
+++ b/lfs/pointer_smudge.go
@@ -31,7 +31,6 @@ func PointerSmudge(writer io.Writer, ptr *Pointer, workingfile string, cb CopyCa
 	if statErr != nil || stat == nil {
 		wErr = downloadFile(writer, ptr, workingfile, mediafile, cb)
 	} else {
-		sendApiEvent(apiEventSuccess)
 		wErr = readLocalFile(writer, ptr, mediafile, cb)
 	}
 
@@ -64,12 +63,10 @@ func PointerSmudgeObject(ptr *Pointer, obj *objectResource, cb CopyCallback) err
 		wErr := downloadObject(ptr, obj, mediafile, cb)
 
 		if wErr != nil {
-			sendApiEvent(apiEventFail)
 			return &SmudgeError{obj.Oid, mediafile, wErr}
 		}
 	}
 
-	sendApiEvent(apiEventSuccess)
 	return nil
 }
 

--- a/lfs/progress_meter.go
+++ b/lfs/progress_meter.go
@@ -118,8 +118,8 @@ func (p *ProgressMeter) update() {
 	}
 
 	out := fmt.Sprintf("\r(%d of %d files), %s/%s",
-		p.transferringFiles,
 		p.finishedFiles,
+		p.transferringFiles,
 		formatBytes(p.currentBytes),
 		formatBytes(p.totalBytes))
 

--- a/lfs/progress_meter.go
+++ b/lfs/progress_meter.go
@@ -2,20 +2,20 @@ package lfs
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
 
 	"github.com/github/git-lfs/vendor/_nuts/github.com/cheggaaa/pb"
 )
 
-type ProgressTracker interface {
-	Log(event progressEvent, name string, read, total int64, current int)
-	Finish()
-}
-
 type ProgressMeter struct {
 	totalBytes   int64
+	startedFiles int64
 	totalFiles   int
-	startedFiles int
 	bar          *pb.ProgressBar
+	logger       *progressLogger
+	fileIndex    map[string]int64 // Maps a file name to its transfer number
 }
 
 type progressEvent int
@@ -33,19 +33,30 @@ func NewProgressMeter(files int, bytes int64) *ProgressMeter {
 	bar.Prefix(fmt.Sprintf("(0 of %d files) ", files))
 	bar.Start()
 
+	logger, err := newProgressLogger()
+	if err != nil {
+		// TODO display an error
+	}
+
 	return &ProgressMeter{
 		totalBytes: bytes,
 		totalFiles: files,
 		bar:        bar,
+		logger:     logger,
+		fileIndex:  make(map[string]int64),
 	}
 }
 
-func (p *ProgressMeter) Log(event progressEvent, name string, read, total int64, current int) {
+func (p *ProgressMeter) Log(event progressEvent, direction, name string, read, total int64, current int) {
 	switch event {
 	case transferStart:
-		p.startedFiles++
+		idx := atomic.AddInt64(&p.startedFiles, 1)
+		p.fileIndex[name] = idx
 	case transferBytes:
 		p.bar.Add(current)
+		p.logBytes(direction, name, read, total)
+	case transferFinish:
+		delete(p.fileIndex, name)
 	}
 
 	p.bar.Prefix(fmt.Sprintf("(%d of %d files) ", p.startedFiles, p.totalFiles))
@@ -53,4 +64,72 @@ func (p *ProgressMeter) Log(event progressEvent, name string, read, total int64,
 
 func (p *ProgressMeter) Finish() {
 	p.bar.Finish()
+	p.logger.Close()
+}
+
+func (p *ProgressMeter) logBytes(direction, name string, read, total int64) {
+	idx := p.fileIndex[name]
+	line := fmt.Sprintf("%s %d/%d %d/%d %s\n", direction, idx, p.totalFiles, read, total, name)
+	if err := p.logger.Write([]byte(line)); err != nil {
+		p.logger.Shutdown()
+	}
+}
+
+// progressLogger provides a wrapper around an os.File that can either
+// write to the file or ignore all writes completely.
+type progressLogger struct {
+	writeData bool
+	log       *os.File
+}
+
+// Write will write to the file and perform a Sync() if writing succeeds.
+func (l *progressLogger) Write(b []byte) error {
+	if l.writeData {
+		if _, err := l.log.Write(b); err != nil {
+			return err
+		}
+		return l.log.Sync()
+	}
+	return nil
+}
+
+// Close will call Close() on the underlying file
+func (l *progressLogger) Close() error {
+	if l.log != nil {
+		return l.log.Close()
+	}
+	return nil
+}
+
+// Shutdown will cause the logger to ignore any further writes. It should
+// be used when writing causes an error.
+func (l *progressLogger) Shutdown() {
+	l.writeData = false
+}
+
+// newProgressLogger creates a progressLogger based on the presence of
+// the GIT_LFS_PROGRESS environment variable. If it is present and a log file
+// is able to be created, the logger will write to the file. If it is absent,
+// or there is an err creating the file, the logger will ignore all writes.
+func newProgressLogger() (*progressLogger, error) {
+	logPath := Config.Getenv("GIT_LFS_PROGRESS")
+
+	if len(logPath) == 0 {
+		return &progressLogger{}, nil
+	}
+	if !filepath.IsAbs(logPath) {
+		return &progressLogger{}, fmt.Errorf("GIT_LFS_PROGRESS must be an absolute path")
+	}
+
+	cbDir := filepath.Dir(logPath)
+	if err := os.MkdirAll(cbDir, 0755); err != nil {
+		return &progressLogger{}, err
+	}
+
+	file, err := os.OpenFile(logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		return &progressLogger{}, err
+	}
+
+	return &progressLogger{true, file}, nil
 }

--- a/lfs/progress_meter.go
+++ b/lfs/progress_meter.go
@@ -1,0 +1,56 @@
+package lfs
+
+import (
+	"fmt"
+
+	"github.com/github/git-lfs/vendor/_nuts/github.com/cheggaaa/pb"
+)
+
+type ProgressTracker interface {
+	Log(event progressEvent, name string, read, total int64, current int)
+	Finish()
+}
+
+type ProgressMeter struct {
+	totalBytes   int64
+	totalFiles   int
+	startedFiles int
+	bar          *pb.ProgressBar
+}
+
+type progressEvent int
+
+const (
+	transferStart = iota
+	transferBytes
+	transferFinish
+)
+
+func NewProgressMeter(files int, bytes int64) *ProgressMeter {
+	bar := pb.New64(bytes)
+	bar.SetUnits(pb.U_BYTES)
+	bar.ShowBar = false
+	bar.Prefix(fmt.Sprintf("(0 of %d files) ", files))
+	bar.Start()
+
+	return &ProgressMeter{
+		totalBytes: bytes,
+		totalFiles: files,
+		bar:        bar,
+	}
+}
+
+func (p *ProgressMeter) Log(event progressEvent, name string, read, total int64, current int) {
+	switch event {
+	case transferStart:
+		p.startedFiles++
+	case transferBytes:
+		p.bar.Add(current)
+	}
+
+	p.bar.Prefix(fmt.Sprintf("(%d of %d files) ", p.startedFiles, p.totalFiles))
+}
+
+func (p *ProgressMeter) Finish() {
+	p.bar.Finish()
+}

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -127,7 +127,7 @@ func (q *TransferQueue) individualApiRoutine(apiWaiter chan interface{}) {
 
 // legacyFallback is used when a batch request is made to a server that does
 // not support the batch endpoint. When this happens, the Transferables are
-// feed from the batcher into apic to be processed individually.
+// fed from the batcher into apic to be processed individually.
 func (q *TransferQueue) legacyFallback(failedBatch []Transferable) {
 	tracerx.Printf("tq: batch api not implemented, falling back to individual")
 

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -119,6 +119,7 @@ func (q *TransferQueue) individualApiRoutine(apiWaiter chan interface{}) {
 
 		if obj != nil {
 			t.SetObject(obj)
+			q.meter.Add(t.Name(), t.Size())
 			q.transferc <- t
 		}
 	}
@@ -183,6 +184,7 @@ func (q *TransferQueue) batchApiRoutine() {
 				// This object needs to be transferred
 				if transfer, ok := q.transferables[o.Oid]; ok {
 					transfer.SetObject(o)
+					q.meter.Add(transfer.Name(), transfer.Size())
 					q.transferc <- transfer
 				} else {
 					q.meter.Skip()
@@ -210,7 +212,6 @@ func (q *TransferQueue) transferWorker() {
 			return nil
 		}
 
-		q.meter.Add(transfer.Name(), transfer.Size())
 		if err := transfer.Transfer(cb); err != nil {
 			q.errorc <- err
 		} else {

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -168,6 +168,8 @@ func (q *TransferQueue) batchApiRoutine() {
 			break
 		}
 
+		tracerx.Printf("tq: sending batch of size %d", len(batch))
+
 		transfers := make([]*objectResource, 0, len(batch))
 		for _, t := range batch {
 			transfers = append(transfers, &objectResource{Oid: t.Oid(), Size: t.Size()})
@@ -281,14 +283,17 @@ func (q *TransferQueue) run() {
 	go q.errorCollector()
 	go q.progressMonitor()
 
+	tracerx.Printf("tq: starting %d transfer workers", q.workers)
 	for i := 0; i < q.workers; i++ {
 		go q.transferWorker()
 	}
 
 	if Config.BatchTransfer() {
+		tracerx.Printf("tq: running as batched queue, batch size of %d", batchSize)
 		q.batcher = NewBatcher(batchSize)
 		go q.batchApiRoutine()
 	} else {
+		tracerx.Printf("tq: running as individual queue")
 		q.launchIndividualApiRoutines()
 	}
 }

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -180,7 +180,7 @@ func (q *TransferQueue) batchApiRoutine() {
 
 		for _, o := range objects {
 			if _, ok := o.Links[q.transferKind]; ok {
-				// This object needs to be transfered
+				// This object needs to be transferred
 				if transfer, ok := q.transferables[o.Oid]; ok {
 					transfer.SetObject(o)
 					q.transferc <- transfer

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -208,7 +208,7 @@ func (q *TransferQueue) errorCollector() {
 func (q *TransferQueue) transferWorker() {
 	for transfer := range q.transferc {
 		cb := func(total, read int64, current int) error {
-			q.meter.Log(transferBytes, q.transferKind, transfer.Name(), read, total, current)
+			q.meter.TransferBytes(q.transferKind, transfer.Name(), read, total, current)
 			return nil
 		}
 
@@ -221,7 +221,7 @@ func (q *TransferQueue) transferWorker() {
 			}
 		}
 
-		q.meter.Log(transferFinish, q.transferKind, transfer.Name(), 0, 0, 0)
+		q.meter.FinishTransfer(transfer.Name())
 
 		q.wait.Done()
 	}

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -162,8 +162,6 @@ func (q *TransferQueue) batchApiRoutine() {
 				}
 			}
 		}
-
-		sendApiEvent(apiEventSuccess) // Wake up transfer workers
 	}
 }
 

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -174,6 +174,8 @@ func (q *TransferQueue) batchApiRoutine() {
 				go q.legacyFallback(batch)
 				return
 			}
+			q.errorc <- err
+			continue
 		}
 
 		for _, o := range objects {

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/cheggaaa/pb"
-	"github.com/rubyist/tracerx"
+	"github.com/github/git-lfs/vendor/_nuts/github.com/rubyist/tracerx"
 )
 
 const (

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -184,7 +184,11 @@ func (q *TransferQueue) batchApiRoutine() {
 				if transfer, ok := q.transferables[o.Oid]; ok {
 					transfer.SetObject(o)
 					q.transferc <- transfer
+				} else {
+					q.wait.Done()
 				}
+			} else {
+				q.wait.Done()
 			}
 		}
 	}

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -72,7 +72,7 @@ func (u *Uploadable) SetObject(o *objectResource) {
 
 // NewUploadQueue builds an UploadQueue, allowing `workers` concurrent uploads.
 func NewUploadQueue(workers, files int) *TransferQueue {
-	q := newTransferQueue(workers, files)
+	q := newTransferQueue(workers)
 	q.transferKind = "upload"
 	return q
 }

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -71,8 +71,8 @@ func (u *Uploadable) SetObject(o *objectResource) {
 }
 
 // NewUploadQueue builds an UploadQueue, allowing `workers` concurrent uploads.
-func NewUploadQueue(workers, files int) *TransferQueue {
-	q := newTransferQueue(workers)
+func NewUploadQueue(workers, files int, size int64) *TransferQueue {
+	q := newTransferQueue(workers, files, size)
 	q.transferKind = "upload"
 	return q
 }

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -17,7 +17,7 @@ begin_test "pre-push"
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
-  grep "(0 of 0 files) 0 B 0" push.log
+  grep "(0 of 0 files)" push.log
 
   git lfs track "*.dat"
   echo "hi" > hi.dat
@@ -67,6 +67,7 @@ begin_test "pre-push dry-run"
     git lfs pre-push --dry-run origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
   grep "push hi.dat" push.log
+  cat push.log
   [ `wc -l < push.log` = 1 ]
 
   refute_server_object "$reponame" 2840e0eafda1d0760771fe28b91247cf81c76aa888af28a850b5648a338dc15b

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -17,7 +17,6 @@ begin_test "push"
 
   git lfs push origin master 2>&1 | tee push.log
   grep "(1 of 1 files)" push.log
-  [ $(wc -l < push.log) -eq 1 ]
 
   git checkout -b push-b
   echo "push b" > b.dat
@@ -26,7 +25,6 @@ begin_test "push"
 
   git lfs push origin push-b 2>&1 | tee push.log
   grep "(2 of 2 files)" push.log
-  [ $(wc -l < push.log) -eq 1 ]
 )
 end_test
 
@@ -74,7 +72,6 @@ begin_test "push object id(s)"
     4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
     2>&1 | tee push.log
   grep "(1 of 1 files)" push.log
-  [ $(wc -l < push.log) -eq 1 ]
 
   echo "push b" > b.dat
   git add b.dat
@@ -85,6 +82,5 @@ begin_test "push object id(s)"
     82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 \
     2>&1 | tee push.log
   grep "(2 of 2 files)" push.log
-  [ $(wc -l < push.log) -eq 1 ]
 )
 end_test


### PR DESCRIPTION
This PR splits up batch requests into several batches of `n` (currently hardcoded to 100).

- [x] Progress counters are a little off
- [x] Handle errors to the batch call, resubmit batch or track failures
- [x] Test with many thousands of files