### PR TITLE
Correctly detect the absence of `ronn`

### DIFF
--- a/script/man
+++ b/script/man
@@ -1,7 +1,7 @@
 #!/bin/sh
 ronn=`which ronn`
 
-if [ -x $ronn ]; then
+if [ -x "$ronn" ]; then
   mkdir -p man
   rm -rf man/*.ronn
   rm -rf man/*.txt


### PR DESCRIPTION
Just a little fix: without the quotes the -x test passes and you get a weird error along the lines of:
`script/man: line 10: man/git-lfs-checkout.1.ronn: Permission denied`
..if ronn isn't installed, instead of the correct error message: 
`Install the 'ronn' ruby gem to build the man pages.`