### PR TITLE
Backport #475 for v0.5.x: Use -text instead of -crlf

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Git LFS uses `.gitattributes` files to configure which are managed by Git LFS.
 Here is a sample one that saves zips and mp3s:
 
     $ cat .gitattributes
-    *.mp3 filter=lfs -crlf
-    *.zip filter=lfs -crlf
+    *.mp3 filter=lfs -text
+    *.zip filter=lfs -text
 
 Git LFS can manage `.gitattributes` for you:
 

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -75,7 +75,7 @@ ArgsLoop:
 		}
 
 		encodedArg := strings.Replace(relT, " ", "[[:space:]]", -1)
-		_, err := attributesFile.WriteString(fmt.Sprintf("%s filter=lfs diff=lfs merge=lfs -crlf\n", encodedArg))
+		_, err := attributesFile.WriteString(fmt.Sprintf("%s filter=lfs diff=lfs merge=lfs -text\n", encodedArg))
 		if err != nil {
 			Print("Error adding path %s", t)
 			continue

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -195,8 +195,8 @@ runs all mp3 and zip files through Git LFS:
 
 ```
 $ cat .gitattributes
-*.mp3 filter=lfs -crlf
-*.zip filter=lfs -crlf
+*.mp3 filter=lfs -text
+*.zip filter=lfs -text
 ```
 
 Use the `git lfs track` command to view and add to `.gitattributes`.

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -32,9 +32,9 @@ begin_test "track"
 
   mkdir -p a/b
 
-  echo "*.mov filter=lfs -crlf" > .git/info/attributes
-  echo "*.gif filter=lfs -crlf" > a/.gitattributes
-  echo "*.png filter=lfs -crlf" > a/b/.gitattributes
+  echo "*.mov filter=lfs -text" > .git/info/attributes
+  echo "*.gif filter=lfs -text" > a/.gitattributes
+  echo "*.png filter=lfs -text" > a/b/.gitattributes
 
   out=$(git lfs track)
   echo "$out" | grep "Listing tracked paths"
@@ -71,12 +71,12 @@ begin_test "track without trailing linebreak"
   mkdir no-linebreak
   cd no-linebreak
   git init
-  printf "*.mov filter=lfs -crlf" > .gitattributes
+  printf "*.mov filter=lfs -text" > .gitattributes
 
   git lfs track "*.gif"
 
-  expected="*.mov filter=lfs -crlf
-*.gif filter=lfs diff=lfs merge=lfs -crlf"
+  expected="*.mov filter=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text"
 
   if [ "$expected" != "$(cat .gitattributes)" ]; then
     exit 1


### PR DESCRIPTION
This backports #475.