### PR TITLE
ensure http responses always have a body

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -358,7 +358,15 @@ func UploadObject(o *objectResource, cb CopyCallback) *WrappedError {
 }
 
 func doHttpRequest(req *http.Request, creds Creds) (*http.Response, *WrappedError) {
-	res, err := DoHTTP(req)
+	res, err := Config.HttpClient().Do(req)
+	if res == nil {
+		res = &http.Response{
+			StatusCode: 0,
+			Header:     make(http.Header),
+			Request:    req,
+			Body:       ioutil.NopCloser(bytes.NewBufferString("")),
+		}
+	}
 
 	var wErr *WrappedError
 

--- a/lfs/http.go
+++ b/lfs/http.go
@@ -98,14 +98,6 @@ func (c *HttpClient) Do(req *http.Request) (*http.Response, error) {
 	return res, err
 }
 
-func DoHTTP(req *http.Request) (*http.Response, error) {
-	res, err := Config.HttpClient().Do(req)
-	if res == nil {
-		res = &http.Response{StatusCode: 0, Header: make(http.Header), Request: req}
-	}
-	return res, err
-}
-
 func (c *Configuration) HttpClient() *HttpClient {
 	if c.httpClient != nil {
 		return c.httpClient


### PR DESCRIPTION
The `doHttpRequest()` function sometimes returns an HTTP response with no body. This is so we don't need `res` nil checks in places [like this](https://github.com/github/git-lfs/blob/bbf2d1654f924cfaca9aa7dbfa124c36471cfc9e/lfs/client.go#L374).

Should fix #317 and #487