### PR TITLE
Dependency linter

### DIFF
--- a/script/fmt
+++ b/script/fmt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 formatter=gofmt
 hash goimports 2>/dev/null && {
@@ -12,3 +12,10 @@ for i in */ ; do
     $formatter -w -l "$@" "${i%?}"
   fi
 done
+
+msg=`script/lint`
+if [ $? -ne 0 ];
+then
+  echo "$msg"
+  exit 1
+fi

--- a/script/fmt
+++ b/script/fmt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 formatter=gofmt
 hash goimports 2>/dev/null && {

--- a/script/lint
+++ b/script/lint
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+deps=$(go list -f '{{join .Deps "\n"}}' . | xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' | grep -v "github.com/github/git-lfs")
+
+# exit 0 means non-vendored deps were found
+if [ $? -eq 0 ];
+then
+  echo "Non vendored dependencies found:"
+  for d in $deps; do echo "\t$d"; done
+  exit 1
+else
+  echo "Looks good!"
+fi
+

--- a/script/lint
+++ b/script/lint
@@ -7,8 +7,10 @@ if [ $? -eq 0 ];
 then
   echo "Non vendored dependencies found:"
   for d in $deps; do echo "\t$d"; done
+  echo
+  echo "These dependencies should be tracked in 'Nut.toml', with an import prefix of:"
+  echo "\tgithub.com/github/git-lfs/vendor/_nuts"
   exit 1
 else
   echo "Looks good!"
 fi
-


### PR DESCRIPTION
A quick script to warn about importing third party packages directly instead of via nut (i.e. vendored).

Example output if you mistakenly import directly (with an exit code of 1):

```
$ ./script/lint
Non vendored dependencies found:
	github.com/cheggaaa/pb
	github.com/rubyist/tracerx
```

Normal output (with an exit code of 0):

```
$  ./script/lint
Looks good!
```
