### PR TITLE
fix non-batch transfer

### DIFF
--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -117,6 +117,9 @@ func (q *TransferQueue) individualApiRoutine(apiWaiter chan interface{}) {
 			t.SetObject(obj)
 			q.meter.Add(t.Name())
 			q.transferc <- t
+		} else {
+			q.meter.Skip(t.Size())
+			q.wait.Done()
 		}
 	}
 }


### PR DESCRIPTION
non-batch transfer was stuck when objects already exist on lfs-server