### PR TITLE
Suppress progress output for a push dry run

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -73,7 +73,7 @@ func fetchAndReportToChan(pointers []*lfs.WrappedPointer, out chan<- *lfs.Wrappe
 	for _, p := range pointers {
 		totalSize += p.Size
 	}
-	q := lfs.NewDownloadQueue(lfs.Config.ConcurrentTransfers(), len(pointers), totalSize, false)
+	q := lfs.NewDownloadQueue(len(pointers), totalSize, false)
 
 	for _, p := range pointers {
 		// Only add to download queue if local file is not the right size already

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -73,7 +73,7 @@ func fetchAndReportToChan(pointers []*lfs.WrappedPointer, out chan<- *lfs.Wrappe
 	for _, p := range pointers {
 		totalSize += p.Size
 	}
-	q := lfs.NewDownloadQueue(lfs.Config.ConcurrentTransfers(), len(pointers), totalSize)
+	q := lfs.NewDownloadQueue(lfs.Config.ConcurrentTransfers(), len(pointers), totalSize, false)
 
 	for _, p := range pointers {
 		// Only add to download queue if local file is not the right size already

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -76,12 +76,11 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 		totalSize += p.Size
 	}
 
-	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(pointers), totalSize)
+	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(pointers), totalSize, prePushDryRun)
 
 	for _, pointer := range pointers {
 		if prePushDryRun {
 			Print("push %s", pointer.Name)
-			uploadQueue.SuppressProgress()
 			continue
 		}
 

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -76,7 +76,7 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 		totalSize += p.Size
 	}
 
-	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(pointers), totalSize, prePushDryRun)
+	uploadQueue := lfs.NewUploadQueue(len(pointers), totalSize, prePushDryRun)
 
 	for _, pointer := range pointers {
 		if prePushDryRun {

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -37,11 +37,7 @@ func uploadsBetweenRefs(left string, right string) *lfs.TransferQueue {
 		totalSize += p.Size
 	}
 
-	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(pointers), totalSize)
-	if pushDryRun {
-		uploadQueue.SuppressProgress()
-	}
-
+	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(pointers), totalSize, pushDryRun)
 	for i, pointer := range pointers {
 		if pushDryRun {
 			Print("push %s", pointer.Name)
@@ -86,10 +82,7 @@ func uploadsWithObjectIDs(oids []string) *lfs.TransferQueue {
 		uploads = append(uploads, u)
 	}
 
-	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(oids), totalSize)
-	if pushDryRun {
-		uploadQueue.SuppressProgress()
-	}
+	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(oids), totalSize, pushDryRun)
 
 	for _, u := range uploads {
 		uploadQueue.Add(u)

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -37,7 +37,7 @@ func uploadsBetweenRefs(left string, right string) *lfs.TransferQueue {
 		totalSize += p.Size
 	}
 
-	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(pointers), totalSize, pushDryRun)
+	uploadQueue := lfs.NewUploadQueue(len(pointers), totalSize, pushDryRun)
 	for i, pointer := range pointers {
 		if pushDryRun {
 			Print("push %s", pointer.Name)
@@ -82,7 +82,7 @@ func uploadsWithObjectIDs(oids []string) *lfs.TransferQueue {
 		uploads = append(uploads, u)
 	}
 
-	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(oids), totalSize, pushDryRun)
+	uploadQueue := lfs.NewUploadQueue(len(oids), totalSize, pushDryRun)
 
 	for _, u := range uploads {
 		uploadQueue.Add(u)

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -38,6 +38,9 @@ func uploadsBetweenRefs(left string, right string) *lfs.TransferQueue {
 	}
 
 	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(pointers), totalSize)
+	if pushDryRun {
+		uploadQueue.SuppressProgress()
+	}
 
 	for i, pointer := range pointers {
 		if pushDryRun {
@@ -84,6 +87,9 @@ func uploadsWithObjectIDs(oids []string) *lfs.TransferQueue {
 	}
 
 	uploadQueue := lfs.NewUploadQueue(lfs.Config.ConcurrentTransfers(), len(oids), totalSize)
+	if pushDryRun {
+		uploadQueue.SuppressProgress()
+	}
 
 	for _, u := range uploads {
 		uploadQueue.Add(u)
@@ -185,8 +191,6 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		if len(uploadQueue.Errors()) > 0 {
 			os.Exit(2)
 		}
-	} else {
-		uploadQueue.SuppressProgress()
 	}
 }
 

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -185,6 +185,8 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		if len(uploadQueue.Errors()) > 0 {
 			os.Exit(2)
 		}
+	} else {
+		uploadQueue.SuppressProgress()
 	}
 }
 

--- a/lfs/download_queue.go
+++ b/lfs/download_queue.go
@@ -42,8 +42,8 @@ func (d *Downloadable) SetObject(o *objectResource) {
 }
 
 // NewDownloadQueue builds a DownloadQueue, allowing `workers` concurrent downloads.
-func NewDownloadQueue(workers, files int, size int64) *TransferQueue {
-	q := newTransferQueue(workers, files, size)
+func NewDownloadQueue(workers, files int, size int64, dryRun bool) *TransferQueue {
+	q := newTransferQueue(workers, files, size, dryRun)
 	q.transferKind = "download"
 	return q
 }

--- a/lfs/download_queue.go
+++ b/lfs/download_queue.go
@@ -42,8 +42,8 @@ func (d *Downloadable) SetObject(o *objectResource) {
 }
 
 // NewDownloadQueue builds a DownloadQueue, allowing `workers` concurrent downloads.
-func NewDownloadQueue(workers, files int, size int64, dryRun bool) *TransferQueue {
-	q := newTransferQueue(workers, files, size, dryRun)
+func NewDownloadQueue(files int, size int64, dryRun bool) *TransferQueue {
+	q := newTransferQueue(files, size, dryRun)
 	q.transferKind = "download"
 	return q
 }

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -38,13 +38,13 @@ type TransferQueue struct {
 }
 
 // newTransferQueue builds a TransferQueue, allowing `workers` concurrent transfers.
-func newTransferQueue(workers, files int, size int64, dryRun bool) *TransferQueue {
+func newTransferQueue(files int, size int64, dryRun bool) *TransferQueue {
 	q := &TransferQueue{
 		meter:         NewProgressMeter(files, size, dryRun),
 		apic:          make(chan Transferable, batchSize),
 		transferc:     make(chan Transferable, batchSize),
 		errorc:        make(chan *WrappedError),
-		workers:       workers,
+		workers:       Config.ConcurrentTransfers(),
 		transferables: make(map[string]Transferable),
 	}
 

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -38,9 +38,9 @@ type TransferQueue struct {
 }
 
 // newTransferQueue builds a TransferQueue, allowing `workers` concurrent transfers.
-func newTransferQueue(workers, files int, size int64) *TransferQueue {
+func newTransferQueue(workers, files int, size int64, dryRun bool) *TransferQueue {
 	q := &TransferQueue{
-		meter:         NewProgressMeter(files, size),
+		meter:         NewProgressMeter(files, size, dryRun),
 		apic:          make(chan Transferable, batchSize),
 		transferc:     make(chan Transferable, batchSize),
 		errorc:        make(chan *WrappedError),
@@ -90,11 +90,6 @@ func (q *TransferQueue) Watch() chan string {
 	c := make(chan string, batchSize)
 	q.watchers = append(q.watchers, c)
 	return c
-}
-
-// SuppressProgress turns off progress metering for the TransferQueue
-func (q *TransferQueue) SuppressProgress() {
-	q.meter.Suppress()
 }
 
 // individualApiRoutine processes the queue of transfers one at a time by making

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -71,8 +71,8 @@ func (u *Uploadable) SetObject(o *objectResource) {
 }
 
 // NewUploadQueue builds an UploadQueue, allowing `workers` concurrent uploads.
-func NewUploadQueue(workers, files int, size int64) *TransferQueue {
-	q := newTransferQueue(workers, files, size)
+func NewUploadQueue(workers, files int, size int64, dryRun bool) *TransferQueue {
+	q := newTransferQueue(workers, files, size, dryRun)
 	q.transferKind = "upload"
 	return q
 }

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -71,8 +71,8 @@ func (u *Uploadable) SetObject(o *objectResource) {
 }
 
 // NewUploadQueue builds an UploadQueue, allowing `workers` concurrent uploads.
-func NewUploadQueue(workers, files int, size int64, dryRun bool) *TransferQueue {
-	q := newTransferQueue(workers, files, size, dryRun)
+func NewUploadQueue(files int, size int64, dryRun bool) *TransferQueue {
+	q := newTransferQueue(files, size, dryRun)
 	q.transferKind = "upload"
 	return q
 }


### PR DESCRIPTION
There should be a `SuppressProgress()` call on the upload queue when it's doing a dry run. I added it to the `pre-push` stuff but overlooked it for `push`. It only fails intermittently because the progress meter output is written in a goroutine, so during a dry run it's possible that the `push` command exits before the goroutine ever runs. On slower or more utilized machines, like this CI, it gets a chance to run and shows progress output.