### PR TITLE
Fixed pseudo pointer with extra data test-clean to work on CentOS

### DIFF
--- a/test/test-clean.sh
+++ b/test/test-clean.sh
@@ -48,11 +48,11 @@ begin_test "clean pseudo pointer with extra data"
   clean_setup "extra-data"
 
   # pointer includes enough extra data to fill the 'git lfs clean' buffer
-  echo "version https://git-lfs.github.com/spec/v1
+  printf "version https://git-lfs.github.com/spec/v1
 oid sha256:7cd8be1d2cd0dd22cd9d229bb6b5785009a05e8b39d405615d882caac56562b5
 size 1024
 \n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n
-This is my test pointer.  There are many like it, but this one is mine." | git lfs clean | tee clean.log
+This is my test pointer.  There are many like it, but this one is mine.\n" | git lfs clean | tee clean.log
   [ "$(pointer c2f909f6961bf85a92e2942ef3ed80c938a3d0ebaee6e72940692581052333be 586)" = "$(cat clean.log)" ]
 )
 end_test


### PR DESCRIPTION
Handle special characters (\n) in sh script no matter what distro

(Unfortunately...) Fedora/RHEL/CentOS/etc... use the same executable for sh and bash. echo "\n" just happens to be one of the few cases when it will produces different (wrong?) results. In order to make this always work for everyone, when trying to print escape characters, using printf works

With this patch, ALL tests pass in Debian and CentOS!