### PR TITLE
don't use ldflags in credential tests

### DIFF
--- a/test/cmd/git-credential-lfstest.go
+++ b/test/cmd/git-credential-lfstest.go
@@ -21,8 +21,14 @@ var (
 
 	hostRE = regexp.MustCompile(`\A127.0.0.1:\d+\z`)
 
-	credsDir = "wat"
+	credsDir = ""
 )
+
+func init() {
+	if len(credsDir) == 0 {
+		credsDir = os.Getenv("CREDSDIR")
+	}
+}
 
 func main() {
 	if argsize := len(os.Args); argsize != 2 {

--- a/test/testenv.sh
+++ b/test/testenv.sh
@@ -49,6 +49,8 @@ TESTHOME="$REMOTEDIR/home"
 
 GIT_CONFIG_NOSYSTEM=1
 
+export CREDSDIR
+
 if [[ `git config --system credential.helper | grep osxkeychain` == "osxkeychain" ]]
 then
   OSXKEYFILE="$TMPDIR/temp.keychain"

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -165,7 +165,7 @@ setup() {
 
   if [ -z "$SKIPCOMPILE" ]; then
     for go in test/cmd/*.go; do
-      go build -ldflags "-X main.credsDir $CREDSDIR" -o "$BINPATH/$(basename $go .go)" "$go"
+      go build -o "$BINPATH/$(basename $go .go)" "$go"
     done
   fi
 


### PR DESCRIPTION
gccgo silently ignores them, causing tests to fail.