### PR TITLE
Allow a subset of tests to be run by script/integration with arguments

### DIFF
--- a/script/integration
+++ b/script/integration
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . "test/testenv.sh"
 set -e

--- a/script/integration
+++ b/script/integration
@@ -5,6 +5,7 @@ set -e
 
 SHUTDOWN_LFS=no
 SHOW_LOGS=yes
+TESTS=( "$@" )
 
 atexit() {
   res=${1:-$?}
@@ -45,6 +46,15 @@ parallel=${GIT_LFS_TEST_MAXPROCS:-4}
 
 echo "Running this maxprocs=$parallel"
 
-for file in test/test-*.sh; do
+if [ ${#TESTS[@]} -eq 0 ]
+then
+  testfiles=(test/test-*.sh)
+else
+  for ((i=0; i<${#TESTS[@]}; i++)); do
+    testfiles[i]=test/test-${TESTS[i]}.sh
+  done
+fi
+
+for file in "${testfiles[@]}"; do
   echo "0$(cat .$(basename $file).time 2>/dev/null || true) $file"
 done | sort -rnk1 | awk '{ print $2 }' | xargs -I % -P $parallel -n 1 /bin/sh -c % --batch


### PR DESCRIPTION
e.g. `script/integration fetch status` will run only status & fetch tests