### PR TITLE
Fix race condition meaning TransferQueue might not report errors in time

### DIFF
--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -100,8 +100,8 @@ func (q *TransferQueue) individualApiRoutine(apiWaiter chan interface{}) {
 	for t := range q.apic {
 		obj, err := t.Check()
 		if err != nil {
-			q.wait.Done()
 			q.errorc <- err
+			q.wait.Done()
 			continue
 		}
 


### PR DESCRIPTION
Previously error went to chan after `q.wait.Done()` so if a caller was blocked on `q.Wait()` it could end up checking `q.Errors()` before the error had been sent to the channel / extracted by errorCollector. Error needs to be sent before `q.wait.Done()`.