### PR TITLE
Fix install.sh for OS X, FreeBSD, etc.

### DIFF
--- a/script/install.sh.example
+++ b/script/install.sh.example
@@ -8,9 +8,11 @@ elif [ "${BOXEN_HOME:-}" != "" ] ; then
   prefix=${BOXEN_HOME:-}
 fi
 
+mkdir -p $prefix/bin
+
 rm -rf $prefix/bin/git-lfs*
 for g in git*; do
-  install -D $g "$prefix/bin/$g"
+  install $g "$prefix/bin/$g"
 done
 
 PATH+=:$prefix/bin


### PR DESCRIPTION
`install(1)`'s `-D` option used in install.sh is a coreutils specific feature. OS X's
implementation does not support it and some other implementation such
as FreeBSD behaves differently.

This PR fixes this problem so that we can use this install script in those OSes.