### PR TITLE
major pre-push optimization

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -66,7 +66,8 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 	}
 
 	// Just use scanner here
-	pointers, err := lfs.ScanRefs(left, right, nil)
+	scanOpt := &lfs.ScanRefsOptions{ScanMode: lfs.ScanDeltaToRemotes}
+	pointers, err := lfs.ScanRefs(left, right, scanOpt)
 	if err != nil {
 		Panic(err, "Error scanning for Git LFS files")
 	}

--- a/test/test-credentials.sh
+++ b/test/test-credentials.sh
@@ -122,13 +122,15 @@ begin_test "credentials with useHttpPath, with correct password"
   git lfs track "*.dat" 2>&1 | tee track.log
   grep "Tracking \*.dat" track.log
 
-  contents="a"
+  # creating new branch does not re-sent any objects existing on other
+  # remote branches anymore, generate new object, different from prev tests
+  contents="b"
   contents_oid=$(printf "$contents" | shasum -a 256 | cut -f 1 -d " ")
 
-  printf "$contents" > a.dat
-  git add a.dat
+  printf "$contents" > b.dat
+  git add b.dat
   git add .gitattributes
-  git commit -m "add a.dat"
+  git commit -m "add b.dat"
 
   git push origin with-path-correct-pass 2>&1 | tee push.log
   grep "(1 of 1 files)" push.log


### PR DESCRIPTION
this change improves drastically pre-push behaviour, by not sending
lfs objects which are already on a remote. Works perfectly with
pushing new branches and tags.

currently pre-push command analyse "local sha1" vs "remote sha1" of the
ref being pushed and if "remote sha1" is available locally tries to send
only lfs objects introduced with new commits.

why this is broken:
- remote branch might have moved forward (local repo is not up to date).
  In this case you have no chance to isolate new lfs objects ("remote sha1"
  does not exist locally) and git-lfs sends everything from the local
  branch history.
- remote branch does not exist (or new tag is pushed). Same consequences.

But what is important - local repository always have remote references,
from which user created his local branch and started making some local
changes. So, all we have to do is to identify new lfs objects which do
not exist on remote references. And all this can be easily achieved with
the same all mighty git rev-list command.

This change makes git-lfs usable with gerrit, where changes are uploaded
by using magic gerrit branches which does not really exist. i.e.
git push origin master:refs/for/master

in this case "refs/for/master" does not exist and git feeds all 0-s as
"remote sha1".