### PR TITLE
newClientRequest() now accepts an initial header

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -581,10 +581,8 @@ func newClientRequest(method, rawurl string, header map[string]string) (*http.Re
 		return nil, nil, err
 	}
 
-	if header != nil {
-		for key, value := range header {
-			req.Header.Set(key, value)
-		}
+	for key, value := range header {
+		req.Header.Set(key, value)
 	}
 
 	req.Header.Set("User-Agent", UserAgent)

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -60,13 +60,9 @@ func (o *objectResource) NewRequest(relation, method string) (*http.Request, Cre
 		return nil, nil, objectRelationDoesNotExist
 	}
 
-	req, creds, err := newClientRequest(method, rel.Href)
+	req, creds, err := newClientRequest(method, rel.Href, rel.Header)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	for h, v := range rel.Header {
-		req.Header.Set(h, v)
 	}
 
 	return req, creds, nil
@@ -402,7 +398,7 @@ func doApiRequestWithRedirects(req *http.Request, creds Creds, via []*http.Reque
 			redirectTo = locurl.String()
 		}
 
-		redirectedReq, redirectedCreds, err := newClientRequest(req.Method, redirectTo)
+		redirectedReq, redirectedCreds, err := newClientRequest(req.Method, redirectTo, nil)
 		if err != nil {
 			return res, Errorf(err, err.Error())
 		}
@@ -570,25 +566,25 @@ func newApiRequest(method, oid string) (*http.Request, Creds, error) {
 		return nil, nil, err
 	}
 
-	req, creds, err := newClientRequest(method, u.String())
+	req, creds, err := newClientRequest(method, u.String(), res.Header)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	req.Header.Set("Accept", mediaType)
-	if res.Header != nil {
-		for key, value := range res.Header {
-			req.Header.Set(key, value)
-		}
-	}
-
 	return req, creds, nil
 }
 
-func newClientRequest(method, rawurl string) (*http.Request, Creds, error) {
+func newClientRequest(method, rawurl string, header map[string]string) (*http.Request, Creds, error) {
 	req, err := http.NewRequest(method, rawurl, nil)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if header != nil {
+		for key, value := range header {
+			req.Header.Set(key, value)
+		}
 	}
 
 	req.Header.Set("User-Agent", UserAgent)


### PR DESCRIPTION
This allows newClientRequest() to set an Authorization header from either an SSH response or link relation without calling git credentials. Fixes #533 

/cc @jatoben 