### PR TITLE
initial backport script

### DIFF
--- a/script/backport-pr
+++ b/script/backport-pr
@@ -48,14 +48,11 @@ if [ "$conflicts" ]; then
 fi
 
 git commit -q --allow-empty --amend -m "$commitmsg"
-git push -q -f internal $prbranch
+git push -q -f origin $prbranch
 git checkout -q -f $relbranch
 git branch -q -D $prbranch
 
-git push -q -f internal $relbranch
-
-#curl -in $pullsurl -d "{
-curl -in https://api.github.com/repos/github/git-lfs-internal/pulls -d "{
+curl -in $pullsurl -d "{
   \"title\": \"Backport #$pr for $relversion: $prtitle\",
   \"head\": \"$prbranch\",
   \"base\": \"$relbranch\",

--- a/script/backport-pr
+++ b/script/backport-pr
@@ -33,7 +33,7 @@ git log -1 $commit
 conflicts=""
 
 git cherry-pick -x --allow-empty -m1 $commit &> /dev/null || {
-  unmerged=$(git ls-files --unmerged --stage | cut -f 2 -d$'\t')
+  unmerged=$(git ls-files --unmerged --stage | cut -f 2 -d$'\t' | uniq)
   conflicts="\n\nConflicting files:"
   for file in $unmerged; do
     git add "$file"

--- a/script/backport-pr
+++ b/script/backport-pr
@@ -1,0 +1,63 @@
+#!/bin/sh
+#
+# Backports a PR into a release branch:
+#
+#   # backport PR #123 into release-0.5-backport-123
+#   $ script/backport-pr 0.5 123
+
+relversion="v$1.x"
+relbranch="release-$1"
+pr="$2"
+prbranch="$relbranch-backport-$pr"
+pullsurl="https://api.github.com/repos/github/git-lfs/pulls"
+prurl="https://api.github.com/repos/github/git-lfs/pulls/$pr"
+prjson="$(curl -n $pullsurl/$pr 2>/dev/null)"
+headref="$(echo $prjson | jq -r -e ".head.ref")"
+[ "$?" -ne 0 ] && {
+  echo "PR #$pr is invalid."
+  exit 1
+}
+prtitle="$(echo $prjson | jq -r ".title" | sed "s/\"/'/g")"
+
+git checkout -q -f $relbranch
+git clean -q -fdx
+git pull -q
+git checkout -q -f -B $prbranch
+
+commit=`git log -1 --pretty=%H "--grep=Merge pull request #$pr" "--grep=Merge branch '.*$headref'" master`
+
+echo "Backporting:\n"
+
+git log -1 $commit
+
+conflicts=""
+
+git cherry-pick -x --allow-empty -m1 $commit &> /dev/null || {
+  unmerged=$(git ls-files --unmerged --stage | cut -f 2 -d$'\t')
+  conflicts="\n\nConflicting files:"
+  for file in $unmerged; do
+    git add "$file"
+    conflicts="$conflicts\n- $file"
+  done
+  git commit -q --no-edit
+}
+
+commitmsg="Backport $headref from #$pr to $relbranch"
+if [ "$conflicts" ]; then
+  commitmsg="$commitmsg [merge conflicts]"
+fi
+
+git commit -q --allow-empty --amend -m "$commitmsg"
+git push -q -f internal $prbranch
+git checkout -q -f $relbranch
+git branch -q -D $prbranch
+
+git push -q -f internal $relbranch
+
+#curl -in $pullsurl -d "{
+curl -in https://api.github.com/repos/github/git-lfs-internal/pulls -d "{
+  \"title\": \"Backport #$pr for $relversion: $prtitle\",
+  \"head\": \"$prbranch\",
+  \"base\": \"$relbranch\",
+  \"body\": \"This backports #$pr.$conflicts\"
+}" 2>/dev/null


### PR DESCRIPTION
Porting over a backport script from ruby to sh that we use internally at GitHub.

![backport__475_for_v0_5_x__use_-text_instead_of_-crlf_by_technoweenie_ _pull_request__13_ _github_git-lfs-internal](https://cloud.githubusercontent.com/assets/21/8815133/42ade492-2fd2-11e5-800c-e5c2293da98c.jpg)

While experimenting with this, I'm pushing to an internal repo that we use for testing.