### PR TITLE
Support using credentials from multiple accounts against the LFS endpoint

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -653,7 +653,7 @@ func getCreds(req *http.Request) (Creds, error) {
 		}
 	}
 
-	creds, err := credentials(req.URL)
+	creds, err := credentials(apiUrl)
 	if err != nil {
 		return nil, err
 	}

--- a/lfs/credentials.go
+++ b/lfs/credentials.go
@@ -17,7 +17,8 @@ type credentialFunc func(Creds, string) (credentialFetcher, error)
 var execCreds credentialFunc
 
 func credentials(u *url.URL) (Creds, error) {
-	creds := Creds{"protocol": u.Scheme, "host": u.Host, "path": u.Path}
+	path := strings.TrimPrefix(u.Path, "/")
+	creds := Creds{"protocol": u.Scheme, "host": u.Host, "path": path}
 	cmd, err := execCreds(creds, "fill")
 	if err != nil {
 		return nil, err

--- a/lfs/credentials.go
+++ b/lfs/credentials.go
@@ -17,7 +17,7 @@ type credentialFunc func(Creds, string) (credentialFetcher, error)
 var execCreds credentialFunc
 
 func credentials(u *url.URL) (Creds, error) {
-	creds := Creds{"protocol": u.Scheme, "host": u.Host}
+	creds := Creds{"protocol": u.Scheme, "host": u.Host, "path": u.Path}
 	cmd, err := execCreds(creds, "fill")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Support credentials from multiple accounts when useHttpPath=true is set in the git config

Provide the URL path to 'git credential fill' for credential helpers that need the path to return the right credentials
Use the objects API URL for credentials so there is a stable path passed to the credential helper for caching