### PR TITLE
Fix test race condition

### DIFF
--- a/script/backport-pr
+++ b/script/backport-pr
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Backports a PR into a release branch:
 #

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 # Only set GOPATH on non-Windows platforms as Windows can't do the symlinking

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 script/test
 script/integration

--- a/script/debian-build
+++ b/script/debian-build
@@ -1,8 +1,9 @@
-#!/bin/bash -eux
+#!/usr/bin/env bash
 #
 # This script works with Debian 8 and Ubuntu 14.04 (LTS)
 # Go seems to build poorly on Ubuntu 12.04 (LTS)
 
+set -eux
 trap 'echo FAIL' ERR
 
 apt-get -y update

--- a/script/fmt
+++ b/script/fmt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 formatter=gofmt
 hash goimports 2>/dev/null && {

--- a/script/install.sh.example
+++ b/script/install.sh.example
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/usr/bin/env bash
+set -eu
 
 prefix="/usr/local"
 

--- a/script/integration
+++ b/script/integration
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . "test/testenv.sh"
 set -e

--- a/script/lint
+++ b/script/lint
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 deps=$(go list -f '{{join .Deps "\n"}}' . | xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' | grep -v "github.com/github/git-lfs")
 

--- a/script/man
+++ b/script/man
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 ronn=`which ronn`
 
 if [ -x "$ronn" ]; then

--- a/script/release
+++ b/script/release
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env bash
 script/fmt
 go run script/*.go -cmd release "$@"

--- a/script/run
+++ b/script/run
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 script/fmt
 commit=`git rev-parse --short HEAD`
 go run -ldflags="-X github.com/github/git-lfs/lfs.GitCommit $commit" ./git-lfs.go "$@"

--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #/ Usage: script/test          # run all tests
 #/        script/test <subdir> # run just a package's tests
 

--- a/script/vendor
+++ b/script/vendor
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/env bash
 nut install

--- a/test/README.md
+++ b/test/README.md
@@ -97,7 +97,7 @@ Tests live in this `./test` directory, and must have a unique name like:
 `test/test-happy-path.sh` for an example.
 
 ```
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-batch-transfer-unsupported.sh
+++ b/test/test-batch-transfer-unsupported.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-batch-transfer.sh
+++ b/test/test-batch-transfer.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # This is a sample Git LFS test.  See test/README.md and testhelpers.sh for
 # more documentation.
 

--- a/test/test-checkout.sh
+++ b/test/test-checkout.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-chunked-transfer-encoding-batched.sh
+++ b/test/test-chunked-transfer-encoding-batched.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # This is a sample Git LFS test.  See test/README.md and testhelpers.sh for
 # more documentation.
 

--- a/test/test-chunked-transfer-encoding.sh
+++ b/test/test-chunked-transfer-encoding.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # This is a sample Git LFS test.  See test/README.md and testhelpers.sh for
 # more documentation.
 

--- a/test/test-clean.sh
+++ b/test/test-clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-commit-delete-push.sh
+++ b/test/test-commit-delete-push.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-env.sh
+++ b/test/test-env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-fsck.sh
+++ b/test/test-fsck.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-happy-path.sh
+++ b/test/test-happy-path.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # This is a sample Git LFS test.  See test/README.md and testhelpers.sh for
 # more documentation.
 

--- a/test/test-init.sh
+++ b/test/test-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-init.sh
+++ b/test/test-init.sh
@@ -6,12 +6,6 @@ begin_test "init again"
 (
   set -e
 
-  tmphome="$(basename "$0" ".sh")"
-  mkdir -p $tmphome
-  cp $HOME/.gitconfig $tmphome/
-  HOME=$PWD/$tmphome
-  cd $HOME
-
   [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
   [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
 
@@ -25,11 +19,6 @@ end_test
 begin_test "init with old settings"
 (
   set -e
-
-  tmphome="$(basename "$0" ".sh")"
-  mkdir -p $tmphome
-  HOME=$PWD/$tmphome
-  cd $HOME
 
   git config --global filter.lfs.smudge "git lfs smudge %f"
   git config --global filter.lfs.clean "git lfs clean %f"

--- a/test/test-logs.sh
+++ b/test/test-logs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-pointer.sh
+++ b/test/test-pointer.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-pull.sh
+++ b/test/test-pull.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-smudge.sh
+++ b/test/test-smudge.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-status.sh
+++ b/test/test-status.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-submodule.sh
+++ b/test/test-submodule.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 reponame="submodule-test-repo"

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-uninit.sh
+++ b/test/test-uninit.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-uninit.sh
+++ b/test/test-uninit.sh
@@ -6,12 +6,6 @@ begin_test "uninit outside repository"
 (
   set -e
 
-  tmphome="$(basename "$0" ".sh")"
-  mkdir -p $tmphome
-  cp $HOME/.gitconfig $tmphome/
-  HOME=$PWD/$tmphome
-  cd $HOME
-
   [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
   [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
 
@@ -32,12 +26,6 @@ end_test
 begin_test "uninit inside repository with default pre-push hook"
 (
   set -e
-
-  tmphome="$(basename "$0" ".sh")"
-  mkdir -p $tmphome
-  cp $HOME/.gitconfig $tmphome/
-  HOME=$PWD/$tmphome
-  cd $HOME
 
   reponame="$(basename "$0" ".sh")-hook"
   mkdir "$reponame"
@@ -66,12 +54,6 @@ begin_test "uninit inside repository without git lfs pre-push hook"
 (
   set -e
 
-  tmphome="$(basename "$0" ".sh")"
-  mkdir -p $tmphome
-  cp $HOME/.gitconfig $tmphome/
-  HOME=$PWD/$tmphome
-  cd $HOME
-
   reponame="$(basename "$0" ".sh")-no-hook"
   mkdir "$reponame"
   cd "$reponame"
@@ -97,12 +79,6 @@ end_test
 begin_test "uninit hooks inside repository"
 (
   set -e
-
-  tmphome="$(basename "$0" ".sh")"
-  mkdir -p $tmphome
-  cp $HOME/.gitconfig $tmphome/
-  HOME=$PWD/$tmphome
-  cd $HOME
 
   reponame="$(basename "$0" ".sh")-only-hook"
   mkdir "$reponame"

--- a/test/test-untrack.sh
+++ b/test/test-untrack.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
 

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -1,7 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 . "test/testlib.sh"
-
 
 begin_test "update"
 (

--- a/test/testenv.sh
+++ b/test/testenv.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Including in script/integration and every test/test-*.sh file.
 
 set -e

--- a/test/testenv.sh
+++ b/test/testenv.sh
@@ -32,9 +32,17 @@ LFS_CONFIG="$REMOTEDIR/config"
 # section in test/README.md
 LFS_URL_FILE="$REMOTEDIR/url"
 
-HOME="$REMOTEDIR/home"
+# the fake home dir used for the initial setup
+TESTHOME="$REMOTEDIR/home"
+
 GIT_CONFIG_NOSYSTEM=1
 
+if [[ `git config --system credential.helper | grep osxkeychain` == "osxkeychain" ]]
+then
+  OSXKEYFILE="$TMPDIR/temp.keychain"
+fi
+
+mkdir -p "$TMPDIR"
 mkdir -p "$TRASHDIR"
 
 . "test/testhelpers.sh"

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # assert_pointer confirms that the pointer in the repository for $path in the
 # given $ref matches the given $oid and $size.

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Usage: . testlib.sh
 # Simple shell command language test library.
 #

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -74,7 +74,14 @@ begin_test () {
     exec 1>"$out" 2>"$err"
 
     # reset global git config
-    cp "$HOME/.gitconfig-backup" "$HOME/.gitconfig"
+    HOME="$TRASHDIR/home"
+    rm -rf "$TRASHDIR/home"
+    mkdir "$HOME"
+    cp "$TESTHOME/.gitconfig" "$HOME/.gitconfig"
+
+    if [ "$OSXKEYFILE" ]; then
+      ln -s "$TESTHOME/Library" "$HOME"
+    fi
 
     # allow the subshell to exit non-zero without exiting this process
     set -x +e

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -20,6 +20,8 @@
 # Copyright (c) 2011-13 by Ryan Tomayko <http://tomayko.com>
 # License: MIT
 
+fullfile="$(pwd)/$0"
+
 . "test/testenv.sh"
 set -e
 
@@ -33,9 +35,17 @@ atexit () {
 
   if [ $failures -gt 0 ]; then
     exit 1
-  else
-    exit 0
   fi
+
+  greptests=`grep 'begin_test "' "$fullfile" -c`
+  if [ "$tests" != "$greptests" ]; then
+    echo
+    echo "Expected to run these $greptests test(s) in $fullfile, but only ran $tests"
+    grep 'begin_test "' "$fullfile"
+    exit 1
+  fi
+
+  exit 0
 }
 
 # create the trash dir

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -37,14 +37,6 @@ atexit () {
     exit 1
   fi
 
-  greptests=`grep 'begin_test "' "$fullfile" -c`
-  if [ "$tests" != "$greptests" ]; then
-    echo
-    echo "Expected to run these $greptests test(s) in $fullfile, but only ran $tests"
-    grep 'begin_test "' "$fullfile"
-    exit 1
-  fi
-
   exit 0
 }
 


### PR DESCRIPTION
This attempts to fix the race condition regarding `$HOME` in the integration tests.

Now, an initial `$TESTHOME` is setup at `$REMOTEDIR/home`. It has the starting git config and OSX keychain (if needed). `begin_test()` resets `$HOME` to `$TRASHDIR/home`, which is unique per test script. Tests run sequentially in a single script.

I also ran into an issue where `begin_test()` was silently failing, causing the scripts to bail after the first test. So, I added something in `shutdown()` that ensures every test runs by grepping the file for all `begin_test()` calls.