### PR TITLE
Never download anything when using the checkout command

### DIFF
--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -57,7 +57,7 @@ func smudgeCommand(cmd *cobra.Command, args []string) {
 		Error(err.Error())
 	}
 
-	err = ptr.Smudge(os.Stdout, filename, cb)
+	err = ptr.Smudge(os.Stdout, filename, true, cb)
 	if file != nil {
 		file.Close()
 	}

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -59,8 +59,8 @@ func NewPointerExtension(name string, priority int, oid string) *PointerExtensio
 	return &PointerExtension{name, priority, oid, oidType}
 }
 
-func (p *Pointer) Smudge(writer io.Writer, workingfile string, cb CopyCallback) error {
-	return PointerSmudge(writer, p, workingfile, cb)
+func (p *Pointer) Smudge(writer io.Writer, workingfile string, download bool, cb CopyCallback) error {
+	return PointerSmudge(writer, p, workingfile, download, cb)
 }
 
 func (p *Pointer) Encode(writer io.Writer) (int, error) {

--- a/test/test-checkout.sh
+++ b/test/test-checkout.sh
@@ -15,6 +15,7 @@ begin_test "checkout"
   grep "Tracking \*.dat" track.log
 
   contents="something something"
+  contentsize=19
   contents_oid=$(printf "$contents" | shasum -a 256 | cut -f 1 -d " ")
 
   # Same content everywhere is ok, just one object in lfs db
@@ -34,7 +35,7 @@ begin_test "checkout"
   [ "$contents" = "$(cat folder1/nested.dat)" ]
   [ "$contents" = "$(cat folder2/nested.dat)" ]
 
-  assert_pointer "master" "file1.dat" "$contents_oid" 19
+  assert_pointer "master" "file1.dat" "$contents_oid" $contentsize
 
   # Remove the working directory
   rm -rf file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat
@@ -86,6 +87,17 @@ begin_test "checkout"
   [ "$contents" = "$(cat file1.dat)" ]
   [ "$contents" = "$(cat file2.dat)" ]
   [ "$contents" = "$(cat file3.dat)" ]
+  [ "$contents" = "$(cat folder1/nested.dat)" ]
+  [ "$contents" = "$(cat folder2/nested.dat)" ]
+
+  # test checkout with missing data doesn't fail
+  git push origin master
+  rm -rf .git/lfs/objects
+  rm file*.dat
+  git lfs checkout
+  [ "$(pointer $contents_oid $contentsize)" = "$(cat file1.dat)" ]
+  [ "$(pointer $contents_oid $contentsize)" = "$(cat file2.dat)" ]
+  [ "$(pointer $contents_oid $contentsize)" = "$(cat file3.dat)" ]
   [ "$contents" = "$(cat folder1/nested.dat)" ]
   [ "$contents" = "$(cat folder2/nested.dat)" ]
 


### PR DESCRIPTION
This was always the intention but the PointerSmudge functions would automatically do it if the local files were missing. Now they take a boolean argument to say whether to download or not, and the case of skipped smudge is dealt with by writing out the original pointer data and returning a known non-fatal error.