### PR TITLE
Support new batch API

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -40,9 +40,15 @@ var (
 )
 
 type objectResource struct {
-	Oid   string                   `json:"oid,omitempty"`
-	Size  int64                    `json:"size"`
-	Links map[string]*linkRelation `json:"_links,omitempty"`
+	Oid     string                   `json:"oid,omitempty"`
+	Size    int64                    `json:"size"`
+	Actions map[string]*linkRelation `json:"actions,omitempty"`
+	Error   objectError              `json:"error,omitempty"`
+}
+
+type objectError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
 }
 
 func (o *objectResource) NewRequest(relation, method string) (*http.Request, Creds, error) {
@@ -60,11 +66,11 @@ func (o *objectResource) NewRequest(relation, method string) (*http.Request, Cre
 }
 
 func (o *objectResource) Rel(name string) (*linkRelation, bool) {
-	if o.Links == nil {
+	if o.Actions == nil {
 		return nil, false
 	}
 
-	rel, ok := o.Links[name]
+	rel, ok := o.Actions[name]
 	return rel, ok
 }
 

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -212,6 +212,8 @@ func Batch(objects []*objectResource, operation string) ([]*objectResource, *Wra
 			tracerx.Printf("api: batch not implemented: %d", res.StatusCode)
 			return nil, Error(newNotImplError())
 		}
+
+		tracerx.Printf("api error: %s", wErr)
 	}
 	LogTransfer("lfs.api.batch", res)
 

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -71,16 +71,15 @@ func (o *objectResource) NewRequest(relation, method string) (*http.Request, Cre
 }
 
 func (o *objectResource) Rel(name string) (*linkRelation, bool) {
-	actions := o.Actions
-	if actions == nil {
-		actions = o.Links
+	var rel *linkRelation
+	var ok bool
+
+	if o.Actions != nil {
+		rel, ok = o.Actions[name]
+	} else {
+		rel, ok = o.Links[name]
 	}
 
-	if actions == nil {
-		return nil, false
-	}
-
-	rel, ok := actions[name]
 	return rel, ok
 }
 

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -39,17 +39,21 @@ var (
 	}
 )
 
+type objectError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *objectError) Error() string {
+	return fmt.Sprintf("[%d] %s", e.Code, e.Message)
+}
+
 type objectResource struct {
 	Oid     string                   `json:"oid,omitempty"`
 	Size    int64                    `json:"size"`
 	Actions map[string]*linkRelation `json:"actions,omitempty"`
 	Links   map[string]*linkRelation `json:"_links,omitempty"`
-	Error   objectError              `json:"error,omitempty"`
-}
-
-type objectError struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
+	Error   *objectError             `json:"error,omitempty"`
 }
 
 func (o *objectResource) NewRequest(relation, method string) (*http.Request, Creds, error) {

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -43,6 +43,7 @@ type objectResource struct {
 	Oid     string                   `json:"oid,omitempty"`
 	Size    int64                    `json:"size"`
 	Actions map[string]*linkRelation `json:"actions,omitempty"`
+	Links   map[string]*linkRelation `json:"_links,omitempty"`
 	Error   objectError              `json:"error,omitempty"`
 }
 
@@ -66,11 +67,16 @@ func (o *objectResource) NewRequest(relation, method string) (*http.Request, Cre
 }
 
 func (o *objectResource) Rel(name string) (*linkRelation, bool) {
-	if o.Actions == nil {
+	actions := o.Actions
+	if actions == nil {
+		actions = o.Links
+	}
+
+	if actions == nil {
 		return nil, false
 	}
 
-	rel, ok := o.Actions[name]
+	rel, ok := actions[name]
 	return rel, ok
 }
 

--- a/lfs/download_test.go
+++ b/lfs/download_test.go
@@ -39,7 +39,7 @@ func TestSuccessfulDownload(t *testing.T) {
 		obj := &objectResource{
 			Oid:  "oid",
 			Size: 4,
-			Links: map[string]*linkRelation{
+			Actions: map[string]*linkRelation{
 				"download": &linkRelation{
 					Href:   server.URL + "/download",
 					Header: map[string]string{"A": "1"},
@@ -171,7 +171,7 @@ func TestSuccessfulDownloadWithRedirects(t *testing.T) {
 		obj := &objectResource{
 			Oid:  "oid",
 			Size: 4,
-			Links: map[string]*linkRelation{
+			Actions: map[string]*linkRelation{
 				"download": &linkRelation{
 					Href:   server.URL + "/download",
 					Header: map[string]string{"A": "1"},
@@ -273,7 +273,7 @@ func TestSuccessfulDownloadWithAuthorization(t *testing.T) {
 		obj := &objectResource{
 			Oid:  "oid",
 			Size: 4,
-			Links: map[string]*linkRelation{
+			Actions: map[string]*linkRelation{
 				"download": &linkRelation{
 					Href: server.URL + "/download",
 					Header: map[string]string{
@@ -379,7 +379,7 @@ func TestSuccessfulDownloadFromSeparateHost(t *testing.T) {
 		obj := &objectResource{
 			Oid:  "oid",
 			Size: 4,
-			Links: map[string]*linkRelation{
+			Actions: map[string]*linkRelation{
 				"download": &linkRelation{
 					Href:   server2.URL + "/download",
 					Header: map[string]string{"A": "1"},
@@ -513,7 +513,7 @@ func TestSuccessfulDownloadFromSeparateRedirectedHost(t *testing.T) {
 		obj := &objectResource{
 			Oid:  "oid",
 			Size: 4,
-			Links: map[string]*linkRelation{
+			Actions: map[string]*linkRelation{
 				"download": &linkRelation{
 					Href:   server3.URL + "/download",
 					Header: map[string]string{"A": "1"},
@@ -640,7 +640,7 @@ func TestDownloadStorageError(t *testing.T) {
 		obj := &objectResource{
 			Oid:  "oid",
 			Size: 4,
-			Links: map[string]*linkRelation{
+			Actions: map[string]*linkRelation{
 				"download": &linkRelation{
 					Href:   server.URL + "/download",
 					Header: map[string]string{"A": "1"},

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -176,6 +176,14 @@ func (q *TransferQueue) batchApiRoutine() {
 
 		for _, o := range objects {
 			if _, ok := o.Rel(q.transferKind); ok {
+				// This object has an error
+				if o.Error != nil {
+					q.errorc <- Error(o.Error)
+					q.meter.Skip(o.Size)
+					q.wait.Done()
+					continue
+				}
+
 				// This object needs to be transferred
 				if transfer, ok := q.transferables[o.Oid]; ok {
 					transfer.SetObject(o)

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -175,7 +175,7 @@ func (q *TransferQueue) batchApiRoutine() {
 		}
 
 		for _, o := range objects {
-			if _, ok := o.Actions[q.transferKind]; ok {
+			if _, ok := o.Rel(q.transferKind); ok {
 				// This object needs to be transferred
 				if transfer, ok := q.transferables[o.Oid]; ok {
 					transfer.SetObject(o)

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -175,7 +175,7 @@ func (q *TransferQueue) batchApiRoutine() {
 		}
 
 		for _, o := range objects {
-			if _, ok := o.Links[q.transferKind]; ok {
+			if _, ok := o.Actions[q.transferKind]; ok {
 				// This object needs to be transferred
 				if transfer, ok := q.transferables[o.Oid]; ok {
 					transfer.SetObject(o)

--- a/lfs/upload_test.go
+++ b/lfs/upload_test.go
@@ -66,7 +66,7 @@ func TestExistingUpload(t *testing.T) {
 		obj := &objectResource{
 			Oid:  reqObj.Oid,
 			Size: reqObj.Size,
-			Links: map[string]*linkRelation{
+			Actions: map[string]*linkRelation{
 				"upload": &linkRelation{
 					Href:   server.URL + "/upload",
 					Header: map[string]string{"A": "1"},
@@ -202,7 +202,7 @@ func TestUploadWithRedirect(t *testing.T) {
 		}
 
 		obj := &objectResource{
-			Links: map[string]*linkRelation{
+			Actions: map[string]*linkRelation{
 				"upload": &linkRelation{
 					Href:   server.URL + "/upload",
 					Header: map[string]string{"A": "1"},
@@ -296,7 +296,7 @@ func TestSuccessfulUploadWithVerify(t *testing.T) {
 		obj := &objectResource{
 			Oid:  reqObj.Oid,
 			Size: reqObj.Size,
-			Links: map[string]*linkRelation{
+			Actions: map[string]*linkRelation{
 				"upload": &linkRelation{
 					Href:   server.URL + "/upload",
 					Header: map[string]string{"A": "1"},
@@ -498,7 +498,7 @@ func TestSuccessfulUploadWithoutVerify(t *testing.T) {
 		obj := &objectResource{
 			Oid:  reqObj.Oid,
 			Size: reqObj.Size,
-			Links: map[string]*linkRelation{
+			Actions: map[string]*linkRelation{
 				"upload": &linkRelation{
 					Href:   server.URL + "/upload",
 					Header: map[string]string{"A": "1"},
@@ -680,7 +680,7 @@ func TestUploadStorageError(t *testing.T) {
 		obj := &objectResource{
 			Oid:  reqObj.Oid,
 			Size: reqObj.Size,
-			Links: map[string]*linkRelation{
+			Actions: map[string]*linkRelation{
 				"upload": &linkRelation{
 					Href:   server.URL + "/upload",
 					Header: map[string]string{"A": "1"},
@@ -796,7 +796,7 @@ func TestUploadVerifyError(t *testing.T) {
 		obj := &objectResource{
 			Oid:  reqObj.Oid,
 			Size: reqObj.Size,
-			Links: map[string]*linkRelation{
+			Actions: map[string]*linkRelation{
 				"upload": &linkRelation{
 					Href:   server.URL + "/upload",
 					Header: map[string]string{"A": "1"},

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -81,9 +81,9 @@ func main() {
 }
 
 type lfsObject struct {
-	Oid   string             `json:"oid,omitempty"`
-	Size  int64              `json:"size,omitempty"`
-	Links map[string]lfsLink `json:"_links,omitempty"`
+	Oid     string             `json:"oid,omitempty"`
+	Size    int64              `json:"size,omitempty"`
+	Actions map[string]lfsLink `json:"actions,omitempty"`
 }
 
 type lfsLink struct {
@@ -140,7 +140,7 @@ func lfsPostHandler(w http.ResponseWriter, r *http.Request, repo string) {
 	res := &lfsObject{
 		Oid:  obj.Oid,
 		Size: obj.Size,
-		Links: map[string]lfsLink{
+		Actions: map[string]lfsLink{
 			"upload": lfsLink{
 				Href:   lfsUrl(repo, obj.Oid),
 				Header: map[string]string{},
@@ -149,7 +149,7 @@ func lfsPostHandler(w http.ResponseWriter, r *http.Request, repo string) {
 	}
 
 	if testingChunkedTransferEncoding(r) {
-		res.Links["upload"].Header["Transfer-Encoding"] = "chunked"
+		res.Actions["upload"].Header["Transfer-Encoding"] = "chunked"
 	}
 
 	by, err := json.Marshal(res)
@@ -177,7 +177,7 @@ func lfsGetHandler(w http.ResponseWriter, r *http.Request, repo string) {
 	obj := &lfsObject{
 		Oid:  oid,
 		Size: int64(len(by)),
-		Links: map[string]lfsLink{
+		Actions: map[string]lfsLink{
 			"download": lfsLink{
 				Href: lfsUrl(repo, oid),
 			},
@@ -227,7 +227,7 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, repo string) {
 		o := lfsObject{
 			Oid:  obj.Oid,
 			Size: obj.Size,
-			Links: map[string]lfsLink{
+			Actions: map[string]lfsLink{
 				"upload": lfsLink{
 					Href:   lfsUrl(repo, obj.Oid),
 					Header: map[string]string{},
@@ -236,7 +236,7 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, repo string) {
 		}
 
 		if testingChunked {
-			o.Links["upload"].Header["Transfer-Encoding"] = "chunked"
+			o.Actions["upload"].Header["Transfer-Encoding"] = "chunked"
 		}
 
 		res = append(res, o)


### PR DESCRIPTION
This adds support for the batch api outlined in #437

- [x] `_links` => `actions`
- [x] Handle the new `error` property
