### PR TITLE
Pre-push hook must exit with a non-zero result when git-lfs isn't found

### DIFF
--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -17,7 +17,7 @@ var (
 	valueRegexp           = regexp.MustCompile("\\Agit[\\-\\s]media")
 	NotInARepositoryError = errors.New("Not in a repository")
 
-	prePushHook     = "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 2; }\ngit lfs pre-push \"$@\""
+	prePushHook     = "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but Git LFS was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-push.\\n\"; exit 2; }\ngit lfs pre-push \"$@\""
 	prePushUpgrades = map[string]bool{
 		"#!/bin/sh\ngit lfs push --stdin $*":     true,
 		"#!/bin/sh\ngit lfs push --stdin \"$@\"": true,

--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -17,7 +17,7 @@ var (
 	valueRegexp           = regexp.MustCompile("\\Agit[\\-\\s]media")
 	NotInARepositoryError = errors.New("Not in a repository")
 
-	prePushHook     = "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 0; }\ngit lfs pre-push \"$@\""
+	prePushHook     = "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 2; }\ngit lfs pre-push \"$@\""
 	prePushUpgrades = map[string]bool{
 		"#!/bin/sh\ngit lfs push --stdin $*":     true,
 		"#!/bin/sh\ngit lfs push --stdin \"$@\"": true,

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -7,7 +7,7 @@ begin_test "update"
   set -e
 
   pre_push_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but Git LFS was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-push.\\n\"; exit 2; }
 git lfs pre-push \"\$@\""
 
   mkdir without-pre-push

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -7,7 +7,7 @@ begin_test "update"
   set -e
 
   pre_push_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 0; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 2; }
 git lfs pre-push \"\$@\""
 
   mkdir without-pre-push


### PR DESCRIPTION
Otherwise the branch push will go ahead and data will be incomplete on the server.

Unfortunately even after this is fixed in the code, it won't fix problems in repos which were initialised beforehand. Need to edit .git/hooks/pre-push manually, even "git lfs init --force" won't fix it because the pre-push already exists.