### PR TITLE
Add include/exclude config options & params to fetch

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"sync"
@@ -143,16 +144,13 @@ func checkoutAll() {
 // either missing, or contains a matching pointer placeholder, from a list of pointers.
 // If the file exists but has other content it is left alone
 func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
-	// Fire up the update-index command
-	cmd := exec.Command("git", "update-index", "-q", "--refresh", "--stdin")
-	updateIdxStdin, err := cmd.StdinPipe()
-	if err != nil {
-		Panic(err, "Could not update the index")
-	}
-
-	if err := cmd.Start(); err != nil {
-		Panic(err, "Could not update the index")
-	}
+	// Don't fire up the update-index command until we have at least one file to
+	// give it. Otherwise git interprets the lack of arguments to mean param-less update-index
+	// which can trigger entire working copy to be re-examined, which triggers clean filters
+	// and which has unexpected side effects (e.g. downloading filtered-out files)
+	var cmd *exec.Cmd
+	var updateIdxStdin io.WriteCloser
+	var err error
 
 	// Get a converter from repo-relative to cwd-relative
 	// Since writing data & calling git update-index must be relative to cwd
@@ -193,13 +191,29 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 			}
 		}
 
+		if cmd == nil {
+			// Fire up the update-index command
+			cmd = exec.Command("git", "update-index", "-q", "--refresh", "--stdin")
+			updateIdxStdin, err = cmd.StdinPipe()
+			if err != nil {
+				Panic(err, "Could not update the index")
+			}
+
+			if err := cmd.Start(); err != nil {
+				Panic(err, "Could not update the index")
+			}
+
+		}
+
 		updateIdxStdin.Write([]byte(cwdfilepath + "\n"))
 	}
 	close(repopathchan)
 
-	updateIdxStdin.Close()
-	if err := cmd.Wait(); err != nil {
-		Panic(err, "Error updating the git index")
+	if cmd != nil && updateIdxStdin != nil {
+		updateIdxStdin.Close()
+		if err := cmd.Wait(); err != nil {
+			Panic(err, "Error updating the git index")
+		}
 	}
 
 }

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -79,10 +79,12 @@ func fetchAndReportToChan(pointers []*lfs.WrappedPointer, out chan<- *lfs.Wrappe
 		// Only add to download queue if local file is not the right size already
 		// This avoids previous case of over-reporting a requirement for files we already have
 		// which would only be skipped by PointerSmudgeObject later
-		if !lfs.ObjectExistsOfSize(p.Oid, p.Size) {
+		passFilter := lfs.FilenamePassesIncludeExcludeFilter(p.Name, lfs.Config.FetchIncludePaths(), lfs.Config.FetchExcludePaths())
+		if !lfs.ObjectExistsOfSize(p.Oid, p.Size) && passFilter {
 			q.Add(lfs.NewDownloadable(p))
 		} else {
-			// If we already have it, report it to chan immediately to support pull/checkout
+			// If we already have it, or it won't be fetched
+			// report it to chan immediately to support pull/checkout
 			if out != nil {
 				out <- p
 			}

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -11,6 +11,8 @@ var (
 		Short: "Downloads LFS files for the current ref, and checks out",
 		Run:   pullCommand,
 	}
+	pullIncludeArg string
+	pullExcludeArg string
 )
 
 func pullCommand(cmd *cobra.Command, args []string) {
@@ -20,10 +22,14 @@ func pullCommand(cmd *cobra.Command, args []string) {
 		Panic(err, "Could not pull")
 	}
 
-	c := fetchRefToChan(ref)
-	checkoutAllFromFetchChan(c)
+	includePaths, excludePaths := determineIncludeExcludePaths(pullIncludeArg, pullExcludeArg)
+
+	c := fetchRefToChan(ref, includePaths, excludePaths)
+	checkoutFromFetchChan(includePaths, excludePaths, c)
 }
 
 func init() {
+	pullCmd.Flags().StringVarP(&pullIncludeArg, "include", "I", "", "Include a list of paths")
+	pullCmd.Flags().StringVarP(&pullExcludeArg, "exclude", "X", "", "Exclude a list of paths")
 	RootCmd.AddCommand(pullCmd)
 }

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -57,7 +57,9 @@ func smudgeCommand(cmd *cobra.Command, args []string) {
 		Error(err.Error())
 	}
 
-	err = ptr.Smudge(os.Stdout, filename, true, cb)
+	cfg := lfs.Config
+	download := lfs.FilenamePassesIncludeExcludeFilter(filename, cfg.FetchIncludePaths(), cfg.FetchExcludePaths())
+	err = ptr.Smudge(os.Stdout, filename, download, cb)
 	if file != nil {
 		file.Close()
 	}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -187,6 +187,30 @@ type ErrorWithStack interface {
 	Stack() []byte
 }
 
+// determineIncludeExcludePaths is a common function to take the string arguments
+// for include/exclude and derive slices either from these options or from the
+// common global config
+func determineIncludeExcludePaths(includeArg, excludeArg string) (include, exclude []string) {
+	var includePaths, excludePaths []string
+	if len(includeArg) > 0 {
+		for _, inc := range strings.Split(includeArg, ",") {
+			inc = strings.TrimSpace(inc)
+			includePaths = append(includePaths, inc)
+		}
+	} else {
+		includePaths = lfs.Config.FetchIncludePaths()
+	}
+	if len(excludeArg) > 0 {
+		for _, ex := range strings.Split(excludeArg, ",") {
+			ex = strings.TrimSpace(ex)
+			excludePaths = append(excludePaths, ex)
+		}
+	} else {
+		excludePaths = lfs.Config.FetchExcludePaths()
+	}
+	return includePaths, excludePaths
+}
+
 func init() {
 	log.SetOutput(ErrorWriter)
 }

--- a/docs/man/git-lfs-fetch.1.ronn
+++ b/docs/man/git-lfs-fetch.1.ronn
@@ -3,7 +3,7 @@ git-lfs-fetch(1) -- Download all Git LFS files for a given ref
 
 ## SYNOPSIS
 
-`git lfs fetch` [<ref>...]
+`git lfs fetch` [options] [<ref>...]
 
 ## DESCRIPTION
 
@@ -12,7 +12,15 @@ the currently checked out ref will be used.
 
 This does not update the working copy.
 
-## INCLUDED & EXCLUDED PATHS
+## OPTIONS
+
+* `-I` <paths> `--include=`<paths>:
+  Specify lfs.fetchinclude just for this invocation; see [INCLUSION & EXCLUSION]
+
+* `-X` <paths> `--exclude=`<paths>:
+  Specify lfs.fetchexclude just for this invocation; see [INCLUSION & EXCLUSION]
+
+## INCLUSION & EXCLUSION
 
 You can configure Git LFS to only fetch objects to satisfy references in certain
 paths of the repo, and/or to exclude certain paths of the repo, to reduce the

--- a/docs/man/git-lfs-fetch.1.ronn
+++ b/docs/man/git-lfs-fetch.1.ronn
@@ -12,6 +12,17 @@ the currently checked out ref will be used.
 
 This does not update the working copy.
 
+## INCLUDED & EXCLUDED PATHS
+
+You can configure Git LFS to only fetch objects to satisfy references in certain
+paths of the repo, and/or to exclude certain paths of the repo, to reduce the
+time you spend downloading things you do not use.
+
+In gitconfig, set lfs.fetchinclude and lfs.fetchexclude to comma-separated lists
+of paths to include/exclude in the fetch (wildcard matching as per gitignore).
+Only paths which are matched by fetchinclude and not matched by fetchexclude
+will have objects fetched for them.
+
 ## EXAMPLES
 
 * Fetch the LFS objects for the current ref

--- a/docs/man/git-lfs-pull.1.ronn
+++ b/docs/man/git-lfs-pull.1.ronn
@@ -3,7 +3,7 @@ git-lfs-pull(1) -- Download all Git LFS files for current ref & checkout
 
 ## SYNOPSIS
 
-`git lfs pull`
+`git lfs pull` [options]
 
 ## DESCRIPTION
 
@@ -12,8 +12,27 @@ the working copy with the downloaded content if required.
 
 This is equivalent to running the following 2 commands:
 
-git lfs fetch
+git lfs fetch [options]
 git lfs checkout
+
+## OPTIONS
+
+* `-I` <paths> `--include=`<paths>:
+  Specify lfs.fetchinclude just for this invocation; see [INCLUSION & EXCLUSION]
+
+* `-X` <paths> `--exclude=`<paths>:
+  Specify lfs.fetchexclude just for this invocation; see [INCLUSION & EXCLUSION]
+
+## INCLUSION & EXCLUSION
+
+You can configure Git LFS to only fetch objects to satisfy references in certain
+paths of the repo, and/or to exclude certain paths of the repo, to reduce the
+time you spend downloading things you do not use.
+
+In gitconfig, set lfs.fetchinclude and lfs.fetchexclude to comma-separated lists
+of paths to include/exclude in the fetch (wildcard matching as per gitignore).
+Only paths which are matched by fetchinclude and not matched by fetchexclude
+will have objects fetched for them.
 
 ## EXAMPLES
 

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -76,6 +76,33 @@ begin_test "fetch"
   git lfs fetch master newbranch
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
+
+  # Test include / exclude filters
+  rm -rf .git/lfs/objects
+  git config "lfs.fetchinclude" "a*"
+  git lfs fetch master newbranch
+  assert_local_object "$contents_oid" 1
+  refute_local_object "$b_oid"
   
+  rm -rf .git/lfs/objects
+  git config --unset "lfs.fetchinclude"
+  git config "lfs.fetchexclude" "a*"
+  git lfs fetch master newbranch
+  refute_local_object "$contents_oid"
+  assert_local_object "$b_oid" 1
+
+  rm -rf .git/lfs/objects
+  git config "lfs.fetchinclude" "a*,b*"
+  git config "lfs.fetchexclude" "c*,d*"
+  git lfs fetch master newbranch
+  assert_local_object "$contents_oid" 1
+  assert_local_object "$b_oid" 1
+  
+  rm -rf .git/lfs/objects
+  git config "lfs.fetchinclude" "c*,d*"
+  git config "lfs.fetchexclude" "a*,b*"
+  git lfs fetch master newbranch
+  refute_local_object "$contents_oid"
+  refute_local_object "$b_oid"
 )
 end_test

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -77,7 +77,7 @@ begin_test "fetch"
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
 
-  # Test include / exclude filters
+  # Test include / exclude filters supplied in gitconfig
   rm -rf .git/lfs/objects
   git config "lfs.fetchinclude" "a*"
   git lfs fetch master newbranch
@@ -102,6 +102,29 @@ begin_test "fetch"
   git config "lfs.fetchinclude" "c*,d*"
   git config "lfs.fetchexclude" "a*,b*"
   git lfs fetch master newbranch
+  refute_local_object "$contents_oid"
+  refute_local_object "$b_oid"
+
+  # Test include / exclude filters supplied on the command line
+  git config --unset "lfs.fetchinclude"
+  git config --unset "lfs.fetchexclude"
+  rm -rf .git/lfs/objects
+  git lfs fetch --include="a*" master newbranch
+  assert_local_object "$contents_oid" 1
+  refute_local_object "$b_oid"
+  
+  rm -rf .git/lfs/objects
+  git lfs fetch --exclude="a*" master newbranch
+  refute_local_object "$contents_oid"
+  assert_local_object "$b_oid" 1
+
+  rm -rf .git/lfs/objects
+  git lfs fetch -I "a*,b*" -X "c*,d*" master newbranch
+  assert_local_object "$contents_oid" 1
+  assert_local_object "$b_oid" 1
+  
+  rm -rf .git/lfs/objects
+  git lfs fetch --include="c*,d*" --exclude="a*,b*" master newbranch
   refute_local_object "$contents_oid"
   refute_local_object "$b_oid"
 )


### PR DESCRIPTION
Note: don't merge until we've resolved https://github.com/github/git-lfs/issues/564.

Added `lfs.fetchinclude` and `lfs.fetchexclude` config options and `--include` and `--exclude` command line args to fetch. These cause certain paths to either be included or excluded when fetching binaries so that people who work in specific subfolders and don't want to waste time or disk space fetching irrelevant things can do so. This is most common in teams using a single shared repo for all assets but where not everyone needs all of them, e.g. only texture artists might need the original .psd files vs exported runtime equivalents, only modellers/animators might need the original .max files etc. Some teams have a more complex pipeline which avoids this but for those that don't wanting to download by subfolder is quite common. I expect the config option variants to be most used, `--include`/`--exclude` args to fetch are there for special occasions.

This affects the behaviour of `fetch`, `pull` and `smudge` since in all cases the `download` argument to PointerSmudge is set based on whether it matches include/exclude filters.

There is a later knock-on effect on `push` though because it means a user won't have all oids for a given commit. Right now that will cause `push` to fail later if the commits in question get included in the scan for pushing a new branch. This is another case of https://github.com/github/git-lfs/issues/564, which needs to be addressed before this can be merged.


