### PR TITLE
Backport #549 for v0.5.x: Don't panic if we can't find the git commit for the version

### DIFF
--- a/script/build.go
+++ b/script/build.go
@@ -35,10 +35,7 @@ func mainBuild() {
 		return
 	}
 
-	cmd, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
-	if err != nil {
-		panic(err)
-	}
+	cmd, _ := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
 
 	if len(cmd) > 0 {
 		LdFlag = strings.TrimSpace("-X github.com/github/git-lfs/lfs.GitCommit " + string(cmd))


### PR DESCRIPTION
This backports #549.