### PR TITLE
Fix annoying keychain errors when running integration tests on OS X

### DIFF
--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -169,11 +169,11 @@ setup() {
     # user env has no keychain; so create one
     mkdir -p $TMPDIR
     mkdir -p $HOME/Library/Preferences # required to store keychain lists
-    security -v create-keychain -p pass $TMPDIR/temp.keychain
-    security -v list-keychains -s $TMPDIR/temp.keychain
-    security -v unlock-keychain -p pass $TMPDIR/temp.keychain
-    security -v set-keychain-settings -lut 7200 $TMPDIR/temp.keychain
-    security -v default-keychain -s $TMPDIR/temp.keychain
+    security create-keychain -p pass $TMPDIR/temp.keychain
+    security list-keychains -s $TMPDIR/temp.keychain
+    security unlock-keychain -p pass $TMPDIR/temp.keychain
+    security set-keychain-settings -lut 7200 $TMPDIR/temp.keychain
+    security default-keychain -s $TMPDIR/temp.keychain
   fi
 
   wait_for_file "$LFS_URL_FILE"


### PR DESCRIPTION
This was caused by the fact that you can't disable the osxkeychain helper
if it's set at the system gitconfig (which is the default in recent git),
and the git credential 'store' operation will call ALL helpers, not just
the special one created for the integration tests. Because the test user
environment doesn't have a keychain this caused lots of annoying popup
error messages saying "A keychain could not be found to store X".