### PR TITLE
Adding parsing methods to extract LFS references from arbitrary history

### DIFF
--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -623,6 +623,8 @@ func parseLogOutputToPointers(log io.Reader, dir LogDiffDirection,
 				p, err := DecodePointer(&pointerData)
 				if err == nil {
 					results <- &WrappedPointer{Name: currentFilename, Size: p.Size, Pointer: p}
+				} else {
+					tracerx.Printf("Unable to parse pointer from log: %v", err)
 				}
 			}
 			pointerData.Reset()

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -32,7 +32,7 @@ var (
 	logLfsSearchArgs = []string{
 		"-G", "oid sha256:", // only diffs which include an lfs file SHA change
 		"-p",   // include diff so we can read the SHA
-		"-U10", // Make sure diff context is always big enough to support extension lines to get whole pointer
+		"-U12", // Make sure diff context is always big enough to support 10 extension lines to get whole pointer
 		`--format=lfs-commit-sha: %H %P`, // just a predictable commit header we can detect
 	}
 )

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -31,8 +31,8 @@ var (
 	// lfs changes and format the output suitable for parseLogOutput.. method(s)
 	logLfsSearchArgs = []string{
 		"-G", "oid sha256:", // only diffs which include an lfs file SHA change
-		"-p",  // include diff so we can read the SHA
-		"-U3", // Make sure diff context is always the same (used to ensure we always see all of pointer data)
+		"-p",   // include diff so we can read the SHA
+		"-U10", // Make sure diff context is always big enough to support extension lines to get whole pointer
 		`--format=lfs-commit-sha: %H %P`, // just a predictable commit header we can detect
 	}
 )

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -611,7 +611,7 @@ func parseLogOutputToPointers(log io.Reader, dir LogDiffDirection,
 	commitHeaderRegex := regexp.MustCompile(`^lfs-commit-sha: ([A-Fa-f0-9]{40})(?: ([A-Fa-f0-9]{40}))*`)
 	fileHeaderRegex := regexp.MustCompile(`diff --git a\/(.+?)\s+b\/(.+)`)
 	fileMergeHeaderRegex := regexp.MustCompile(`diff --cc (.+)`)
-	pointerDataRegex := regexp.MustCompile(`^([\+\- ])(version https://git-lfs|oid sha256|size).*$`)
+	pointerDataRegex := regexp.MustCompile(`^([\+\- ])(version https://git-lfs|oid sha256|size|ext-).*$`)
 	var pointerData bytes.Buffer
 	var currentFilename string
 	currentFileIncluded := true

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -26,6 +26,17 @@ const (
 	chanBufSize = 100
 )
 
+var (
+	// Arguments to append to a git log call which will limit the output to
+	// lfs changes and format the output suitable for parseLogOutput.. method(s)
+	logLfsSearchArgs = []string{
+		"-G", "oid sha256:", // only diffs which include an lfs file SHA change
+		"-p",  // include diff so we can read the SHA
+		"-U3", // Make sure diff context is always the same (used to ensure we always see all of pointer data)
+		`--format=lfs-commit-sha: %H %P`, // just a predictable commit header we can detect
+	}
+)
+
 // WrappedPointer wraps a pointer.Pointer and provides the git sha1
 // and the file name associated with the object, taken from the
 // rev-list output.
@@ -516,4 +527,150 @@ func lsTreeBlobs(ref string) (chan TreeBlob, error) {
 	}()
 
 	return blobs, nil
+}
+
+// ScanUnpushed scans history for all LFS pointers which have been added but not pushed to any remote
+func ScanUnpushed() ([]*WrappedPointer, error) {
+
+	start := time.Now()
+	defer func() {
+		tracerx.PerformanceSince("scan", start)
+	}()
+
+	pointerchan, err := logUnpushedSHAs()
+	if err != nil {
+		return nil, err
+	}
+	pointers := make([]*WrappedPointer, 0, 10)
+	for p := range pointerchan {
+		pointers = append(pointers, p)
+	}
+	return pointers, nil
+}
+
+// logUnpushedSHAs scans history for all LFS pointers which have been added but not pushed to any remote,
+// return progressively in a channel
+func logUnpushedSHAs() (chan *WrappedPointer, error) {
+	logArgs := []string{"log",
+		"--branches", "--tags", // include all locally referenced commits
+		"--not", "--remotes", // but exclude everything reachable from any remote
+	}
+	// Add standard search args to find lfs references
+	logArgs = append(logArgs, logLfsSearchArgs...)
+
+	cmd, err := startCommand("git", logArgs...)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd.Stdin.Close()
+
+	pchan := make(chan *WrappedPointer, chanBufSize)
+
+	go parseLogOutputToPointers(cmd.Stdout, LogDiffAdditions, nil, nil, pchan)
+
+	return pchan, nil
+
+}
+
+// When scanning diffs e.g. parseLogOutputToPointers, which direction of diff to include
+// data from, i.e. '+' or '-'. Depending on what you're scanning for either might be useful
+type LogDiffDirection byte
+
+const (
+	LogDiffAdditions = LogDiffDirection('+') // include '+' diffs
+	LogDiffDeletions = LogDiffDirection('-') // include '-' diffs
+)
+
+// parseLogOutputToPointers parses log output formatted as per logLfsSearchArgs & return pointers
+// log: a stream of output from git log with at least logLfsSearchArgs specified
+// dir: whether to include results from + or - diffs
+// includePaths, excludePaths: filter the results by filename
+// results: a channel which will receive the pointers
+func parseLogOutputToPointers(log io.Reader, dir LogDiffDirection,
+	includePaths, excludePaths []string, results chan *WrappedPointer) {
+
+	// For each commit we'll get something like this:
+	/*
+		lfs-commit-sha: 60fde3d23553e10a55e2a32ed18c20f65edd91e7 e2eaf1c10b57da7b98eb5d722ec5912ddeb53ea1
+
+		diff --git a/1D_Noise.png b/1D_Noise.png
+		new file mode 100644
+		index 0000000..2622b4a
+		--- /dev/null
+		+++ b/1D_Noise.png
+		@@ -0,0 +1,3 @@
+		+version https://git-lfs.github.com/spec/v1
+		+oid sha256:f5d84da40ab1f6aa28df2b2bf1ade2cdcd4397133f903c12b4106641b10e1ed6
+		+size 1289
+	*/
+	// There can be multiple diffs per commit (multiple binaries)
+	// Also when a binary is changed the diff will include a '-' line for the old SHA
+
+	// Define regexes to capture commit & diff headers
+	commitHeaderRegex := regexp.MustCompile(`^lfs-commit-sha: ([A-Fa-f0-9]{40})(?: ([A-Fa-f0-9]{40}))*`)
+	fileHeaderRegex := regexp.MustCompile(`diff --git a\/(.+?)\s+b\/(.+)`)
+	fileMergeHeaderRegex := regexp.MustCompile(`diff --cc (.+)`)
+	pointerDataRegex := regexp.MustCompile(`^([\+\- ])(version https://git-lfs|oid sha256|size).*$`)
+	var pointerData bytes.Buffer
+	var currentFilename string
+	currentFileIncluded := true
+
+	// Utility func used at several points below (keep in narrow scope)
+	finishLastPointer := func() {
+		if pointerData.Len() > 0 {
+			if currentFileIncluded {
+				p, err := DecodePointer(&pointerData)
+				if err == nil {
+					results <- &WrappedPointer{Name: currentFilename, Size: p.Size, Pointer: p}
+				}
+			}
+			pointerData.Reset()
+		}
+	}
+
+	scanner := bufio.NewScanner(log)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if match := commitHeaderRegex.FindStringSubmatch(line); match != nil {
+			// Currently we're not pulling out commit groupings, but could if we wanted
+			// This just acts as a delimiter for finishing a multiline pointer
+			finishLastPointer()
+
+		} else if match := fileHeaderRegex.FindStringSubmatch(line); match != nil {
+			// Finding a regular file header
+			finishLastPointer()
+			// Pertinent file name depends on whether we're listening to additions or removals
+			if dir == LogDiffAdditions {
+				currentFilename = match[2]
+			} else {
+				currentFilename = match[1]
+			}
+			currentFileIncluded = FilenamePassesIncludeExcludeFilter(currentFilename, includePaths, excludePaths)
+		} else if match := fileMergeHeaderRegex.FindStringSubmatch(line); match != nil {
+			// Git merge file header is a little different, only one file
+			finishLastPointer()
+			currentFilename = match[1]
+			currentFileIncluded = FilenamePassesIncludeExcludeFilter(currentFilename, includePaths, excludePaths)
+		} else if currentFileIncluded {
+			if match := pointerDataRegex.FindStringSubmatch(line); match != nil {
+				// An LFS pointer data line
+				// Include only the entirety of one side of the diff
+				// -U3 will ensure we always get all of it, even if only
+				// the SHA changed (version & size the same)
+				changeType := match[1][0]
+				// Always include unchanged context lines (normally just the version line)
+				if LogDiffDirection(changeType) == dir || changeType == ' ' {
+					// Must skip diff +/- marker
+					pointerData.WriteString(line[1:])
+					pointerData.WriteString("\n") // newline was stripped off by scanner
+				}
+			}
+		}
+	}
+	// Final pointer if in progress
+	finishLastPointer()
+
+	close(results)
+
 }

--- a/lfs/scanner_test.go
+++ b/lfs/scanner_test.go
@@ -1,0 +1,195 @@
+package lfs
+
+import (
+	"strings"
+
+	"github.com/github/git-lfs/vendor/_nuts/github.com/technoweenie/assert"
+
+	"testing"
+)
+
+var (
+	pointerParseLogOutput = `lfs-commit-sha: 637908bf28b38ab238e1b5e6a5bfbfb2e513a0df 07d571b413957508679042e45508af5945b3f1e5
+
+diff --git a/smoke_1.png b/smoke_1.png
+deleted file mode 100644
+index 2fe5451..0000000
+--- a/smoke_1.png
++++ /dev/null
+@@ -1,3 +0,0 @@
+-version https://git-lfs.github.com/spec/v1
+-oid sha256:8eb65d66303acc60062f44b44ef1f7360d7189db8acf3d066e59e2528f39514e
+-size 35022
+lfs-commit-sha: 07d571b413957508679042e45508af5945b3f1e5 8e5bd456b754f7d61c7157e82edc5ed124be4da6
+
+diff --git a/flare_1.png b/flare_1.png
+deleted file mode 100644
+index 1cfc5a1..0000000
+--- a/flare_1.png
++++ /dev/null
+@@ -1,3 +0,0 @@
+-version https://git-lfs.github.com/spec/v1
+-oid sha256:ea61c67cc5e8b3504d46de77212364045f31d9a023ad4448a1ace2a2fb4eed28
+-size 72982
+diff --git a/radial_1.png b/radial_1.png
+index 9daa2e5..c648385 100644
+--- a/radial_1.png
++++ b/radial_1.png
+@@ -1,3 +1,3 @@
+ version https://git-lfs.github.com/spec/v1
+-oid sha256:334c8a0a520cf9f58189dba5a9a26c7bff2769b4a3cc199650c00618bde5b9dd
+-size 16849
++oid sha256:3301b3da173d231f0f6b1f9bf075e573758cd79b3cfeff7623a953d708d6688b
++size 3152388
+lfs-commit-sha: 60fde3d23553e10a55e2a32ed18c20f65edd91e7 e2eaf1c10b57da7b98eb5d722ec5912ddeb53ea1
+
+diff --git a/1D_Noise.png b/1D_Noise.png
+new file mode 100644
+index 0000000..2622b4a
+--- /dev/null
++++ b/1D_Noise.png
+@@ -0,0 +1,3 @@
++version https://git-lfs.github.com/spec/v1
++oid sha256:f5d84da40ab1f6aa28df2b2bf1ade2cdcd4397133f903c12b4106641b10e1ed6
++size 1289
+diff --git a/waveNM.png b/waveNM.png
+new file mode 100644
+index 0000000..8519883
+--- /dev/null
++++ b/waveNM.png
+@@ -0,0 +1,3 @@
++version https://git-lfs.github.com/spec/v1
++oid sha256:fe2c2f236b97bba4585d9909a227a8fa64897d9bbe297fa272f714302d86c908
++size 125873
+lfs-commit-sha: 64b3372e108daaa593412d5e1d9df8169a9547ea e99c9cac7ff3f3cf1b2e670a64a5a381c44ffceb
+
+diff --git a/hobbit_5armies_2.mov b/hobbit_5armies_2.mov
+new file mode 100644
+index 0000000..92a88f8
+--- /dev/null
++++ b/hobbit_5armies_2.mov
+@@ -0,0 +1,3 @@
++version https://git-lfs.github.com/spec/v1
++oid sha256:ebff26d6b557b1416a6fded097fd9b9102e2d8195532c377ac365c736c87d4bc
++size 127142413
+`
+)
+
+func TestParseLogOutputToPointersAdditions(t *testing.T) {
+
+	// test + diff, no filtering
+	r := strings.NewReader(pointerParseLogOutput)
+	pchan := make(chan *WrappedPointer, chanBufSize)
+	go parseLogOutputToPointers(r, LogDiffAdditions, nil, nil, pchan)
+	pointers := make([]*WrappedPointer, 0, 5)
+	for p := range pchan {
+		pointers = append(pointers, p)
+	}
+	assert.Equal(t, 4, len(pointers))
+
+	// modification, + side
+	assert.Equal(t, "radial_1.png", pointers[0].Name)
+	assert.Equal(t, "3301b3da173d231f0f6b1f9bf075e573758cd79b3cfeff7623a953d708d6688b", pointers[0].Oid)
+	assert.Equal(t, int64(3152388), pointers[0].Size)
+	// addition, + side
+	assert.Equal(t, "1D_Noise.png", pointers[1].Name)
+	assert.Equal(t, "f5d84da40ab1f6aa28df2b2bf1ade2cdcd4397133f903c12b4106641b10e1ed6", pointers[1].Oid)
+	assert.Equal(t, int64(1289), pointers[1].Size)
+	// addition, + side
+	assert.Equal(t, "waveNM.png", pointers[2].Name)
+	assert.Equal(t, "fe2c2f236b97bba4585d9909a227a8fa64897d9bbe297fa272f714302d86c908", pointers[2].Oid)
+	assert.Equal(t, int64(125873), pointers[2].Size)
+	// addition, + side
+	assert.Equal(t, "hobbit_5armies_2.mov", pointers[3].Name)
+	assert.Equal(t, "ebff26d6b557b1416a6fded097fd9b9102e2d8195532c377ac365c736c87d4bc", pointers[3].Oid)
+	assert.Equal(t, int64(127142413), pointers[3].Size)
+
+	// test filtered, include
+	r = strings.NewReader(pointerParseLogOutput)
+	pointers = pointers[:0]
+	pchan = make(chan *WrappedPointer, chanBufSize)
+	go parseLogOutputToPointers(r, LogDiffAdditions, []string{"wave*"}, nil, pchan)
+	for p := range pchan {
+		pointers = append(pointers, p)
+	}
+	assert.Equal(t, 1, len(pointers))
+	assert.Equal(t, "waveNM.png", pointers[0].Name)
+	assert.Equal(t, "fe2c2f236b97bba4585d9909a227a8fa64897d9bbe297fa272f714302d86c908", pointers[0].Oid)
+	assert.Equal(t, int64(125873), pointers[0].Size)
+
+	// test filtered, exclude
+	r = strings.NewReader(pointerParseLogOutput)
+	pointers = pointers[:0]
+	pchan = make(chan *WrappedPointer, chanBufSize)
+	go parseLogOutputToPointers(r, LogDiffAdditions, nil, []string{"wave*"}, pchan)
+	for p := range pchan {
+		pointers = append(pointers, p)
+	}
+	assert.Equal(t, 3, len(pointers))
+	assert.Equal(t, "radial_1.png", pointers[0].Name)
+	assert.Equal(t, "3301b3da173d231f0f6b1f9bf075e573758cd79b3cfeff7623a953d708d6688b", pointers[0].Oid)
+	assert.Equal(t, int64(3152388), pointers[0].Size)
+	assert.Equal(t, "1D_Noise.png", pointers[1].Name)
+	assert.Equal(t, "f5d84da40ab1f6aa28df2b2bf1ade2cdcd4397133f903c12b4106641b10e1ed6", pointers[1].Oid)
+	assert.Equal(t, int64(1289), pointers[1].Size)
+	assert.Equal(t, "hobbit_5armies_2.mov", pointers[2].Name)
+	assert.Equal(t, "ebff26d6b557b1416a6fded097fd9b9102e2d8195532c377ac365c736c87d4bc", pointers[2].Oid)
+	assert.Equal(t, int64(127142413), pointers[2].Size)
+
+}
+
+func TestParseLogOutputToPointersDeletion(t *testing.T) {
+
+	// test - diff, no filtering
+	r := strings.NewReader(pointerParseLogOutput)
+	pchan := make(chan *WrappedPointer, chanBufSize)
+	go parseLogOutputToPointers(r, LogDiffDeletions, nil, nil, pchan)
+	pointers := make([]*WrappedPointer, 0, 5)
+	for p := range pchan {
+		pointers = append(pointers, p)
+	}
+	assert.Equal(t, 3, len(pointers))
+
+	// deletion, - side
+	assert.Equal(t, "smoke_1.png", pointers[0].Name)
+	assert.Equal(t, "8eb65d66303acc60062f44b44ef1f7360d7189db8acf3d066e59e2528f39514e", pointers[0].Oid)
+	assert.Equal(t, int64(35022), pointers[0].Size)
+	// addition, + side
+	assert.Equal(t, "flare_1.png", pointers[1].Name)
+	assert.Equal(t, "ea61c67cc5e8b3504d46de77212364045f31d9a023ad4448a1ace2a2fb4eed28", pointers[1].Oid)
+	assert.Equal(t, int64(72982), pointers[1].Size)
+	// modification, - side
+	assert.Equal(t, "radial_1.png", pointers[2].Name)
+	assert.Equal(t, "334c8a0a520cf9f58189dba5a9a26c7bff2769b4a3cc199650c00618bde5b9dd", pointers[2].Oid)
+	assert.Equal(t, int64(16849), pointers[2].Size)
+
+	// test filtered, include
+	r = strings.NewReader(pointerParseLogOutput)
+	pointers = pointers[:0]
+	pchan = make(chan *WrappedPointer, chanBufSize)
+	go parseLogOutputToPointers(r, LogDiffDeletions, []string{"flare*"}, nil, pchan)
+	for p := range pchan {
+		pointers = append(pointers, p)
+	}
+	assert.Equal(t, 1, len(pointers))
+	assert.Equal(t, "flare_1.png", pointers[0].Name)
+	assert.Equal(t, "ea61c67cc5e8b3504d46de77212364045f31d9a023ad4448a1ace2a2fb4eed28", pointers[0].Oid)
+	assert.Equal(t, int64(72982), pointers[0].Size)
+
+	// test filtered, exclude
+	r = strings.NewReader(pointerParseLogOutput)
+	pointers = pointers[:0]
+	pchan = make(chan *WrappedPointer, chanBufSize)
+	go parseLogOutputToPointers(r, LogDiffDeletions, nil, []string{"flare*"}, pchan)
+	for p := range pchan {
+		pointers = append(pointers, p)
+	}
+	assert.Equal(t, 2, len(pointers))
+	assert.Equal(t, "smoke_1.png", pointers[0].Name)
+	assert.Equal(t, "8eb65d66303acc60062f44b44ef1f7360d7189db8acf3d066e59e2528f39514e", pointers[0].Oid)
+	assert.Equal(t, int64(35022), pointers[0].Size)
+	assert.Equal(t, "radial_1.png", pointers[1].Name)
+	assert.Equal(t, "334c8a0a520cf9f58189dba5a9a26c7bff2769b4a3cc199650c00618bde5b9dd", pointers[1].Oid)
+	assert.Equal(t, int64(16849), pointers[1].Size)
+
+}

--- a/lfs/scanner_test.go
+++ b/lfs/scanner_test.go
@@ -28,6 +28,9 @@ index 1cfc5a1..0000000
 +++ /dev/null
 @@ -1,3 +0,0 @@
 -version https://git-lfs.github.com/spec/v1
+-ext-0-foo sha256:36485434f4f8a55150282ae7c78619a89de52721c00f48159f2562463df9c043
+-ext-1-bar sha256:382a2a13e705bbd8de7e2e13857c26551db17121ac57edca5dec9b5bd753e9c8
+-ext-2-ray sha256:423ee9e5988fb4670bf815990e9307c3b23296210c31581dec4d4ae89dabae46
 -oid sha256:ea61c67cc5e8b3504d46de77212364045f31d9a023ad4448a1ace2a2fb4eed28
 -size 72982
 diff --git a/radial_1.png b/radial_1.png
@@ -39,6 +42,22 @@ index 9daa2e5..c648385 100644
 -oid sha256:334c8a0a520cf9f58189dba5a9a26c7bff2769b4a3cc199650c00618bde5b9dd
 -size 16849
 +oid sha256:3301b3da173d231f0f6b1f9bf075e573758cd79b3cfeff7623a953d708d6688b
++size 3152388
+diff --git a/radial_2.png b/radial_2.png
+index 9daa2e5..c648385 100644
+--- a/radial_2.png
++++ b/radial_2.png
+@@ -1,3 +1,3 @@
+ version https://git-lfs.github.com/spec/v1
+-ext-0-foo sha256:36485434f4f8a55150282ae7c78619a89de52721c00f48159f2562463df9c043
+-ext-1-bar sha256:382a2a13e705bbd8de7e2e13857c26551db17121ac57edca5dec9b5bd753e9c8
+-ext-2-ray sha256:423ee9e5988fb4670bf815990e9307c3b23296210c31581dec4d4ae89dabae46
+-oid sha256:334c8a0a520cf9f58189dba5a9a26c7bff2769b4a3cc199650c00618bde5b9dd
+-size 16849
++ext-0-foo sha256:95d8260e8365a9dfd39842bdeee9b20e0e3fe3daf9bb4a8c0a1acb31008ed7b4
++ext-1-bar sha256:674bf4995720a43e03e174bcc1132ca95de6a8e4155fe3b2c482dceb42cbc0a5
++ext-2-ray sha256:0d323c95ae4b0a9c195ddc437c470678bddd2ee0906fb2f7b8166cd2474e22d9
++oid sha256:4b666195c133d8d0541ad0bc0e77399b9dc81861577a98314ac1ff1e9877893a
 +size 3152388
 lfs-commit-sha: 60fde3d23553e10a55e2a32ed18c20f65edd91e7 e2eaf1c10b57da7b98eb5d722ec5912ddeb53ea1
 
@@ -69,6 +88,8 @@ index 0000000..92a88f8
 +++ b/hobbit_5armies_2.mov
 @@ -0,0 +1,3 @@
 +version https://git-lfs.github.com/spec/v1
++ext-0-foo sha256:b37197ac149950d057521bcb7e00806f0528e19352bd72767165bc390d4f055e
++ext-1-bar sha256:c71772e5ea8e8c6f053f0f1dc89f8c01243975b1a040acbcf732fe2dbc0bcb61
 +oid sha256:ebff26d6b557b1416a6fded097fd9b9102e2d8195532c377ac365c736c87d4bc
 +size 127142413
 `
@@ -84,24 +105,28 @@ func TestParseLogOutputToPointersAdditions(t *testing.T) {
 	for p := range pchan {
 		pointers = append(pointers, p)
 	}
-	assert.Equal(t, 4, len(pointers))
+	assert.Equal(t, 5, len(pointers))
 
 	// modification, + side
 	assert.Equal(t, "radial_1.png", pointers[0].Name)
 	assert.Equal(t, "3301b3da173d231f0f6b1f9bf075e573758cd79b3cfeff7623a953d708d6688b", pointers[0].Oid)
 	assert.Equal(t, int64(3152388), pointers[0].Size)
+	// modification, + side with extensions
+	assert.Equal(t, "radial_2.png", pointers[1].Name)
+	assert.Equal(t, "4b666195c133d8d0541ad0bc0e77399b9dc81861577a98314ac1ff1e9877893a", pointers[1].Oid)
+	assert.Equal(t, int64(3152388), pointers[1].Size)
 	// addition, + side
-	assert.Equal(t, "1D_Noise.png", pointers[1].Name)
-	assert.Equal(t, "f5d84da40ab1f6aa28df2b2bf1ade2cdcd4397133f903c12b4106641b10e1ed6", pointers[1].Oid)
-	assert.Equal(t, int64(1289), pointers[1].Size)
+	assert.Equal(t, "1D_Noise.png", pointers[2].Name)
+	assert.Equal(t, "f5d84da40ab1f6aa28df2b2bf1ade2cdcd4397133f903c12b4106641b10e1ed6", pointers[2].Oid)
+	assert.Equal(t, int64(1289), pointers[2].Size)
 	// addition, + side
-	assert.Equal(t, "waveNM.png", pointers[2].Name)
-	assert.Equal(t, "fe2c2f236b97bba4585d9909a227a8fa64897d9bbe297fa272f714302d86c908", pointers[2].Oid)
-	assert.Equal(t, int64(125873), pointers[2].Size)
-	// addition, + side
-	assert.Equal(t, "hobbit_5armies_2.mov", pointers[3].Name)
-	assert.Equal(t, "ebff26d6b557b1416a6fded097fd9b9102e2d8195532c377ac365c736c87d4bc", pointers[3].Oid)
-	assert.Equal(t, int64(127142413), pointers[3].Size)
+	assert.Equal(t, "waveNM.png", pointers[3].Name)
+	assert.Equal(t, "fe2c2f236b97bba4585d9909a227a8fa64897d9bbe297fa272f714302d86c908", pointers[3].Oid)
+	assert.Equal(t, int64(125873), pointers[3].Size)
+	// addition, + side with extensions
+	assert.Equal(t, "hobbit_5armies_2.mov", pointers[4].Name)
+	assert.Equal(t, "ebff26d6b557b1416a6fded097fd9b9102e2d8195532c377ac365c736c87d4bc", pointers[4].Oid)
+	assert.Equal(t, int64(127142413), pointers[4].Size)
 
 	// test filtered, include
 	r = strings.NewReader(pointerParseLogOutput)
@@ -124,16 +149,19 @@ func TestParseLogOutputToPointersAdditions(t *testing.T) {
 	for p := range pchan {
 		pointers = append(pointers, p)
 	}
-	assert.Equal(t, 3, len(pointers))
+	assert.Equal(t, 4, len(pointers))
 	assert.Equal(t, "radial_1.png", pointers[0].Name)
 	assert.Equal(t, "3301b3da173d231f0f6b1f9bf075e573758cd79b3cfeff7623a953d708d6688b", pointers[0].Oid)
 	assert.Equal(t, int64(3152388), pointers[0].Size)
-	assert.Equal(t, "1D_Noise.png", pointers[1].Name)
-	assert.Equal(t, "f5d84da40ab1f6aa28df2b2bf1ade2cdcd4397133f903c12b4106641b10e1ed6", pointers[1].Oid)
-	assert.Equal(t, int64(1289), pointers[1].Size)
-	assert.Equal(t, "hobbit_5armies_2.mov", pointers[2].Name)
-	assert.Equal(t, "ebff26d6b557b1416a6fded097fd9b9102e2d8195532c377ac365c736c87d4bc", pointers[2].Oid)
-	assert.Equal(t, int64(127142413), pointers[2].Size)
+	assert.Equal(t, "radial_2.png", pointers[1].Name)
+	assert.Equal(t, "4b666195c133d8d0541ad0bc0e77399b9dc81861577a98314ac1ff1e9877893a", pointers[1].Oid)
+	assert.Equal(t, int64(3152388), pointers[1].Size)
+	assert.Equal(t, "1D_Noise.png", pointers[2].Name)
+	assert.Equal(t, "f5d84da40ab1f6aa28df2b2bf1ade2cdcd4397133f903c12b4106641b10e1ed6", pointers[2].Oid)
+	assert.Equal(t, int64(1289), pointers[2].Size)
+	assert.Equal(t, "hobbit_5armies_2.mov", pointers[3].Name)
+	assert.Equal(t, "ebff26d6b557b1416a6fded097fd9b9102e2d8195532c377ac365c736c87d4bc", pointers[3].Oid)
+	assert.Equal(t, int64(127142413), pointers[3].Size)
 
 }
 
@@ -147,13 +175,14 @@ func TestParseLogOutputToPointersDeletion(t *testing.T) {
 	for p := range pchan {
 		pointers = append(pointers, p)
 	}
-	assert.Equal(t, 3, len(pointers))
+
+	assert.Equal(t, 4, len(pointers))
 
 	// deletion, - side
 	assert.Equal(t, "smoke_1.png", pointers[0].Name)
 	assert.Equal(t, "8eb65d66303acc60062f44b44ef1f7360d7189db8acf3d066e59e2528f39514e", pointers[0].Oid)
 	assert.Equal(t, int64(35022), pointers[0].Size)
-	// addition, + side
+	// deletion, - side with extensions
 	assert.Equal(t, "flare_1.png", pointers[1].Name)
 	assert.Equal(t, "ea61c67cc5e8b3504d46de77212364045f31d9a023ad4448a1ace2a2fb4eed28", pointers[1].Oid)
 	assert.Equal(t, int64(72982), pointers[1].Size)
@@ -161,6 +190,10 @@ func TestParseLogOutputToPointersDeletion(t *testing.T) {
 	assert.Equal(t, "radial_1.png", pointers[2].Name)
 	assert.Equal(t, "334c8a0a520cf9f58189dba5a9a26c7bff2769b4a3cc199650c00618bde5b9dd", pointers[2].Oid)
 	assert.Equal(t, int64(16849), pointers[2].Size)
+	// modification, - side with extensions
+	assert.Equal(t, "radial_2.png", pointers[3].Name)
+	assert.Equal(t, "334c8a0a520cf9f58189dba5a9a26c7bff2769b4a3cc199650c00618bde5b9dd", pointers[3].Oid)
+	assert.Equal(t, int64(16849), pointers[3].Size)
 
 	// test filtered, include
 	r = strings.NewReader(pointerParseLogOutput)
@@ -183,12 +216,15 @@ func TestParseLogOutputToPointersDeletion(t *testing.T) {
 	for p := range pchan {
 		pointers = append(pointers, p)
 	}
-	assert.Equal(t, 2, len(pointers))
+	assert.Equal(t, 3, len(pointers))
 	assert.Equal(t, "smoke_1.png", pointers[0].Name)
 	assert.Equal(t, "8eb65d66303acc60062f44b44ef1f7360d7189db8acf3d066e59e2528f39514e", pointers[0].Oid)
 	assert.Equal(t, int64(35022), pointers[0].Size)
 	assert.Equal(t, "radial_1.png", pointers[1].Name)
 	assert.Equal(t, "334c8a0a520cf9f58189dba5a9a26c7bff2769b4a3cc199650c00618bde5b9dd", pointers[1].Oid)
 	assert.Equal(t, int64(16849), pointers[1].Size)
+	assert.Equal(t, "radial_2.png", pointers[2].Name)
+	assert.Equal(t, "334c8a0a520cf9f58189dba5a9a26c7bff2769b4a3cc199650c00618bde5b9dd", pointers[2].Oid)
+	assert.Equal(t, int64(16849), pointers[2].Size)
 
 }

--- a/lfs/scanner_test.go
+++ b/lfs/scanner_test.go
@@ -2,10 +2,9 @@ package lfs
 
 import (
 	"strings"
+	"testing"
 
 	"github.com/github/git-lfs/vendor/_nuts/github.com/technoweenie/assert"
-
-	"testing"
 )
 
 var (


### PR DESCRIPTION
This is part of my preparatory work to support the `prune` command; I thought I would submit this part early both to establish its use while I continue working on the specific features, and in case it is useful elsewhere. 

The focus of this PR is the `parseLogOutputToPointers` function which can scan a properly formatted `git log` output & extract relevant changes to LFS references. I've included an example of its use, ScanUnpushed() which shows what oids haven't been pushed anywhere & therefore only exist locally. However it will also be useful for other tasks (e.g. `fetch --recent`). The reason for it being able to scan for additions or removals is that depending on which direction in history you're scanning you might want either one (e.g. scanning backwards from a snapshot date between commits you want the '-' diffs to know what was being used beforehand).

The main feature of this method compared to alternatives is that it can extract WrappedPointers from arbitrary history with just a single `git log` command (and can be run in parallel with other tasks if needed)