### PR TITLE
Support `git lfs checkout .` and similar correctly

### DIFF
--- a/lfs/util.go
+++ b/lfs/util.go
@@ -115,6 +115,11 @@ func FilenamePassesIncludeExcludeFilter(filename string, includePaths, excludePa
 	if len(includePaths) > 0 {
 		matched := false
 		for _, inc := range includePaths {
+			// Special case local dir, matches all (inc subpaths)
+			if inc == "." || inc == "./" || inc == ".\\" {
+				matched = true
+				break
+			}
 			matched, _ = filepath.Match(inc, filename)
 			if !matched && IsWindows() {
 				// Also Win32 match
@@ -138,6 +143,10 @@ func FilenamePassesIncludeExcludeFilter(filename string, includePaths, excludePa
 
 	if len(excludePaths) > 0 {
 		for _, ex := range excludePaths {
+			// Special case local dir, matches all (inc subpaths)
+			if ex == "." || ex == "./" || ex == ".\\" {
+				return false
+			}
 			matched, _ := filepath.Match(ex, filename)
 			if !matched && IsWindows() {
 				// Also Win32 match

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -110,13 +110,18 @@ func FilenamePassesIncludeExcludeFilter(filename string, includePaths, excludePa
 		return true
 	}
 
+	matchLocalDir := map[string]struct{}{
+		".":   {},
+		"./":  {},
+		".\\": {},
+	}
 	// For Win32, because git reports files with / separators
 	cleanfilename := filepath.Clean(filename)
 	if len(includePaths) > 0 {
 		matched := false
 		for _, inc := range includePaths {
 			// Special case local dir, matches all (inc subpaths)
-			if inc == "." || inc == "./" || inc == ".\\" {
+			if _, local := matchLocalDir[inc]; local {
 				matched = true
 				break
 			}
@@ -144,7 +149,7 @@ func FilenamePassesIncludeExcludeFilter(filename string, includePaths, excludePa
 	if len(excludePaths) > 0 {
 		for _, ex := range excludePaths {
 			// Special case local dir, matches all (inc subpaths)
-			if ex == "." || ex == "./" || ex == ".\\" {
+			if _, local := matchLocalDir[ex]; local {
 				return false
 			}
 			matched, _ := filepath.Match(ex, filename)

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -101,6 +101,12 @@ func wrapProgressError(err error, event, filename string) error {
 	return nil
 }
 
+var localDirSet = map[string]struct{}{
+	".":   {},
+	"./":  {},
+	".\\": {},
+}
+
 // Return whether a given filename passes the include / exclude path filters
 // Only paths that are in includePaths and outside excludePaths are passed
 // If includePaths is empty that filter always passes and the same with excludePaths
@@ -110,18 +116,13 @@ func FilenamePassesIncludeExcludeFilter(filename string, includePaths, excludePa
 		return true
 	}
 
-	matchLocalDir := map[string]struct{}{
-		".":   {},
-		"./":  {},
-		".\\": {},
-	}
 	// For Win32, because git reports files with / separators
 	cleanfilename := filepath.Clean(filename)
 	if len(includePaths) > 0 {
 		matched := false
 		for _, inc := range includePaths {
 			// Special case local dir, matches all (inc subpaths)
-			if _, local := matchLocalDir[inc]; local {
+			if _, local := localDirSet[inc]; local {
 				matched = true
 				break
 			}
@@ -149,7 +150,7 @@ func FilenamePassesIncludeExcludeFilter(filename string, includePaths, excludePa
 	if len(excludePaths) > 0 {
 		for _, ex := range excludePaths {
 			// Special case local dir, matches all (inc subpaths)
-			if _, local := matchLocalDir[ex]; local {
+			if _, local := localDirSet[ex]; local {
 				return false
 			}
 			matched, _ := filepath.Match(ex, filename)

--- a/test/test-checkout.sh
+++ b/test/test-checkout.sh
@@ -70,10 +70,24 @@ begin_test "checkout"
   git lfs checkout nested.dat
   [ "$contents" = "$(cat nested.dat)" ]
   [ ! -f ../folder2/nested.dat ]
+  # test '.' in current dir
+  rm nested.dat
+  git lfs checkout .
+  [ "$contents" = "$(cat nested.dat)" ]  
   popd
 
   # test folder param
   git lfs checkout folder2
   [ "$contents" = "$(cat folder2/nested.dat)" ]
+
+  # test '.' in current dir
+  rm -rf file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat
+  git lfs checkout .
+  [ "$contents" = "$(cat file1.dat)" ]
+  [ "$contents" = "$(cat file2.dat)" ]
+  [ "$contents" = "$(cat file3.dat)" ]
+  [ "$contents" = "$(cat folder1/nested.dat)" ]
+  [ "$contents" = "$(cat folder2/nested.dat)" ]
+
 )
 end_test


### PR DESCRIPTION
Previously using `.` `./` and `.\` would only behave as expected in subdirs
(because calculating the relative dir would resolve it), using them in the
root would match nothing. Behave as expected instead.