### PR TITLE
Backport #404 for v0.5.x: Improved SSH support: non-bare urls, custom ports, and GIT_SSH/plink

### DIFF
--- a/lfs/config.go
+++ b/lfs/config.go
@@ -51,6 +51,16 @@ func (c *Configuration) Getenv(key string) string {
 	return v
 }
 
+func (c *Configuration) Setenv(key, value string) error {
+	// Check see if we have this in our cache, if so update it
+	if _, ok := c.envVars[key]; ok {
+		c.envVars[key] = value
+	}
+
+	// Now set in process
+	return os.Setenv(key, value)
+}
+
 // GetenvBool parses a boolean environment variable and returns the result as a bool.
 // If the environment variable is unset, empty, or if the parsing fails,
 // the value of def (default) is returned instead.

--- a/lfs/config_test.go
+++ b/lfs/config_test.go
@@ -102,11 +102,12 @@ func TestSSHEndpointOverridden(t *testing.T) {
 	assert.Equal(t, "lfs", endpoint.Url)
 	assert.Equal(t, "", endpoint.SshUserAndHost)
 	assert.Equal(t, "", endpoint.SshPath)
+	assert.Equal(t, "", endpoint.SshPort)
 }
 
 func TestSSHEndpointAddsLfsSuffix(t *testing.T) {
 	config := &Configuration{
-		gitConfig: map[string]string{"remote.origin.url": "git@example.com:foo/bar"},
+		gitConfig: map[string]string{"remote.origin.url": "ssh://git@example.com/foo/bar"},
 		remotes:   []string{},
 	}
 
@@ -114,6 +115,20 @@ func TestSSHEndpointAddsLfsSuffix(t *testing.T) {
 	assert.Equal(t, "https://example.com/foo/bar.git/info/lfs", endpoint.Url)
 	assert.Equal(t, "git@example.com", endpoint.SshUserAndHost)
 	assert.Equal(t, "foo/bar", endpoint.SshPath)
+	assert.Equal(t, "", endpoint.SshPort)
+}
+
+func TestSSHCustomPortEndpointAddsLfsSuffix(t *testing.T) {
+	config := &Configuration{
+		gitConfig: map[string]string{"remote.origin.url": "ssh://git@example.com:9000/foo/bar"},
+		remotes:   []string{},
+	}
+
+	endpoint := config.Endpoint()
+	assert.Equal(t, "https://example.com/foo/bar.git/info/lfs", endpoint.Url)
+	assert.Equal(t, "git@example.com", endpoint.SshUserAndHost)
+	assert.Equal(t, "foo/bar", endpoint.SshPath)
+	assert.Equal(t, "9000", endpoint.SshPort)
 }
 
 func TestBareSSHEndpointAddsLfsSuffix(t *testing.T) {
@@ -126,6 +141,20 @@ func TestBareSSHEndpointAddsLfsSuffix(t *testing.T) {
 	assert.Equal(t, "https://example.com/foo/bar.git/info/lfs", endpoint.Url)
 	assert.Equal(t, "git@example.com", endpoint.SshUserAndHost)
 	assert.Equal(t, "foo/bar.git", endpoint.SshPath)
+	assert.Equal(t, "", endpoint.SshPort)
+}
+
+func TestSSHEndpointFromGlobalLfsUrl(t *testing.T) {
+	config := &Configuration{
+		gitConfig: map[string]string{"lfs.url": "git@example.com:foo/bar.git"},
+		remotes:   []string{},
+	}
+
+	endpoint := config.Endpoint()
+	assert.Equal(t, "https://example.com/foo/bar.git", endpoint.Url)
+	assert.Equal(t, "git@example.com", endpoint.SshUserAndHost)
+	assert.Equal(t, "foo/bar.git", endpoint.SshPath)
+	assert.Equal(t, "", endpoint.SshPort)
 }
 
 func TestHTTPEndpointAddsLfsSuffix(t *testing.T) {
@@ -138,6 +167,7 @@ func TestHTTPEndpointAddsLfsSuffix(t *testing.T) {
 	assert.Equal(t, "http://example.com/foo/bar.git/info/lfs", endpoint.Url)
 	assert.Equal(t, "", endpoint.SshUserAndHost)
 	assert.Equal(t, "", endpoint.SshPath)
+	assert.Equal(t, "", endpoint.SshPort)
 }
 
 func TestBareHTTPEndpointAddsLfsSuffix(t *testing.T) {
@@ -150,6 +180,7 @@ func TestBareHTTPEndpointAddsLfsSuffix(t *testing.T) {
 	assert.Equal(t, "http://example.com/foo/bar.git/info/lfs", endpoint.Url)
 	assert.Equal(t, "", endpoint.SshUserAndHost)
 	assert.Equal(t, "", endpoint.SshPath)
+	assert.Equal(t, "", endpoint.SshPort)
 }
 
 func TestObjectUrl(t *testing.T) {

--- a/lfs/endpoint.go
+++ b/lfs/endpoint.go
@@ -10,13 +10,12 @@ import (
 
 const EndpointUrlUnknown = "<unknown>"
 
-var httpPrefixRe = regexp.MustCompile("\\Ahttps?://")
-
 // An Endpoint describes how to access a Git LFS server.
 type Endpoint struct {
 	Url            string
 	SshUserAndHost string
 	SshPath        string
+	SshPort        string
 }
 
 // NewEndpointFromCloneURL creates an Endpoint from a git clone URL by appending
@@ -37,21 +36,97 @@ func NewEndpointFromCloneURL(url string) Endpoint {
 }
 
 // NewEndpoint initializes a new Endpoint for a given URL.
-func NewEndpoint(url string) Endpoint {
-	e := Endpoint{Url: url}
-
-	if httpPrefixRe.MatchString(url) {
-		return e
+func NewEndpoint(rawurl string) Endpoint {
+	var endpoint Endpoint
+	// Check for SSH URLs
+	// Support ssh://user@host.com/path/to/repo and user@host.com:path/to/repo
+	u, err := url.Parse(rawurl)
+	if err == nil {
+		u = processBareSshUrl(u)
+		switch u.Scheme {
+		case "ssh":
+			endpoint = endpointFromSshUrl(u)
+		case "http", "https":
+			endpoint = endpointFromHttpUrl(u)
+		default:
+			// Just passthrough to preserve
+			endpoint = Endpoint{Url: rawurl}
+		}
+	} else {
+		endpoint = Endpoint{Url: EndpointUrlUnknown}
 	}
 
-	pieces := strings.SplitN(e.Url, ":", 2)
-	hostPieces := strings.SplitN(pieces[0], "@", 2)
-	if len(hostPieces) == 2 {
-		e.SshUserAndHost = pieces[0]
-		e.SshPath = pieces[1]
-		e.Url = fmt.Sprintf("https://%s/%s", hostPieces[1], pieces[1])
+	return endpoint
+}
+
+// For ease of processing, sanitise a bare Git SSH URL into a ssh:// URL
+func processBareSshUrl(u *url.URL) *url.URL {
+	if u.Scheme != "" || u.Path == "" {
+		return u
 	}
-	return e
+	// This might be a bare SSH URL
+	// Turn it into ssh:// for simplicity of extraction later
+	parts := strings.Split(u.Path, ":")
+	if len(parts) > 1 {
+		// Treat presence of ':' as a bare URL
+		var newPath string
+		if len(parts) > 2 { // port included; really should only ever be 3 parts
+			newPath = fmt.Sprintf("%v:%v", parts[0], strings.Join(parts[1:], "/"))
+		} else {
+			newPath = strings.Join(parts, "/")
+		}
+		newrawurl := fmt.Sprintf("ssh://%v", newPath)
+		newu, err := url.Parse(newrawurl)
+		if err == nil {
+			return newu
+		}
+	}
+	return u
+}
+
+// Construct a new endpoint from a SSH URL (sanitised to ssh://)
+func endpointFromSshUrl(u *url.URL) Endpoint {
+	if u.Scheme != "ssh" {
+		return Endpoint{Url: EndpointUrlUnknown}
+	}
+	var host string
+	var endpoint Endpoint
+	// Pull out port now, we need it separately for SSH
+	regex := regexp.MustCompile(`^([^\:]+)(?:\:(\d+))?$`)
+	if match := regex.FindStringSubmatch(u.Host); match != nil {
+		host = match[1]
+		if u.User != nil && u.User.Username() != "" {
+			endpoint.SshUserAndHost = fmt.Sprintf("%s@%s", u.User.Username(), host)
+		} else {
+			endpoint.SshUserAndHost = host
+		}
+		if len(match) > 2 {
+			endpoint.SshPort = match[2]
+		}
+	} else {
+		endpoint.Url = EndpointUrlUnknown
+		return endpoint
+	}
+
+	// u.Path includes a preceding '/', strip off manually
+	// rooted paths in the URL will be '//path/to/blah'
+	// this is just how Go's URL parsing works
+	if strings.HasPrefix(u.Path, "/") {
+		endpoint.SshPath = u.Path[1:]
+	} else {
+		endpoint.SshPath = u.Path
+	}
+	// Fallback URL for using HTTPS while still using SSH for git
+	// u.Host includes host & port so can't use SSH port
+	endpoint.Url = fmt.Sprintf("https://%s%s", host, u.Path)
+
+	return endpoint
+}
+
+// Construct a new endpoint from a HTTP URL
+func endpointFromHttpUrl(u *url.URL) Endpoint {
+	// just pass this straight through
+	return Endpoint{Url: u.String()}
 }
 
 func ObjectUrl(endpoint Endpoint, oid string) (*url.URL, error) {

--- a/lfs/ssh.go
+++ b/lfs/ssh.go
@@ -55,16 +55,20 @@ func sshGetExeAndArgs(endpoint Endpoint) (exe string, baseargs []string) {
 		return "", nil
 	}
 
+	isPlink := false
+	isTortoise := false
+
 	ssh := Config.Getenv("GIT_SSH")
-	basessh := filepath.Base(ssh)
-	// Strip extension for easier comparison
-	if ext := filepath.Ext(basessh); len(ext) > 0 {
-		basessh = basessh[:len(basessh)-len(ext)]
-	}
-	isPlink := strings.EqualFold(basessh, "plink")
-	isTortoise := strings.EqualFold(basessh, "tortoiseplink")
 	if ssh == "" {
 		ssh = "ssh"
+	} else {
+		basessh := filepath.Base(ssh)
+		// Strip extension for easier comparison
+		if ext := filepath.Ext(basessh); len(ext) > 0 {
+			basessh = basessh[:len(basessh)-len(ext)]
+		}
+		isPlink = strings.EqualFold(basessh, "plink")
+		isTortoise = strings.EqualFold(basessh, "tortoiseplink")
 	}
 
 	args := make([]string, 0, 4)

--- a/lfs/ssh.go
+++ b/lfs/ssh.go
@@ -3,6 +3,8 @@ package lfs
 import (
 	"encoding/json"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/github/git-lfs/vendor/_nuts/github.com/rubyist/tracerx"
 )
@@ -15,6 +17,10 @@ type sshAuthResponse struct {
 }
 
 func sshAuthenticate(endpoint Endpoint, operation, oid string) (sshAuthResponse, error) {
+
+	// This is only used as a fallback where the Git URL is SSH but server doesn't support a full SSH binary protocol
+	// and therefore we derive a HTTPS endpoint for binaries instead; but check authentication here via SSH
+
 	res := sshAuthResponse{}
 	if len(endpoint.SshUserAndHost) == 0 {
 		return res, nil
@@ -22,11 +28,14 @@ func sshAuthenticate(endpoint Endpoint, operation, oid string) (sshAuthResponse,
 
 	tracerx.Printf("ssh: %s git-lfs-authenticate %s %s %s",
 		endpoint.SshUserAndHost, endpoint.SshPath, operation, oid)
-	cmd := exec.Command("ssh", endpoint.SshUserAndHost,
+
+	exe, args := sshGetExeAndArgs(endpoint)
+	args = append(args,
 		"git-lfs-authenticate",
 		endpoint.SshPath,
-		operation, oid,
-	)
+		operation, oid)
+
+	cmd := exec.Command(exe, args...)
 
 	out, err := cmd.CombinedOutput()
 
@@ -37,4 +46,42 @@ func sshAuthenticate(endpoint Endpoint, operation, oid string) (sshAuthResponse,
 	}
 
 	return res, err
+}
+
+// Return the executable name for ssh on this machine and the base args
+// Base args includes port settings, user/host, everything pre the command to execute
+func sshGetExeAndArgs(endpoint Endpoint) (exe string, baseargs []string) {
+	if len(endpoint.SshUserAndHost) == 0 {
+		return "", nil
+	}
+
+	ssh := Config.Getenv("GIT_SSH")
+	basessh := filepath.Base(ssh)
+	// Strip extension for easier comparison
+	if ext := filepath.Ext(basessh); len(ext) > 0 {
+		basessh = basessh[:len(basessh)-len(ext)]
+	}
+	isPlink := strings.EqualFold(basessh, "plink")
+	isTortoise := strings.EqualFold(basessh, "tortoiseplink")
+	if ssh == "" {
+		ssh = "ssh"
+	}
+
+	args := make([]string, 0, 4)
+	if isTortoise {
+		// TortoisePlink requires the -batch argument to behave like ssh/plink
+		args = append(args, "-batch")
+	}
+
+	if len(endpoint.SshPort) > 0 {
+		if isPlink || isTortoise {
+			args = append(args, "-P")
+		} else {
+			args = append(args, "-p")
+		}
+		args = append(args, endpoint.SshPort)
+	}
+	args = append(args, endpoint.SshUserAndHost)
+
+	return ssh, args
 }

--- a/lfs/ssh_test.go
+++ b/lfs/ssh_test.go
@@ -1,0 +1,91 @@
+package lfs
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/github/git-lfs/vendor/_nuts/github.com/technoweenie/assert"
+)
+
+func TestSSHGetExeAndArgsSsh(t *testing.T) {
+	endpoint := Config.Endpoint()
+	endpoint.SshUserAndHost = "user@foo.com"
+	oldGITSSH := Config.Getenv("GIT_SSH")
+	Config.Setenv("GIT_SSH", "")
+	exe, args := sshGetExeAndArgs(endpoint)
+	assert.Equal(t, "ssh", exe)
+	assert.Equal(t, []string{"user@foo.com"}, args)
+
+	Config.Setenv("GIT_SSH", oldGITSSH)
+}
+
+func TestSSHGetExeAndArgsSshCustomPort(t *testing.T) {
+	endpoint := Config.Endpoint()
+	endpoint.SshUserAndHost = "user@foo.com"
+	endpoint.SshPort = "8888"
+	oldGITSSH := Config.Getenv("GIT_SSH")
+	Config.Setenv("GIT_SSH", "")
+	exe, args := sshGetExeAndArgs(endpoint)
+	assert.Equal(t, "ssh", exe)
+	assert.Equal(t, []string{"-p", "8888", "user@foo.com"}, args)
+
+	Config.Setenv("GIT_SSH", oldGITSSH)
+}
+
+func TestSSHGetExeAndArgsPlink(t *testing.T) {
+	endpoint := Config.Endpoint()
+	endpoint.SshUserAndHost = "user@foo.com"
+	oldGITSSH := Config.Getenv("GIT_SSH")
+	// this will run on non-Windows platforms too but no biggie
+	plink := filepath.Join("Users", "joebloggs", "bin", "plink.exe")
+	Config.Setenv("GIT_SSH", plink)
+	exe, args := sshGetExeAndArgs(endpoint)
+	assert.Equal(t, plink, exe)
+	assert.Equal(t, []string{"user@foo.com"}, args)
+
+	Config.Setenv("GIT_SSH", oldGITSSH)
+}
+
+func TestSSHGetExeAndArgsPlinkCustomPort(t *testing.T) {
+	endpoint := Config.Endpoint()
+	endpoint.SshUserAndHost = "user@foo.com"
+	endpoint.SshPort = "8888"
+	oldGITSSH := Config.Getenv("GIT_SSH")
+	// this will run on non-Windows platforms too but no biggie
+	plink := filepath.Join("Users", "joebloggs", "bin", "plink")
+	Config.Setenv("GIT_SSH", plink)
+	exe, args := sshGetExeAndArgs(endpoint)
+	assert.Equal(t, plink, exe)
+	assert.Equal(t, []string{"-P", "8888", "user@foo.com"}, args)
+
+	Config.Setenv("GIT_SSH", oldGITSSH)
+}
+
+func TestSSHGetExeAndArgsTortoisePlink(t *testing.T) {
+	endpoint := Config.Endpoint()
+	endpoint.SshUserAndHost = "user@foo.com"
+	oldGITSSH := Config.Getenv("GIT_SSH")
+	// this will run on non-Windows platforms too but no biggie
+	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink.exe")
+	Config.Setenv("GIT_SSH", plink)
+	exe, args := sshGetExeAndArgs(endpoint)
+	assert.Equal(t, plink, exe)
+	assert.Equal(t, []string{"-batch", "user@foo.com"}, args)
+
+	Config.Setenv("GIT_SSH", oldGITSSH)
+}
+
+func TestSSHGetExeAndArgsTortoisePlinkCustomPort(t *testing.T) {
+	endpoint := Config.Endpoint()
+	endpoint.SshUserAndHost = "user@foo.com"
+	endpoint.SshPort = "8888"
+	oldGITSSH := Config.Getenv("GIT_SSH")
+	// this will run on non-Windows platforms too but no biggie
+	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink")
+	Config.Setenv("GIT_SSH", plink)
+	exe, args := sshGetExeAndArgs(endpoint)
+	assert.Equal(t, plink, exe)
+	assert.Equal(t, []string{"-batch", "-P", "8888", "user@foo.com"}, args)
+
+	Config.Setenv("GIT_SSH", oldGITSSH)
+}


### PR DESCRIPTION
This backports #404 and #464.