### PR TITLE
Backport #472 for v0.5.x: Check doHttpRequest() error in UploadObject()

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -353,7 +353,15 @@ func UploadObject(o *objectResource, cb CopyCallback) *WrappedError {
 }
 
 func doHttpRequest(req *http.Request, creds Creds) (*http.Response, *WrappedError) {
-	res, err := DoHTTP(req)
+	res, err := Config.HttpClient().Do(req)
+	if res == nil {
+		res = &http.Response{
+			StatusCode: 0,
+			Header:     make(http.Header),
+			Request:    req,
+			Body:       ioutil.NopCloser(bytes.NewBufferString("")),
+		}
+	}
 
 	var wErr *WrappedError
 

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -341,8 +341,11 @@ func UploadObject(o *objectResource, cb CopyCallback) *WrappedError {
 	req.ContentLength = int64(len(by))
 	req.Body = ioutil.NopCloser(bytes.NewReader(by))
 	res, wErr = doHttpRequest(req, creds)
-	LogTransfer("lfs.data.verify", res)
+	if wErr != nil {
+		return wErr
+	}
 
+	LogTransfer("lfs.data.verify", res)
 	io.Copy(ioutil.Discard, res.Body)
 	res.Body.Close()
 

--- a/lfs/http.go
+++ b/lfs/http.go
@@ -98,14 +98,6 @@ func (c *HttpClient) Do(req *http.Request) (*http.Response, error) {
 	return res, err
 }
 
-func DoHTTP(req *http.Request) (*http.Response, error) {
-	res, err := Config.HttpClient().Do(req)
-	if res == nil {
-		res = &http.Response{StatusCode: 0, Header: make(http.Header), Request: req}
-	}
-	return res, err
-}
-
 func (c *Configuration) HttpClient() *HttpClient {
 	if c.httpClient != nil {
 		return c.httpClient


### PR DESCRIPTION
This backports #472 and #488.