### PR TITLE
Don't panic if we can't find the git commit for the version

### DIFF
--- a/script/build.go
+++ b/script/build.go
@@ -36,9 +36,6 @@ func mainBuild() {
 	}
 
 	cmd, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
-	if err != nil {
-		panic(err)
-	}
 
 	if len(cmd) > 0 {
 		LdFlag = strings.TrimSpace("-X github.com/github/git-lfs/lfs.GitCommit " + string(cmd))

--- a/script/build.go
+++ b/script/build.go
@@ -35,7 +35,7 @@ func mainBuild() {
 		return
 	}
 
-	cmd, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
+	cmd, _ := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
 
 	if len(cmd) > 0 {
 		LdFlag = strings.TrimSpace("-X github.com/github/git-lfs/lfs.GitCommit " + string(cmd))


### PR DESCRIPTION
When building from a non git checkout the build script would panic when it can't find the commit hash. Instead, just ignore it.

Fixes #548