### PR TITLE
Allow for special chars in password

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -691,7 +691,7 @@ func getCreds(req *http.Request) (Creds, error) {
 
 func setRequestAuth(req *http.Request, user, pass string) {
 	token := fmt.Sprintf("%s:%s", user, pass)
-	auth := "Basic " + base64.URLEncoding.EncodeToString([]byte(token))
+	auth := "Basic " + base64.StdEncoding.EncodeToString([]byte(token))
 	req.Header.Set("Authorization", auth)
 }
 


### PR DESCRIPTION
When using special-ish characters, `><-`, etc, in your password, the string would get garbled and base64 decoding breaks on the test server with the following err: `illegal base64 data at input byte...`  