### PR TITLE
SHA in user agent

### DIFF
--- a/git-lfs.go
+++ b/git-lfs.go
@@ -7,6 +7,5 @@ import (
 
 func main() {
 	commands.Run()
-
 	lfs.LogHttpStats()
 }

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -11,12 +11,8 @@ import (
 	"github.com/github/git-lfs/vendor/_nuts/github.com/rubyist/tracerx"
 )
 
-const Version = "0.5.3"
-
-//
-// Setup permissions for the given directories used here.
-//
 const (
+	Version            = "0.5.3"
 	tempDirPerms       = 0755
 	localMediaDirPerms = 0755
 	localLogDirPerms   = 0755
@@ -25,6 +21,7 @@ const (
 var (
 	LargeSizeThreshold = 5 * 1024 * 1024
 	TempDir            = filepath.Join(os.TempDir(), "git-lfs")
+	GitCommit          string
 	UserAgent          string
 	LocalWorkingDir    string
 	LocalGitDir        string
@@ -108,10 +105,17 @@ func init() {
 
 	}
 
-	UserAgent = fmt.Sprintf("git-lfs/%s (GitHub; %s %s; go %s)", Version,
+	gitCommit := ""
+	if len(GitCommit) > 0 {
+		gitCommit = "; git " + GitCommit
+	}
+	UserAgent = fmt.Sprintf("git-lfs/%s (GitHub; %s %s; go %s%s)",
+		Version,
 		runtime.GOOS,
 		runtime.GOARCH,
-		strings.Replace(runtime.Version(), "go", "", 1))
+		strings.Replace(runtime.Version(), "go", "", 1),
+		gitCommit,
+	)
 }
 
 func resolveGitDir() (string, string, error) {

--- a/script/build.go
+++ b/script/build.go
@@ -28,15 +28,6 @@ var (
 )
 
 func mainBuild() {
-	cmd, err := exec.Command("script/fmt").Output()
-	if err != nil {
-		panic(err)
-	}
-
-	if len(cmd) > 0 {
-		fmt.Println(string(cmd))
-	}
-
 	if *ShowHelp {
 		fmt.Println("usage: script/bootstrap [-os] [-arch] [-all]")
 		flag.PrintDefaults()

--- a/script/build.go
+++ b/script/build.go
@@ -41,8 +41,7 @@ func mainBuild() {
 	}
 
 	if len(cmd) > 0 {
-		arg := strings.TrimSpace("-X github.com/github/git-lfs/lfs.GitCommit " + string(cmd))
-		LdFlag = fmt.Sprintf("-ldflags=%q", arg)
+		LdFlag = strings.TrimSpace("-X github.com/github/git-lfs/lfs.GitCommit " + string(cmd))
 	}
 
 	buildMatrix := make(map[string]Release)
@@ -129,10 +128,10 @@ func buildCommand(dir, buildos, buildarch string) error {
 		bin = bin + ".exe"
 	}
 
-	args := make([]string, 1, 5)
+	args := make([]string, 1, 6)
 	args[0] = "build"
 	if len(LdFlag) > 0 {
-		args = append(args, LdFlag)
+		args = append(args, "-ldflags", LdFlag)
 	}
 	args = append(args, "-o", bin, ".")
 

--- a/script/run
+++ b/script/run
@@ -1,3 +1,4 @@
 #!/bin/sh
 script/fmt
-go run ./git-lfs.go "$@"
+commit=`git rev-parse --short HEAD`
+go run -ldflags="-X github.com/github/git-lfs/lfs.GitCommit $commit" ./git-lfs.go "$@"


### PR DESCRIPTION
I want the version string to include the git commit that built it:

```
$ git lfs version
git-lfs/0.5.3 (GitHub; darwin amd64; go 1.3; git 0cf7c47)
```

This PR gets it working with `script/run version`, but not `script/bootstrap`.

```
$ script/bootstrap
# github.com/github/git-lfs
/opt/boxen/chgo/versions/1.3/pkg/tool/darwin_amd64/6l: unknown flag -X github.com/github/git-lfs/lfs.GitCommit 22bb4ab

2015/07/28 16:04:56 exit status 2
exit status 1
```

I'm really not sure why it [fails here](https://github.com/github/git-lfs/blob/0cf7c479e403deee9f8e0cdafa9b6597d22fab71/script/build.go#L132-L139) when it works in `script/run` or running `go build` manually.

A workaround is to create a file like `lfs/aaaaa_version.go`:

```go
package lfs

func init() {
  GitCommit = "22bb4ab"
}
```

Such a file could be created and then trashed during every `script/bootstrap` run.