### PR TITLE
re-organize the error logs to make them more useful

### DIFF
--- a/test/test-logs.sh
+++ b/test/test-logs.sh
@@ -22,7 +22,7 @@ begin_test "logs"
   logfile=".git/lfs/objects/logs/$logname"
   cat "$logfile"
   echo "... grep ..."
-  grep "> git-lfs logs boomtown" "$logfile"
+  grep "$ git-lfs logs boomtown" "$logfile"
 
   [ "$(cat "$logfile")" = "$(git lfs logs last)" ]
 )


### PR DESCRIPTION
I'm tired of asking people for their version info.  This update adds the Git LFS and Git versions to the top. It also throws the git lfs environment at the bottom, so we can see things like their git lfs concurrency setting.

OLD:

```
> git-lfs logs boomtown
LocalWorkingDir=/Users/rick/go/src/github.com/github/git-lfs
LocalGitDir=/Users/rick/go/src/github.com/github/git-lfs/.git
LocalMediaDir=/Users/rick/go/src/github.com/github/git-lfs/.git/lfs/objects
TempDir=/Users/rick/go/src/github.com/github/git-lfs/.git/lfs/tmp
ConcurrentTransfers=3
BatchTransfer=false
GIT_LFS_TEST_DIR=/Users/rick/p/git-lfs-temp
GIT_LFS_TEST_MAXPROCS=4

Welcome to Boomtown

Error!
Inner error message!
goroutine 16 [running]:
github.com/github/git-lfs/lfs.Stack(0x0, 0x0, 0x0)
	/Users/rick/go/src/github.com/github/git-lfs/lfs/errors.go:85 +0x89
github.com/github/git-lfs/lfs.Errorf(0x6831b0, 0xc208034d00, 0x3b9e00, 0x6, 0x0, 0x0, 0x0, 0x5b8f20)
	/Users/rick/go/src/github.com/github/git-lfs/lfs/errors.go:29 +0x62
github.com/github/git-lfs/commands.logsBoomtownCommand(0x5b8f20, 0x5bfc78, 0x0, 0x0)
	/Users/rick/go/src/github.com/github/git-lfs/commands/command_logs.go:88 +0xf6
github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra.(*Command).execute(0x5b8f20, 0x5bfc78, 0x0, 0x0, 0x0, 0x0)
	/Users/rick/go/src/github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra/command.go:355 +0x17c
github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra.(*Command).findAndExecute(0x5b9c20, 0xc20800e010, 0x2, 0x2, 0x0, 0x0)
	/Users/rick/go/src/github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra/command.go:334 +0xd3
github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra.(*Command).Execute(0x5b9c20, 0x0, 0x0)
	/Users/rick/go/src/github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra/command.go:408 +0x7b0
github.com/github/git-lfs/commands.Run()
	/Users/rick/go/src/github.com/github/git-lfs/commands/commands.go:84 +0x2a
main.main()
	/Users/rick/go/src/github.com/github/git-lfs/git-lfs.go:9 +0x1a
```

NEW:

```
git-lfs/0.5.3 (GitHub; darwin amd64; go 1.3)
git version 2.3.0

$ git-lfs logs boomtown
Welcome to Boomtown

Error!
Inner error message!
goroutine 16 [running]:
github.com/github/git-lfs/lfs.Stack(0x0, 0x0, 0x0)
	/Users/rick/go/src/github.com/github/git-lfs/lfs/errors.go:85 +0x89
github.com/github/git-lfs/lfs.Errorf(0x6831b0, 0xc208034d00, 0x3ba0e0, 0x6, 0x0, 0x0, 0x0, 0x5b8f20)
	/Users/rick/go/src/github.com/github/git-lfs/lfs/errors.go:29 +0x62
github.com/github/git-lfs/commands.logsBoomtownCommand(0x5b8f20, 0x5bfc78, 0x0, 0x0)
	/Users/rick/go/src/github.com/github/git-lfs/commands/command_logs.go:88 +0xf6
github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra.(*Command).execute(0x5b8f20, 0x5bfc78, 0x0, 0x0, 0x0, 0x0)
	/Users/rick/go/src/github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra/command.go:355 +0x17c
github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra.(*Command).findAndExecute(0x5b9c20, 0xc20800e010, 0x2, 0x2, 0x0, 0x0)
	/Users/rick/go/src/github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra/command.go:334 +0xd3
github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra.(*Command).Execute(0x5b9c20, 0x0, 0x0)
	/Users/rick/go/src/github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra/command.go:408 +0x7b0
github.com/github/git-lfs/commands.Run()
	/Users/rick/go/src/github.com/github/git-lfs/commands/commands.go:85 +0x2a
main.main()
	/Users/rick/go/src/github.com/github/git-lfs/git-lfs.go:9 +0x1a

ENV:
LocalWorkingDir=/Users/rick/go/src/github.com/github/git-lfs
LocalGitDir=/Users/rick/go/src/github.com/github/git-lfs/.git
LocalMediaDir=/Users/rick/go/src/github.com/github/git-lfs/.git/lfs/objects
TempDir=/Users/rick/go/src/github.com/github/git-lfs/.git/lfs/tmp
ConcurrentTransfers=3
BatchTransfer=false
GIT_LFS_TEST_DIR=/Users/rick/p/git-lfs-temp
GIT_LFS_TEST_MAXPROCS=4
```