### PR TITLE
Add checkout & pull commands, changes and fixes to fetch

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -95,15 +95,10 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 			continue
 		}
 		// OK now we can (over)write the file content
-		file, err := os.Create(pointer.Name)
+		err = lfs.PointerSmudgeToFile(pointer.Name, pointer.Pointer, nil)
 		if err != nil {
-			Panic(err, "Could not create working directory file")
+			Panic(err, "Could not checkout file")
 		}
-
-		if err := lfs.PointerSmudge(file, pointer.Pointer, pointer.Name, nil); err != nil {
-			Panic(err, "Could not write working directory file")
-		}
-		file.Close()
 
 		updateIdxStdin.Write([]byte(pointer.Name + "\n"))
 	}

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -18,6 +18,16 @@ var (
 )
 
 func checkoutCommand(cmd *cobra.Command, args []string) {
+
+	// No params
+	checkoutAll()
+}
+
+func init() {
+	RootCmd.AddCommand(checkoutCmd)
+}
+
+func checkoutAll() {
 	ref, err := git.CurrentRef()
 	if err != nil {
 		Panic(err, "Could not checkout")
@@ -39,10 +49,7 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 	}
 	close(c)
 	wait.Wait()
-}
 
-func init() {
-	RootCmd.AddCommand(checkoutCmd)
 }
 
 // Populate the working copy with the real content of objects where the file is

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -19,15 +19,15 @@ var (
 
 func checkoutCommand(cmd *cobra.Command, args []string) {
 
-	// No params
-	checkoutAll()
+	// Parameters are filters
+	checkoutWithIncludeExclude(args, nil)
 }
 
 func init() {
 	RootCmd.AddCommand(checkoutCmd)
 }
 
-func checkoutAll() {
+func checkoutWithIncludeExclude(include []string, exclude []string) {
 	ref, err := git.CurrentRef()
 	if err != nil {
 		Panic(err, "Could not checkout")
@@ -45,11 +45,18 @@ func checkoutAll() {
 
 	checkoutWithChan(c, &wait)
 	for _, pointer := range pointers {
-		c <- pointer
+		if lfs.FilenamePassesIncludeExcludeFilter(pointer.Name, include, exclude) {
+			c <- pointer
+		}
+
 	}
 	close(c)
 	wait.Wait()
 
+}
+
+func checkoutAll() {
+	checkoutWithIncludeExclude(nil, nil)
 }
 
 // Populate the working copy with the real content of objects where the file is

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -1,0 +1,104 @@
+package commands
+
+import (
+	"github.com/github/git-lfs/git"
+	"github.com/github/git-lfs/lfs"
+	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
+	"os"
+	"os/exec"
+	"sync"
+)
+
+var (
+	checkoutCmd = &cobra.Command{
+		Use:   "checkout",
+		Short: "checkout",
+		Run:   checkoutCommand,
+	}
+)
+
+func checkoutCommand(cmd *cobra.Command, args []string) {
+	ref, err := git.CurrentRef()
+	if err != nil {
+		Panic(err, "Could not checkout")
+	}
+
+	pointers, err := lfs.ScanRefs(ref, "", nil)
+	if err != nil {
+		Panic(err, "Could not scan for Git LFS files")
+	}
+
+	var wait sync.WaitGroup
+	wait.Add(1)
+
+	c := make(chan *lfs.WrappedPointer)
+
+	checkoutWithChan(c, wait)
+	for _, pointer := range pointers {
+		c <- pointer
+	}
+	close(c)
+	wait.Wait()
+}
+
+func init() {
+	RootCmd.AddCommand(checkoutCmd)
+}
+
+// Populate the working copy with the real content of objects where the file is
+// either missing, or contains a matching pointer placeholder, from a list of pointers.
+// If the file exists but has other content it is left alone
+// returns immediately but a goroutine listens on the in channel for objects
+// calls wait.Done() when the final item after the channel is closed is done
+func checkoutWithChan(in <-chan *lfs.WrappedPointer, wait sync.WaitGroup) {
+	go func() {
+		// Fire up the update-index command
+		cmd := exec.Command("git", "update-index", "-q", "--refresh", "--stdin")
+		updateIdxStdin, err := cmd.StdinPipe()
+		if err != nil {
+			Panic(err, "Could not update the index")
+		}
+
+		if err := cmd.Start(); err != nil {
+			Panic(err, "Could not update the index")
+		}
+
+		// As files come in, write them to the wd and update the index
+		for pointer := range in {
+
+			// Check the content - either missing or still this pointer (not exist is ok)
+			filepointer, err := lfs.DecodePointerFromFile(pointer.Name)
+			if err != nil && !os.IsNotExist(err) {
+				if err == lfs.NotAPointerError {
+					// File has non-pointer content, leave it alone
+					continue
+				}
+				Panic(err, "Problem accessing %v", pointer.Name)
+			}
+			if filepointer != nil && filepointer.Oid != pointer.Oid {
+				// User has probably manually reset a file to another commit
+				// while leaving it a pointer; don't mess with this
+				continue
+			}
+			// OK now we can (over)write the file content
+			file, err := os.Create(pointer.Name)
+			if err != nil {
+				Panic(err, "Could not create working directory file")
+			}
+
+			if err := lfs.PointerSmudge(file, pointer.Pointer, pointer.Name, nil); err != nil {
+				Panic(err, "Could not write working directory file")
+			}
+			file.Close()
+
+			updateIdxStdin.Write([]byte(pointer.Name + "\n"))
+		}
+
+		updateIdxStdin.Close()
+		if err := cmd.Wait(); err != nil {
+			Panic(err, "Error updating the git index")
+		}
+		wait.Done()
+	}()
+
+}

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -1,12 +1,13 @@
 package commands
 
 import (
-	"github.com/github/git-lfs/git"
-	"github.com/github/git-lfs/lfs"
-	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
 	"os"
 	"os/exec"
 	"sync"
+
+	"github.com/github/git-lfs/git"
+	"github.com/github/git-lfs/lfs"
+	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
 )
 
 var (

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -43,7 +43,10 @@ func checkoutWithIncludeExclude(include []string, exclude []string) {
 
 	c := make(chan *lfs.WrappedPointer)
 
-	checkoutWithChan(c, &wait)
+	go func() {
+		checkoutWithChan(c)
+		wait.Done()
+	}()
 	for _, pointer := range pointers {
 		if lfs.FilenamePassesIncludeExcludeFilter(pointer.Name, include, exclude) {
 			c <- pointer
@@ -62,57 +65,52 @@ func checkoutAll() {
 // Populate the working copy with the real content of objects where the file is
 // either missing, or contains a matching pointer placeholder, from a list of pointers.
 // If the file exists but has other content it is left alone
-// returns immediately but a goroutine listens on the in channel for objects
-// calls wait.Done() when the final item after the channel is closed is done
-func checkoutWithChan(in <-chan *lfs.WrappedPointer, wait *sync.WaitGroup) {
-	go func() {
-		defer wait.Done()
-		// Fire up the update-index command
-		cmd := exec.Command("git", "update-index", "-q", "--refresh", "--stdin")
-		updateIdxStdin, err := cmd.StdinPipe()
-		if err != nil {
-			Panic(err, "Could not update the index")
-		}
+func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
+	// Fire up the update-index command
+	cmd := exec.Command("git", "update-index", "-q", "--refresh", "--stdin")
+	updateIdxStdin, err := cmd.StdinPipe()
+	if err != nil {
+		Panic(err, "Could not update the index")
+	}
 
-		if err := cmd.Start(); err != nil {
-			Panic(err, "Could not update the index")
-		}
+	if err := cmd.Start(); err != nil {
+		Panic(err, "Could not update the index")
+	}
 
-		// As files come in, write them to the wd and update the index
-		for pointer := range in {
+	// As files come in, write them to the wd and update the index
+	for pointer := range in {
 
-			// Check the content - either missing or still this pointer (not exist is ok)
-			filepointer, err := lfs.DecodePointerFromFile(pointer.Name)
-			if err != nil && !os.IsNotExist(err) {
-				if err == lfs.NotAPointerError {
-					// File has non-pointer content, leave it alone
-					continue
-				}
-				Panic(err, "Problem accessing %v", pointer.Name)
-			}
-			if filepointer != nil && filepointer.Oid != pointer.Oid {
-				// User has probably manually reset a file to another commit
-				// while leaving it a pointer; don't mess with this
+		// Check the content - either missing or still this pointer (not exist is ok)
+		filepointer, err := lfs.DecodePointerFromFile(pointer.Name)
+		if err != nil && !os.IsNotExist(err) {
+			if err == lfs.NotAPointerError {
+				// File has non-pointer content, leave it alone
 				continue
 			}
-			// OK now we can (over)write the file content
-			file, err := os.Create(pointer.Name)
-			if err != nil {
-				Panic(err, "Could not create working directory file")
-			}
-
-			if err := lfs.PointerSmudge(file, pointer.Pointer, pointer.Name, nil); err != nil {
-				Panic(err, "Could not write working directory file")
-			}
-			file.Close()
-
-			updateIdxStdin.Write([]byte(pointer.Name + "\n"))
+			Panic(err, "Problem accessing %v", pointer.Name)
+		}
+		if filepointer != nil && filepointer.Oid != pointer.Oid {
+			// User has probably manually reset a file to another commit
+			// while leaving it a pointer; don't mess with this
+			continue
+		}
+		// OK now we can (over)write the file content
+		file, err := os.Create(pointer.Name)
+		if err != nil {
+			Panic(err, "Could not create working directory file")
 		}
 
-		updateIdxStdin.Close()
-		if err := cmd.Wait(); err != nil {
-			Panic(err, "Error updating the git index")
+		if err := lfs.PointerSmudge(file, pointer.Pointer, pointer.Name, nil); err != nil {
+			Panic(err, "Could not write working directory file")
 		}
-	}()
+		file.Close()
+
+		updateIdxStdin.Write([]byte(pointer.Name + "\n"))
+	}
+
+	updateIdxStdin.Close()
+	if err := cmd.Wait(); err != nil {
+		Panic(err, "Error updating the git index")
+	}
 
 }

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -12,7 +12,7 @@ import (
 var (
 	checkoutCmd = &cobra.Command{
 		Use:   "checkout",
-		Short: "checkout",
+		Short: "Checks out LFS files into the working copy",
 		Run:   checkoutCommand,
 	}
 )

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -33,7 +33,7 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 
 	c := make(chan *lfs.WrappedPointer)
 
-	checkoutWithChan(c, wait)
+	checkoutWithChan(c, &wait)
 	for _, pointer := range pointers {
 		c <- pointer
 	}
@@ -50,7 +50,7 @@ func init() {
 // If the file exists but has other content it is left alone
 // returns immediately but a goroutine listens on the in channel for objects
 // calls wait.Done() when the final item after the channel is closed is done
-func checkoutWithChan(in <-chan *lfs.WrappedPointer, wait sync.WaitGroup) {
+func checkoutWithChan(in <-chan *lfs.WrappedPointer, wait *sync.WaitGroup) {
 	go func() {
 		// Fire up the update-index command
 		cmd := exec.Command("git", "update-index", "-q", "--refresh", "--stdin")

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -33,7 +33,7 @@ func checkoutWithIncludeExclude(include []string, exclude []string) {
 		Panic(err, "Could not checkout")
 	}
 
-	pointers, err := lfs.ScanRefs(ref, "", nil)
+	pointers, err := lfs.ScanTree(ref)
 	if err != nil {
 		Panic(err, "Could not scan for Git LFS files")
 	}

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
+	"github.com/github/git-lfs/vendor/_nuts/github.com/rubyist/tracerx"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
-	"github.com/rubyist/tracerx"
 )
 
 var (

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -52,6 +52,7 @@ func init() {
 // calls wait.Done() when the final item after the channel is closed is done
 func checkoutWithChan(in <-chan *lfs.WrappedPointer, wait *sync.WaitGroup) {
 	go func() {
+		defer wait.Done()
 		// Fire up the update-index command
 		cmd := exec.Command("git", "update-index", "-q", "--refresh", "--stdin")
 		updateIdxStdin, err := cmd.StdinPipe()
@@ -98,7 +99,6 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer, wait *sync.WaitGroup) {
 		if err := cmd.Wait(); err != nil {
 			Panic(err, "Error updating the git index")
 		}
-		wait.Done()
 	}()
 
 }

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -1,11 +1,12 @@
 package commands
 
 import (
+	"time"
+
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/rubyist/tracerx"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
-	"time"
 )
 
 var (

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -50,7 +50,12 @@ func fetchAndReportToChan(pointers []*lfs.WrappedPointer, out chan<- *lfs.Wrappe
 	q := lfs.NewDownloadQueue(lfs.Config.ConcurrentTransfers(), len(pointers))
 
 	for _, p := range pointers {
-		q.Add(lfs.NewDownloadable(p))
+		// Only add to download queue if local file is not the right size already
+		// This avoids previous case of over-reporting a requirement for files we already have
+		// which would only be skipped by PointerSmudgeObject later
+		if !lfs.ObjectExistsOfSize(p.Oid, p.Size) {
+			q.Add(lfs.NewDownloadable(p))
+		}
 	}
 
 	if out != nil {

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -74,7 +74,10 @@ func fetchAndReportToChan(pointers []*lfs.WrappedPointer, out chan<- *lfs.Wrappe
 			q.Add(lfs.NewDownloadable(p))
 		} else {
 			// If we already have it, report it to chan immediately to support pull/checkout
-			out <- p
+			if out != nil {
+				out <- p
+			}
+
 		}
 	}
 

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -11,7 +11,7 @@ import (
 var (
 	fetchCmd = &cobra.Command{
 		Use:   "fetch",
-		Short: "fetch",
+		Short: "Downloads LFS files",
 		Run:   fetchCommand,
 	}
 )

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -29,19 +29,23 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	pointers, err := lfs.ScanRefs(ref, "", nil)
-	if err != nil {
-		Panic(err, "Could not scan for Git LFS files")
-	}
-
-	fetchImpl(pointers)
+	fetchRef(ref)
 }
 
 func init() {
 	RootCmd.AddCommand(fetchCmd)
 }
 
-func fetchImpl(pointers []*lfs.WrappedPointer) {
+// Fetch all binaries for a given ref (that we don't have already)
+func fetchRef(ref string) {
+	pointers, err := lfs.ScanRefs(ref, "", nil)
+	if err != nil {
+		Panic(err, "Could not scan for Git LFS files")
+	}
+	fetchPointers(pointers)
+}
+
+func fetchPointers(pointers []*lfs.WrappedPointer) {
 	fetchAndReportToChan(pointers, nil)
 }
 

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -2,9 +2,7 @@ package commands
 
 import (
 	"github.com/github/git-lfs/git"
-	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
-	"sync"
 )
 
 var (
@@ -22,22 +20,13 @@ func pullCommand(cmd *cobra.Command, args []string) {
 		Panic(err, "Could not pull")
 	}
 
-	pointers, err := lfs.ScanRefs(ref, "", nil)
-	if err != nil {
-		Panic(err, "Could not scan for Git LFS files")
-	}
-
-	fetchChan := make(chan *lfs.WrappedPointer)
-	var wait sync.WaitGroup
-	wait.Add(1)
-	// Prep the checkout process for items that come out of fetch
-	// this doesn't do anything except set up the goroutine & wait on the fetchChan
-	checkoutWithChan(fetchChan, &wait)
-	// Do the downloading & report to channel which checkout watches
-	fetchAndReportToChan(pointers, fetchChan)
-
-	// Wait for final checkouts to finish
-	wait.Wait()
+	// Previously we would only checkout files that were downloaded, as they
+	// were downloaded. However this would ignore files where the content was
+	// already present locally (since these are no longer included in transfer Q for
+	// better reporting purposes).
+	// So now we do exactly what we say on the tin, fetch then a separate checkout
+	fetchRef(ref)
+	checkoutAll()
 }
 
 func init() {

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -32,7 +32,7 @@ func pullCommand(cmd *cobra.Command, args []string) {
 	wait.Add(1)
 	// Prep the checkout process for items that come out of fetch
 	// this doesn't do anything except set up the goroutine & wait on the fetchChan
-	checkoutWithChan(fetchChan, wait)
+	checkoutWithChan(fetchChan, &wait)
 	// Do the downloading & report to channel which checkout watches
 	fetchAndReportToChan(pointers, fetchChan)
 

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"github.com/github/git-lfs/git"
+	"github.com/github/git-lfs/lfs"
+	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
+	"sync"
+)
+
+var (
+	pullCmd = &cobra.Command{
+		Use:   "pull",
+		Short: "pull",
+		Run:   pullCommand,
+	}
+)
+
+func pullCommand(cmd *cobra.Command, args []string) {
+
+	ref, err := git.CurrentRef()
+	if err != nil {
+		Panic(err, "Could not pull")
+	}
+
+	pointers, err := lfs.ScanRefs(ref, "", nil)
+	if err != nil {
+		Panic(err, "Could not scan for Git LFS files")
+	}
+
+	fetchChan := make(chan *lfs.WrappedPointer)
+	var wait sync.WaitGroup
+	wait.Add(1)
+	// Prep the checkout process for items that come out of fetch
+	// this doesn't do anything except set up the goroutine & wait on the fetchChan
+	checkoutWithChan(fetchChan, wait)
+	// Do the downloading & report to channel which checkout watches
+	fetchAndReportToChan(pointers, fetchChan)
+
+	// Wait for final checkouts to finish
+	wait.Wait()
+}
+
+func init() {
+	RootCmd.AddCommand(pullCmd)
+}

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -10,7 +10,7 @@ import (
 var (
 	pullCmd = &cobra.Command{
 		Use:   "pull",
-		Short: "pull",
+		Short: "Downloads LFS files for the current ref, and checks out",
 		Run:   pullCommand,
 	}
 )

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -20,13 +20,8 @@ func pullCommand(cmd *cobra.Command, args []string) {
 		Panic(err, "Could not pull")
 	}
 
-	// Previously we would only checkout files that were downloaded, as they
-	// were downloaded. However this would ignore files where the content was
-	// already present locally (since these are no longer included in transfer Q for
-	// better reporting purposes).
-	// So now we do exactly what we say on the tin, fetch then a separate checkout
-	fetchRef(ref)
-	checkoutAll()
+	c := fetchRefToChan(ref)
+	checkoutAllFromFetchChan(c)
 }
 
 func init() {

--- a/docs/man/git-lfs-checkout.1.ronn
+++ b/docs/man/git-lfs-checkout.1.ronn
@@ -1,0 +1,36 @@
+git-lfs-checkout(1) -- Update working copy with file content if available
+=========================================================================
+
+## SYNOPSIS
+
+`git lfs checkout` <filespec>...
+
+## DESCRIPTION
+
+Try to ensure that the working copy contains file content for Git LFS objects
+for the current ref, if the object data is available. Does not download any
+content, see git-lfs-fetch(1) for that. 
+
+Checkout scans the current ref for all LFS objects that would be required, then
+where a file is either missing in the working copy, or contains placeholder
+pointer content with the same SHA, the real file content is written, provided
+we have it in the local store. Modified files are never overwritten.
+
+Filespecs can be provided as arguments to restrict the files which are updated.
+
+## EXAMPLES
+
+* Checkout all files that are missing or placeholders
+
+  `git lfs checkout`
+
+* Checkout a specific couple of files
+
+  `git lfs checkout path/to/file1.png path/to.file2.png`
+
+## SEE ALSO
+
+git-lfs-fetch(1), git-lfs-pull(1).
+
+Part of the git-lfs(1) suite.
+

--- a/docs/man/git-lfs-fetch.1.ronn
+++ b/docs/man/git-lfs-fetch.1.ronn
@@ -10,8 +10,7 @@ git-lfs-fetch(1) -- Download all Git LFS files for a given ref
 Download any Git LFS objects for a given ref. If no ref is given,
 the currently checked out ref will be used.
 
-If the given ref is the same as the currently checked out ref, the
-files will be written to the working directory.
+This does not update the working copy.
 
 ## EXAMPLES
 
@@ -26,6 +25,10 @@ files will be written to the working directory.
 * Fetch the LFS objects for a commit
 
   `git lfs fetch e445b45c1c9c6282614f201b62778e4c0688b5c8`
+
+## SEE ALSO
+
+git-lfs-checkout(1), git-lfs-pull(1).
 
 Part of the git-lfs(1) suite.
 

--- a/docs/man/git-lfs-pull.1.ronn
+++ b/docs/man/git-lfs-pull.1.ronn
@@ -1,0 +1,25 @@
+git-lfs-pull(1) -- Download all Git LFS files for current ref & checkout
+========================================================================
+
+## SYNOPSIS
+
+`git lfs pull`
+
+## DESCRIPTION
+
+Download Git LFS objects for the currently checked out ref, and update
+the working copy with the downloaded content if required.
+
+This is equivalent to running the following 2 commands:
+
+git lfs fetch
+git lfs checkout
+
+## EXAMPLES
+
+## SEE ALSO
+
+git-lfs-fetch(1), git-lfs-checkout(1).
+
+Part of the git-lfs(1) suite.
+

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -49,13 +49,29 @@ func ResetTempDir() error {
 	return os.RemoveAll(TempDir)
 }
 
+func localMediaDirNoCreate(sha string) string {
+	return filepath.Join(LocalMediaDir, sha[0:2], sha[2:4])
+}
+func localMediaPathNoCreate(sha string) string {
+	return filepath.Join(localMediaDirNoCreate(sha), sha)
+}
+
 func LocalMediaPath(sha string) (string, error) {
-	path := filepath.Join(LocalMediaDir, sha[0:2], sha[2:4])
+	path := localMediaDirNoCreate(sha)
 	if err := os.MkdirAll(path, localMediaDirPerms); err != nil {
 		return "", fmt.Errorf("Error trying to create local media directory in '%s': %s", path, err)
 	}
 
 	return filepath.Join(path, sha), nil
+}
+
+func ObjectExistsOfSize(sha string, size int64) bool {
+	path := localMediaPathNoCreate(sha)
+	stat, err := os.Stat(path)
+	if err == nil && size == stat.Size() {
+		return true
+	}
+	return false
 }
 
 func Environ() []string {

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -27,6 +28,8 @@ size %d
 `
 	matcherRE   = regexp.MustCompile("git-media|hawser|git-lfs")
 	pointerKeys = []string{"version", "oid", "size"}
+
+	NotAPointerError = errors.New("Not a pointer")
 )
 
 type Pointer struct {
@@ -56,6 +59,22 @@ func EncodePointer(writer io.Writer, pointer *Pointer) (int, error) {
 	return writer.Write([]byte(pointer.Encoded()))
 }
 
+func DecodePointerFromFile(file string) (*Pointer, error) {
+	// Check size before reading
+	stat, err := os.Stat(file)
+	if err != nil {
+		return nil, err
+	}
+	if stat.Size() > blobSizeCutoff {
+		return nil, NotAPointerError
+	}
+	f, err := os.OpenFile(file, os.O_RDONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return DecodePointer(f)
+}
 func DecodePointer(reader io.Reader) (*Pointer, error) {
 	_, p, err := DecodeFrom(reader)
 	return p, err

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -29,7 +29,7 @@ size %d
 	matcherRE   = regexp.MustCompile("git-media|hawser|git-lfs")
 	pointerKeys = []string{"version", "oid", "size"}
 
-	NotAPointerError = errors.New("Not a pointer")
+	NotAPointerError = errors.New("Not a valid Git LFS pointer file.")
 )
 
 type Pointer struct {
@@ -149,7 +149,7 @@ func decodeKVData(data []byte) (map[string]string, error) {
 	m := make(map[string]string)
 
 	if !matcherRE.Match(data) {
-		return m, fmt.Errorf("Not a valid Git LFS pointer file.")
+		return m, NotAPointerError
 	}
 
 	scanner := bufio.NewScanner(bytes.NewBuffer(data))

--- a/lfs/pointer_smudge.go
+++ b/lfs/pointer_smudge.go
@@ -11,6 +11,17 @@ import (
 	contentaddressable "github.com/github/git-lfs/vendor/_nuts/github.com/technoweenie/go-contentaddressable"
 )
 
+func PointerSmudgeToFile(filename string, ptr *Pointer, cb CopyCallback) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("Could not create working directory file: %v", err)
+	}
+	defer file.Close()
+	if err := PointerSmudge(file, ptr, filename, cb); err != nil {
+		return fmt.Errorf("Could not write working directory file: %v", err)
+	}
+	return nil
+}
 func PointerSmudge(writer io.Writer, ptr *Pointer, workingfile string, cb CopyCallback) error {
 	mediafile, err := LocalMediaPath(ptr.Oid)
 	if err != nil {

--- a/lfs/pointer_smudge.go
+++ b/lfs/pointer_smudge.go
@@ -12,6 +12,7 @@ import (
 )
 
 func PointerSmudgeToFile(filename string, ptr *Pointer, cb CopyCallback) error {
+	os.MkdirAll(filepath.Dir(filename), 0755)
 	file, err := os.Create(filename)
 	if err != nil {
 		return fmt.Errorf("Could not create working directory file: %v", err)

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -221,9 +221,20 @@ func ConvertCwdFilesRelativeToRepo(cwdchan <-chan string) (<-chan string, error)
 	if err != nil {
 		return nil, fmt.Errorf("Could not retrieve current directory: %v", err)
 	}
+
+	// Early-out if working dir is root dir, same result
+	passthrough := false
+	if LocalWorkingDir == curdir {
+		passthrough = true
+	}
+
 	outchan := make(chan string, 1)
 	go func() {
 		for p := range cwdchan {
+			if passthrough {
+				outchan <- p
+				continue
+			}
 			var abs string
 			if filepath.IsAbs(p) {
 				abs = p

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -16,6 +16,18 @@ type CallbackReader struct {
 	io.Reader
 }
 
+type Platform int
+
+const (
+	PlatformWindows      = Platform(iota)
+	PlatformLinux        = Platform(iota)
+	PlatformOSX          = Platform(iota)
+	PlatformOther        = Platform(iota) // most likely a *nix variant e.g. freebsd
+	PlatformUndetermined = Platform(iota)
+)
+
+var currentPlatform = PlatformUndetermined
+
 type CopyCallback func(totalSize int64, readSoFar int64, readSinceLast int) error
 
 func (w *CallbackReader) Read(p []byte) (int, error) {
@@ -145,7 +157,23 @@ func FilenamePassesIncludeExcludeFilter(filename string, includePaths, excludePa
 	return true
 }
 
+func GetPlatform() Platform {
+	if currentPlatform == PlatformUndetermined {
+		switch runtime.GOOS {
+		case "windows":
+			currentPlatform = PlatformWindows
+		case "linux":
+			currentPlatform = PlatformLinux
+		case "darwin":
+			currentPlatform = PlatformOSX
+		default:
+			currentPlatform = PlatformOther
+		}
+	}
+	return currentPlatform
+}
+
 // Are we running on Windows? Need to handle some extra path shenanigans
 func IsWindows() bool {
-	return runtime.GOOS == "windows"
+	return GetPlatform() == PlatformWindows
 }

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -98,7 +98,7 @@ func FilenamePassesIncludeExcludeFilter(filename string, includePaths, excludePa
 		return true
 	}
 
-	// For Win32, becuase git reports files with / separators
+	// For Win32, because git reports files with / separators
 	cleanfilename := filepath.Clean(filename)
 	if len(includePaths) > 0 {
 		matched := false

--- a/test/test-checkout.sh
+++ b/test/test-checkout.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+. "test/testlib.sh"
+
+begin_test "checkout"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")"
+  setup_remote_repo "$reponame"
+
+  clone_repo "$reponame" repo
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \*.dat" track.log
+
+  contents="something something"
+  contents_oid=$(printf "$contents" | shasum -a 256 | cut -f 1 -d " ")
+
+  # Same content everywhere is ok, just one object in lfs db
+  printf "$contents" > file1.dat
+  printf "$contents" > file2.dat
+  printf "$contents" > file3.dat
+  mkdir folder1 folder2
+  printf "$contents" > folder1/nested.dat
+  printf "$contents" > folder2/nested.dat
+  git add file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat
+  git add .gitattributes
+  git commit -m "add files"
+
+  [ "$contents" = "$(cat file1.dat)" ]
+  [ "$contents" = "$(cat file2.dat)" ]
+  [ "$contents" = "$(cat file3.dat)" ]
+  [ "$contents" = "$(cat folder1/nested.dat)" ]
+  [ "$contents" = "$(cat folder2/nested.dat)" ]
+
+  assert_pointer "master" "file1.dat" "$contents_oid" 19
+
+  # Remove the working directory
+  rm -rf file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat
+
+  # checkout should replace all
+  git lfs checkout
+  [ "$contents" = "$(cat file1.dat)" ]
+  [ "$contents" = "$(cat file2.dat)" ]
+  [ "$contents" = "$(cat file3.dat)" ]
+  [ "$contents" = "$(cat folder1/nested.dat)" ]
+  [ "$contents" = "$(cat folder2/nested.dat)" ]
+
+)
+end_test

--- a/test/test-checkout.sh
+++ b/test/test-checkout.sh
@@ -47,5 +47,33 @@ begin_test "checkout"
   [ "$contents" = "$(cat folder1/nested.dat)" ]
   [ "$contents" = "$(cat folder2/nested.dat)" ]
 
+  # Remove again
+  rm -rf file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat
+
+  # checkout with filters
+  git lfs checkout file2.dat
+  [ "$contents" = "$(cat file2.dat)" ]
+  [ ! -f file1.dat ]
+  [ ! -f file3.dat ]
+  [ ! -f folder1/nested.dat ]
+  [ ! -f folder2/nested.dat ]
+
+  # quotes to avoid shell globbing
+  git lfs checkout "file*.dat"
+  [ "$contents" = "$(cat file1.dat)" ]
+  [ "$contents" = "$(cat file3.dat)" ]
+  [ ! -f folder1/nested.dat ]
+  [ ! -f folder2/nested.dat ]
+
+  # test subdir context
+  pushd folder1
+  git lfs checkout nested.dat
+  [ "$contents" = "$(cat nested.dat)" ]
+  [ ! -f ../folder2/nested.dat ]
+  popd
+
+  # test folder param
+  git lfs checkout folder2
+  [ "$contents" = "$(cat folder2/nested.dat)" ]
 )
 end_test

--- a/test/test-checkout.sh
+++ b/test/test-checkout.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . "test/testlib.sh"
 

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -63,12 +63,11 @@ begin_test "fetch"
 
 
   # Remove the working directory and lfs files
-  rm a.dat
   rm -rf .git/lfs/objects
 
   git lfs fetch 2>&1 | grep "(1 of 1 files)"
 
-  [ "a" = "$(cat a.dat)" ]
+  assert_pointer "master" "a.dat" "$contents_oid" 1
 
   git checkout newbranch
   git checkout master

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -17,7 +17,8 @@ begin_test "pre-push"
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
-  grep "(0 of 0 files) 0 B 0" push.log
+  # no output if nothing to do
+  [ "$(du -k push.log | cut -f 1)" == "0" ]
 
   git lfs track "*.dat"
   echo "hi" > hi.dat

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . "test/testlib.sh"
 

--- a/test/test-pull.sh
+++ b/test/test-pull.sh
@@ -40,18 +40,6 @@ begin_test "pull"
 
   assert_server_object "$reponame" "$contents_oid"
 
-  # Add a file in a different branch
-  git checkout -b newbranch
-  b="b"
-  b_oid=$(printf "$b" | shasum -a 256 | cut -f 1 -d " ")
-  printf "$b" > b.dat
-  git add b.dat
-  git commit -m "add b.dat"
-  assert_pointer "newbranch" "b.dat" "$b_oid" 1
-
-  git push origin newbranch
-  assert_server_object "$reponame" "$b_oid"
-
   # change to the clone's working directory
   cd ../clone
 
@@ -65,15 +53,14 @@ begin_test "pull"
   # Remove the working directory and lfs files
   rm a.dat
   rm -rf .git/lfs/objects
-
   git lfs pull 2>&1 | grep "(1 of 1 files)"
+  [ "a" = "$(cat a.dat)" ]
+  assert_pointer "master" "a.dat" "$contents_oid" 1
 
+  # Remove just the working directory
+  rm a.dat
+  git lfs pull
   [ "a" = "$(cat a.dat)" ]
 
-  git checkout newbranch
-  git checkout master
-  rm -rf .git/lfs/objects
-
-  git lfs pull newbranch 2>&1 | grep "(2 of 2 files)"
 )
 end_test

--- a/test/test-pull.sh
+++ b/test/test-pull.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+. "test/testlib.sh"
+
+begin_test "pull"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")"
+  setup_remote_repo "$reponame"
+
+  clone_repo "$reponame" clone
+
+  clone_repo "$reponame" repo
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \*.dat" track.log
+
+  contents="a"
+  contents_oid=$(printf "$contents" | shasum -a 256 | cut -f 1 -d " ")
+
+  printf "$contents" > a.dat
+  git add a.dat
+  git add .gitattributes
+  git commit -m "add a.dat" 2>&1 | tee commit.log
+  grep "master (root-commit)" commit.log
+  grep "2 files changed" commit.log
+  grep "create mode 100644 a.dat" commit.log
+  grep "create mode 100644 .gitattributes" commit.log
+
+  [ "a" = "$(cat a.dat)" ]
+
+  assert_pointer "master" "a.dat" "$contents_oid" 1
+
+  refute_server_object "$reponame" "$contents_oid"
+
+  git push origin master 2>&1 | tee push.log
+  grep "(1 of 1 files)" push.log
+  grep "master -> master" push.log
+
+  assert_server_object "$reponame" "$contents_oid"
+
+  # Add a file in a different branch
+  git checkout -b newbranch
+  b="b"
+  b_oid=$(printf "$b" | shasum -a 256 | cut -f 1 -d " ")
+  printf "$b" > b.dat
+  git add b.dat
+  git commit -m "add b.dat"
+  assert_pointer "newbranch" "b.dat" "$b_oid" 1
+
+  git push origin newbranch
+  assert_server_object "$reponame" "$b_oid"
+
+  # change to the clone's working directory
+  cd ../clone
+
+  git pull 2>&1 | grep "Downloading a.dat (1 B)"
+
+  [ "a" = "$(cat a.dat)" ]
+
+  assert_pointer "master" "a.dat" "$contents_oid" 1
+
+
+  # Remove the working directory and lfs files
+  rm a.dat
+  rm -rf .git/lfs/objects
+
+  git lfs pull 2>&1 | grep "(1 of 1 files)"
+
+  [ "a" = "$(cat a.dat)" ]
+
+  git checkout newbranch
+  git checkout master
+  rm -rf .git/lfs/objects
+
+  git lfs pull newbranch 2>&1 | grep "(2 of 2 files)"
+)
+end_test


### PR DESCRIPTION
1. `fetch` no longer updates the working copy, it only downloads files
2. Added `checkout` command which updates the working copy with content if files are missing or are matching pointers. Modified files are left alone (user should reset if they want)
3. Added `pull` command which performs `fetch` and `checkout` for the current ref
4. ~~`fetch` now supports multiple refs as arguments~~
5. `checkout` will correctly populate multiple local files with the same content (old `fetch` would only populate the first one returned from `git rev-list`)
6. `fetch` only adds missing or incorrect objects to the download queue, not all of them. This improves the progress reporting; previously fetch would appear to be trying to download all objects referenced at a ref then only have to download the missing ones as the download queue figured out they were already local. Also means fetch reports nothing at all if you're completely up to date already, instead of reporting "(0 of 1000 files)".
7. A side effect is that 'pull' does all fetching first, then all checkout (not interleaved as before). This is because there may be more objects to checkout than to fetch (missing in working copy but already in store). Coupling these has unwanted edge cases & it's better to simplify & do what it says on the tin i.e. the same as running fetch then checkout.

Note that the ScanTree does something similar to ScanRefs but reports pointers for every file that uses the content and not just one where multiple files share the same content. I'm not sure if this is the intended behaviour elsewhere but for now I've left it as a separate method. It also doesn't have the race conditions on nameMap that I believe ScanRefs has (commented elsewhere).