### PR TITLE
build a helper for confirming the git version in tests

### DIFF
--- a/test/test-worktree.sh
+++ b/test/test-worktree.sh
@@ -2,12 +2,7 @@
 
 . "test/testlib.sh"
 
-# git 2.5 or higher only
-compare_version $(git version | cut -d" " -f3) "2.5.0"
-if [[ $? == $VERSION_LOWER ]]; then
-  echo "Skipping git worktree tests since git version < 2.5.0"
-  exit
-fi
+ensure_git_version_isnt $VERSION_LOWER "2.5.0"
 
 begin_test "git worktree"
 (

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -209,9 +209,27 @@ shutdown() {
   fi
 }
 
+ensure_git_version_isnt() {
+  local expectedComparison=$1
+  local version=$2
+
+  local gitVersion=$(git version | cut -d" " -f3)
+
+  set +e
+  compare_version $gitVersion $version
+  result=$?
+  set -e
+
+  if [[ $result == $expectedComparison ]]; then
+    echo "skip: $0 (git version $(comparison_to_operator $expectedComparison) $version)"
+    exit
+  fi
+}
+
 VERSION_EQUAL=0
 VERSION_HIGHER=1
 VERSION_LOWER=2
+
 # Compare $1 and $2 and return VERSION_EQUAL / VERSION_LOWER / VERSION_HIGHER
 compare_version() {
     if [[ $1 == $2 ]]
@@ -242,4 +260,17 @@ compare_version() {
         fi
     done
     return $VERSION_EQUAL
+}
+
+comparison_to_operator() {
+  local comparison=$1
+  if [[ $1 == $VERSION_EQUAL ]]; then
+    echo "=="
+  elif [[ $1 == $VERSION_HIGHER ]]; then
+    echo ">"
+  elif [[ $1 == $VERSION_LOWER ]]; then
+    echo "<"
+  else
+    echo "???"
+  fi
 }


### PR DESCRIPTION
I didn't notice until too late that the skip message from #546 never showed up. The problem is that `comparison_to_operator()` causes the script to halt if it returns something other than `$VERSION_EQUAL` (0) because of `set -e`.

/cc @sinbad 