### PR TITLE
Fetch tests should test local storage

### DIFF
--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -30,7 +30,7 @@ begin_test "fetch"
 
   [ "a" = "$(cat a.dat)" ]
 
-  assert_pointer "master" "a.dat" "$contents_oid" 1
+  assert_local_object "$contents_oid" 1
 
   refute_server_object "$reponame" "$contents_oid"
 
@@ -47,7 +47,7 @@ begin_test "fetch"
   printf "$b" > b.dat
   git add b.dat
   git commit -m "add b.dat"
-  assert_pointer "newbranch" "b.dat" "$b_oid" 1
+  assert_local_object "$b_oid" 1
 
   git push origin newbranch
   assert_server_object "$reponame" "$b_oid"
@@ -59,7 +59,7 @@ begin_test "fetch"
 
   [ "a" = "$(cat a.dat)" ]
 
-  assert_pointer "master" "a.dat" "$contents_oid" 1
+  assert_local_object "$contents_oid" 1
 
 
   # Remove the working directory and lfs files
@@ -67,15 +67,15 @@ begin_test "fetch"
 
   git lfs fetch 2>&1 | grep "(1 of 1 files)"
 
-  assert_pointer "master" "a.dat" "$contents_oid" 1
+  assert_local_object "$contents_oid" 1
 
   git checkout newbranch
   git checkout master
   rm -rf .git/lfs/objects
 
   git lfs fetch master newbranch
-  assert_pointer "master" "a.dat" "$contents_oid" 1
-  assert_pointer "newbranch" "b.dat" "$b_oid" 1
+  assert_local_object "$contents_oid" 1
+  assert_local_object "$b_oid" 1
   
 )
 end_test

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -20,6 +20,32 @@ assert_pointer() {
   fi
 }
 
+# assert_local_object confirms that an object file is stored for the given oid &
+# has the correct size
+# $ assert_local_object "some-oid" size
+assert_local_object() {
+  local oid="$1"
+  local size="$2"
+  local cfg=`git lfs env | grep LocalMediaDir`
+  local f="${cfg:14}/${oid:0:2}/${oid:2:2}/$oid"
+  actualsize=$(wc -c <"$f" | tr -d '[[:space:]]')
+  if [ "$size" != "$actualsize" ]; then
+    exit 1
+  fi
+}
+
+# refute_local_object confirms that an object file is NOT stored for an oid
+# $ refute_local_object "some-oid"
+refute_local_object() {
+  local oid="$1"
+  local cfg=`git lfs env | grep LocalMediaDir`
+  local regex="LocalMediaDir=(\S+)"
+  local f="${cfg:14}/${oid:0:2}/${oid:2:2}/$oid"
+  if [ -e $f ]; then
+    exit 1
+  fi
+}
+
 # check that the object does not exist in the git lfs server. HTTP log is
 # written to http.log. JSON output is written to http.json.
 #


### PR DESCRIPTION
Spotted while working on other things that assert_pointer wasn't a good test for fetch, since it only validates that the git commit objects have the right pointer data, not that the content exists locally. 

Added assert_local_object and refute_local_object instead & used in fetch tests.