### PR TITLE
Add progress meter to checkout

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -101,7 +101,7 @@ func checkoutWithIncludeExclude(include []string, exclude []string) {
 	var wait sync.WaitGroup
 	wait.Add(1)
 
-	c := make(chan *lfs.WrappedPointer)
+	c := make(chan *lfs.WrappedPointer, 1)
 
 	go func() {
 		checkoutWithChan(c)
@@ -114,6 +114,7 @@ func checkoutWithIncludeExclude(include []string, exclude []string) {
 		totalBytes += pointer.Size
 	}
 	progress := lfs.NewProgressMeter(len(pointers), totalBytes, false)
+	progress.Start()
 	totalBytes = 0
 	for _, pointer := range pointers {
 		totalBytes += pointer.Size


### PR DESCRIPTION
Only displayed when running a separate checkout command, not on pull (lets the download queue do the progress to avoid mixing the 2)