### PR TITLE
Add optional remote arg to fetch & pull, and default to tracking remote

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"sync"
@@ -143,16 +144,13 @@ func checkoutAll() {
 // either missing, or contains a matching pointer placeholder, from a list of pointers.
 // If the file exists but has other content it is left alone
 func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
-	// Fire up the update-index command
-	cmd := exec.Command("git", "update-index", "-q", "--refresh", "--stdin")
-	updateIdxStdin, err := cmd.StdinPipe()
-	if err != nil {
-		Panic(err, "Could not update the index")
-	}
-
-	if err := cmd.Start(); err != nil {
-		Panic(err, "Could not update the index")
-	}
+	// Don't fire up the update-index command until we have at least one file to
+	// give it. Otherwise git interprets the lack of arguments to mean param-less update-index
+	// which can trigger entire working copy to be re-examined, which triggers clean filters
+	// and which has unexpected side effects (e.g. downloading filtered-out files)
+	var cmd *exec.Cmd
+	var updateIdxStdin io.WriteCloser
+	var err error
 
 	// Get a converter from repo-relative to cwd-relative
 	// Since writing data & calling git update-index must be relative to cwd
@@ -193,13 +191,29 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 			}
 		}
 
+		if cmd == nil {
+			// Fire up the update-index command
+			cmd = exec.Command("git", "update-index", "-q", "--refresh", "--stdin")
+			updateIdxStdin, err = cmd.StdinPipe()
+			if err != nil {
+				Panic(err, "Could not update the index")
+			}
+
+			if err := cmd.Start(); err != nil {
+				Panic(err, "Could not update the index")
+			}
+
+		}
+
 		updateIdxStdin.Write([]byte(cwdfilepath + "\n"))
 	}
 	close(repopathchan)
 
-	updateIdxStdin.Close()
-	if err := cmd.Wait(); err != nil {
-		Panic(err, "Error updating the git index")
+	if cmd != nil && updateIdxStdin != nil {
+		updateIdxStdin.Close()
+		if err := cmd.Wait(); err != nil {
+			Panic(err, "Error updating the git index")
+		}
 	}
 
 }

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -23,7 +23,16 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 	var refs []string
 
 	if len(args) > 0 {
-		refs = args
+		// Remote is first arg
+		lfs.Config.CurrentRemote = args[0]
+	} else {
+		trackedRemote, err := git.CurrentRemote()
+		if err == nil {
+			lfs.Config.CurrentRemote = trackedRemote
+		} // otherwise leave as default (origin)
+	}
+	if len(args) > 1 {
+		refs = args[1:]
 	} else {
 		ref, err := git.CurrentRef()
 		if err != nil {

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -79,10 +79,12 @@ func fetchAndReportToChan(pointers []*lfs.WrappedPointer, out chan<- *lfs.Wrappe
 		// Only add to download queue if local file is not the right size already
 		// This avoids previous case of over-reporting a requirement for files we already have
 		// which would only be skipped by PointerSmudgeObject later
-		if !lfs.ObjectExistsOfSize(p.Oid, p.Size) {
+		passFilter := lfs.FilenamePassesIncludeExcludeFilter(p.Name, lfs.Config.FetchIncludePaths(), lfs.Config.FetchExcludePaths())
+		if !lfs.ObjectExistsOfSize(p.Oid, p.Size) && passFilter {
 			q.Add(lfs.NewDownloadable(p))
 		} else {
-			// If we already have it, report it to chan immediately to support pull/checkout
+			// If we already have it, or it won't be fetched
+			// report it to chan immediately to support pull/checkout
 			if out != nil {
 				out <- p
 			}

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -11,6 +11,8 @@ var (
 		Short: "Downloads LFS files for the current ref, and checks out",
 		Run:   pullCommand,
 	}
+	pullIncludeArg string
+	pullExcludeArg string
 )
 
 func pullCommand(cmd *cobra.Command, args []string) {
@@ -20,10 +22,14 @@ func pullCommand(cmd *cobra.Command, args []string) {
 		Panic(err, "Could not pull")
 	}
 
-	c := fetchRefToChan(ref)
-	checkoutAllFromFetchChan(c)
+	includePaths, excludePaths := determineIncludeExcludePaths(pullIncludeArg, pullExcludeArg)
+
+	c := fetchRefToChan(ref, includePaths, excludePaths)
+	checkoutFromFetchChan(includePaths, excludePaths, c)
 }
 
 func init() {
+	pullCmd.Flags().StringVarP(&pullIncludeArg, "include", "I", "", "Include a list of paths")
+	pullCmd.Flags().StringVarP(&pullExcludeArg, "exclude", "X", "", "Exclude a list of paths")
 	RootCmd.AddCommand(pullCmd)
 }

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/github/git-lfs/git"
+	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
 )
 
@@ -16,6 +17,16 @@ var (
 )
 
 func pullCommand(cmd *cobra.Command, args []string) {
+
+	if len(args) > 0 {
+		// Remote is first arg
+		lfs.Config.CurrentRemote = args[0]
+	} else {
+		trackedRemote, err := git.CurrentRemote()
+		if err == nil {
+			lfs.Config.CurrentRemote = trackedRemote
+		} // otherwise leave as default (origin)
+	}
 
 	ref, err := git.CurrentRef()
 	if err != nil {

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -57,7 +57,9 @@ func smudgeCommand(cmd *cobra.Command, args []string) {
 		Error(err.Error())
 	}
 
-	err = ptr.Smudge(os.Stdout, filename, true, cb)
+	cfg := lfs.Config
+	download := lfs.FilenamePassesIncludeExcludeFilter(filename, cfg.FetchIncludePaths(), cfg.FetchExcludePaths())
+	err = ptr.Smudge(os.Stdout, filename, download, cb)
 	if file != nil {
 		file.Close()
 	}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -187,6 +187,30 @@ type ErrorWithStack interface {
 	Stack() []byte
 }
 
+// determineIncludeExcludePaths is a common function to take the string arguments
+// for include/exclude and derive slices either from these options or from the
+// common global config
+func determineIncludeExcludePaths(includeArg, excludeArg string) (include, exclude []string) {
+	var includePaths, excludePaths []string
+	if len(includeArg) > 0 {
+		for _, inc := range strings.Split(includeArg, ",") {
+			inc = strings.TrimSpace(inc)
+			includePaths = append(includePaths, inc)
+		}
+	} else {
+		includePaths = lfs.Config.FetchIncludePaths()
+	}
+	if len(excludeArg) > 0 {
+		for _, ex := range strings.Split(excludeArg, ",") {
+			ex = strings.TrimSpace(ex)
+			excludePaths = append(excludePaths, ex)
+		}
+	} else {
+		excludePaths = lfs.Config.FetchExcludePaths()
+	}
+	return includePaths, excludePaths
+}
+
 func init() {
 	log.SetOutput(ErrorWriter)
 }

--- a/docs/man/git-lfs-fetch.1.ronn
+++ b/docs/man/git-lfs-fetch.1.ronn
@@ -3,7 +3,7 @@ git-lfs-fetch(1) -- Download all Git LFS files for a given ref
 
 ## SYNOPSIS
 
-`git lfs fetch` [<ref>...]
+`git lfs fetch` [options] [<ref>...]
 
 ## DESCRIPTION
 
@@ -12,7 +12,15 @@ the currently checked out ref will be used.
 
 This does not update the working copy.
 
-## INCLUDED & EXCLUDED PATHS
+## OPTIONS
+
+* `-I` <paths> `--include=`<paths>:
+  Specify lfs.fetchinclude just for this invocation; see [INCLUSION & EXCLUSION]
+
+* `-X` <paths> `--exclude=`<paths>:
+  Specify lfs.fetchexclude just for this invocation; see [INCLUSION & EXCLUSION]
+
+## INCLUSION & EXCLUSION
 
 You can configure Git LFS to only fetch objects to satisfy references in certain
 paths of the repo, and/or to exclude certain paths of the repo, to reduce the

--- a/docs/man/git-lfs-fetch.1.ronn
+++ b/docs/man/git-lfs-fetch.1.ronn
@@ -3,7 +3,7 @@ git-lfs-fetch(1) -- Download all Git LFS files for a given ref
 
 ## SYNOPSIS
 
-`git lfs fetch` [options] [<ref>...]
+`git lfs fetch` [options] [<remote> [<ref>...]]
 
 ## DESCRIPTION
 
@@ -31,19 +31,29 @@ of paths to include/exclude in the fetch (wildcard matching as per gitignore).
 Only paths which are matched by fetchinclude and not matched by fetchexclude
 will have objects fetched for them.
 
+## DEFAULT REMOTE & REF
+
+Without arguments, fetch downloads the current ref from the default remote. 
+The default remote is the same as for `git fetch`, i.e. based on the remote
+branch you're tracking first, or origin otherwise.
+
 ## EXAMPLES
 
-* Fetch the LFS objects for the current ref
+* Fetch the LFS objects for the current ref from default remote
 
   `git lfs fetch`
 
-* Fetch the LFS objects for a branch
+* Fetch the LFS objects for the current ref from a secondary remote 'upstream'
 
-  `git lfs fetch mybranch`
+  `git lfs fetch upstream`
 
-* Fetch the LFS objects for 2 branches and a commit
+* Fetch the LFS objects for a branch from origin
 
-  `git lfs fetch master mybranch e445b45c1c9c6282614f201b62778e4c0688b5c8`
+  `git lfs fetch origin mybranch`
+
+* Fetch the LFS objects for 2 branches and a commit from origin
+
+  `git lfs fetch origin master mybranch e445b45c1c9c6282614f201b62778e4c0688b5c8`
 
 ## SEE ALSO
 

--- a/docs/man/git-lfs-fetch.1.ronn
+++ b/docs/man/git-lfs-fetch.1.ronn
@@ -12,6 +12,17 @@ the currently checked out ref will be used.
 
 This does not update the working copy.
 
+## INCLUDED & EXCLUDED PATHS
+
+You can configure Git LFS to only fetch objects to satisfy references in certain
+paths of the repo, and/or to exclude certain paths of the repo, to reduce the
+time you spend downloading things you do not use.
+
+In gitconfig, set lfs.fetchinclude and lfs.fetchexclude to comma-separated lists
+of paths to include/exclude in the fetch (wildcard matching as per gitignore).
+Only paths which are matched by fetchinclude and not matched by fetchexclude
+will have objects fetched for them.
+
 ## EXAMPLES
 
 * Fetch the LFS objects for the current ref

--- a/docs/man/git-lfs-pull.1.ronn
+++ b/docs/man/git-lfs-pull.1.ronn
@@ -3,7 +3,7 @@ git-lfs-pull(1) -- Download all Git LFS files for current ref & checkout
 
 ## SYNOPSIS
 
-`git lfs pull` [options]
+`git lfs pull` [options] [<remote>]
 
 ## DESCRIPTION
 
@@ -12,7 +12,7 @@ the working copy with the downloaded content if required.
 
 This is equivalent to running the following 2 commands:
 
-git lfs fetch [options]
+git lfs fetch [options] [<remote>]
 git lfs checkout
 
 ## OPTIONS
@@ -33,6 +33,12 @@ In gitconfig, set lfs.fetchinclude and lfs.fetchexclude to comma-separated lists
 of paths to include/exclude in the fetch (wildcard matching as per gitignore).
 Only paths which are matched by fetchinclude and not matched by fetchexclude
 will have objects fetched for them.
+
+## DEFAULT REMOTE
+
+Without arguments, pull downloads from the default remote. The default remote is
+the same as for `git pull`, i.e. based on the remote branch you're tracking 
+first, or origin otherwise.
 
 ## EXAMPLES
 

--- a/docs/man/git-lfs-pull.1.ronn
+++ b/docs/man/git-lfs-pull.1.ronn
@@ -3,7 +3,7 @@ git-lfs-pull(1) -- Download all Git LFS files for current ref & checkout
 
 ## SYNOPSIS
 
-`git lfs pull`
+`git lfs pull` [options]
 
 ## DESCRIPTION
 
@@ -12,8 +12,27 @@ the working copy with the downloaded content if required.
 
 This is equivalent to running the following 2 commands:
 
-git lfs fetch
+git lfs fetch [options]
 git lfs checkout
+
+## OPTIONS
+
+* `-I` <paths> `--include=`<paths>:
+  Specify lfs.fetchinclude just for this invocation; see [INCLUSION & EXCLUSION]
+
+* `-X` <paths> `--exclude=`<paths>:
+  Specify lfs.fetchexclude just for this invocation; see [INCLUSION & EXCLUSION]
+
+## INCLUSION & EXCLUSION
+
+You can configure Git LFS to only fetch objects to satisfy references in certain
+paths of the repo, and/or to exclude certain paths of the repo, to reduce the
+time you spend downloading things you do not use.
+
+In gitconfig, set lfs.fetchinclude and lfs.fetchexclude to comma-separated lists
+of paths to include/exclude in the fetch (wildcard matching as per gitignore).
+Only paths which are matched by fetchinclude and not matched by fetchexclude
+will have objects fetched for them.
 
 ## EXAMPLES
 

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -64,44 +64,47 @@ begin_test "fetch"
 
   # Remove the working directory and lfs files
   rm -rf .git/lfs/objects
-
   git lfs fetch 2>&1 | grep "(1 of 1 files)"
+  assert_local_object "$contents_oid" 1
 
+  # test with just remote specified
+  rm -rf .git/lfs/objects
+  git lfs fetch origin 2>&1 | grep "(1 of 1 files)"
   assert_local_object "$contents_oid" 1
 
   git checkout newbranch
   git checkout master
   rm -rf .git/lfs/objects
 
-  git lfs fetch master newbranch
+  git lfs fetch origin master newbranch
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
 
   # Test include / exclude filters supplied in gitconfig
   rm -rf .git/lfs/objects
   git config "lfs.fetchinclude" "a*"
-  git lfs fetch master newbranch
+  git lfs fetch origin master newbranch
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid"
   
   rm -rf .git/lfs/objects
   git config --unset "lfs.fetchinclude"
   git config "lfs.fetchexclude" "a*"
-  git lfs fetch master newbranch
+  git lfs fetch origin master newbranch
   refute_local_object "$contents_oid"
   assert_local_object "$b_oid" 1
 
   rm -rf .git/lfs/objects
   git config "lfs.fetchinclude" "a*,b*"
   git config "lfs.fetchexclude" "c*,d*"
-  git lfs fetch master newbranch
+  git lfs fetch origin master newbranch
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
   
   rm -rf .git/lfs/objects
   git config "lfs.fetchinclude" "c*,d*"
   git config "lfs.fetchexclude" "a*,b*"
-  git lfs fetch master newbranch
+  git lfs fetch origin master newbranch
   refute_local_object "$contents_oid"
   refute_local_object "$b_oid"
 
@@ -109,22 +112,22 @@ begin_test "fetch"
   git config --unset "lfs.fetchinclude"
   git config --unset "lfs.fetchexclude"
   rm -rf .git/lfs/objects
-  git lfs fetch --include="a*" master newbranch
+  git lfs fetch --include="a*" origin master newbranch
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid"
   
   rm -rf .git/lfs/objects
-  git lfs fetch --exclude="a*" master newbranch
+  git lfs fetch --exclude="a*" origin master newbranch
   refute_local_object "$contents_oid"
   assert_local_object "$b_oid" 1
 
   rm -rf .git/lfs/objects
-  git lfs fetch -I "a*,b*" -X "c*,d*" master newbranch
+  git lfs fetch -I "a*,b*" -X "c*,d*" origin master newbranch
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
   
   rm -rf .git/lfs/objects
-  git lfs fetch --include="c*,d*" --exclude="a*,b*" master newbranch
+  git lfs fetch --include="c*,d*" --exclude="a*,b*" origin master newbranch
   refute_local_object "$contents_oid"
   refute_local_object "$b_oid"
 )

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -76,6 +76,33 @@ begin_test "fetch"
   git lfs fetch master newbranch
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
+
+  # Test include / exclude filters
+  rm -rf .git/lfs/objects
+  git config "lfs.fetchinclude" "a*"
+  git lfs fetch master newbranch
+  assert_local_object "$contents_oid" 1
+  refute_local_object "$b_oid"
   
+  rm -rf .git/lfs/objects
+  git config --unset "lfs.fetchinclude"
+  git config "lfs.fetchexclude" "a*"
+  git lfs fetch master newbranch
+  refute_local_object "$contents_oid"
+  assert_local_object "$b_oid" 1
+
+  rm -rf .git/lfs/objects
+  git config "lfs.fetchinclude" "a*,b*"
+  git config "lfs.fetchexclude" "c*,d*"
+  git lfs fetch master newbranch
+  assert_local_object "$contents_oid" 1
+  assert_local_object "$b_oid" 1
+  
+  rm -rf .git/lfs/objects
+  git config "lfs.fetchinclude" "c*,d*"
+  git config "lfs.fetchexclude" "a*,b*"
+  git lfs fetch master newbranch
+  refute_local_object "$contents_oid"
+  refute_local_object "$b_oid"
 )
 end_test

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -77,7 +77,7 @@ begin_test "fetch"
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
 
-  # Test include / exclude filters
+  # Test include / exclude filters supplied in gitconfig
   rm -rf .git/lfs/objects
   git config "lfs.fetchinclude" "a*"
   git lfs fetch master newbranch
@@ -102,6 +102,29 @@ begin_test "fetch"
   git config "lfs.fetchinclude" "c*,d*"
   git config "lfs.fetchexclude" "a*,b*"
   git lfs fetch master newbranch
+  refute_local_object "$contents_oid"
+  refute_local_object "$b_oid"
+
+  # Test include / exclude filters supplied on the command line
+  git config --unset "lfs.fetchinclude"
+  git config --unset "lfs.fetchexclude"
+  rm -rf .git/lfs/objects
+  git lfs fetch --include="a*" master newbranch
+  assert_local_object "$contents_oid" 1
+  refute_local_object "$b_oid"
+  
+  rm -rf .git/lfs/objects
+  git lfs fetch --exclude="a*" master newbranch
+  refute_local_object "$contents_oid"
+  assert_local_object "$b_oid" 1
+
+  rm -rf .git/lfs/objects
+  git lfs fetch -I "a*,b*" -X "c*,d*" master newbranch
+  assert_local_object "$contents_oid" 1
+  assert_local_object "$b_oid" 1
+  
+  rm -rf .git/lfs/objects
+  git lfs fetch --include="c*,d*" --exclude="a*,b*" master newbranch
   refute_local_object "$contents_oid"
   refute_local_object "$b_oid"
 )

--- a/test/test-pull.sh
+++ b/test/test-pull.sh
@@ -57,6 +57,13 @@ begin_test "pull"
   [ "a" = "$(cat a.dat)" ]
   assert_local_object "$contents_oid" 1
 
+  # Try with remote arg
+  rm a.dat
+  rm -rf .git/lfs/objects
+  git lfs pull origin 2>&1 | grep "(1 of 1 files)"
+  [ "a" = "$(cat a.dat)" ]
+  assert_local_object "$contents_oid" 1
+
   # Remove just the working directory
   rm a.dat
   git lfs pull


### PR DESCRIPTION
The first arg to fetch & pull is now a remote. In addition, the default remote if you don't specify is now the tracking remote as in `git pull` if it exists, and origin if that's not set. This makes it more consistent with the underlying git workflow especially in triangular fork setups.

Note: I had to base this on top of https://github.com/github/git-lfs/pull/573 to avoid conflicts.