### PR TITLE
Extend #582 with more tests

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,8 +17,8 @@ and we have a good idea how they could work.
 
 * Fast, efficient uploading and downloading ([#414](https://github.com/github/git-lfs/issues/414)).
 * Improved local storage management ([#490](https://github.com/github/git-lfs/issues/490)).
-* [Extensions](docs/proposals/extensions.md) (#486).
-* Improved installation/upgrade experience (#531).
+* [Extensions](docs/proposals/extensions.md) ([#486](https://github.com/github/git-lfs/pull/486)).
+* Improved installation/upgrade experience ([#531](https://github.com/github/git-lfs/issues/531)).
 * Ability to remove objects from the command line through the API.
 * Go 1.5+
 

--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -31,13 +31,12 @@ func initCommand(cmd *cobra.Command, args []string) {
 		initHooksCommand(cmd, args)
 	}
 
-	Print("Git LFS initialized")
+	Print("Git LFS initialized.")
 }
 
 func initHooksCommand(cmd *cobra.Command, args []string) {
-	if err := lfs.InstallHooks(false); err != nil {
-		Error(err.Error())
-	}
+	updateForce = forceInit
+	updateCommand(cmd, args)
 }
 
 func init() {

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -18,18 +18,12 @@ var (
 // updateCommand is used for updating parts of Git LFS that reside under
 // .git/lfs.
 func updateCommand(cmd *cobra.Command, args []string) {
-	updatePrePushHook()
-}
-
-// updatePrePushHook will force an update of the pre-push hook.
-func updatePrePushHook() {
 	if err := lfs.InstallHooks(updateForce); err != nil {
 		Error(err.Error())
 		Print("Run `git lfs update --force` to overwrite this hook.")
 	} else {
-		Print("Updated pre-push hook")
+		Print("Updated pre-push hook.")
 	}
-
 }
 
 func init() {

--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -17,7 +17,7 @@ var (
 	valueRegexp           = regexp.MustCompile("\\Agit[\\-\\s]media")
 	NotInARepositoryError = errors.New("Not in a repository")
 
-	prePushHook     = "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\nDelete $0 if this repository no longer uses Git LFS.\\n\"; exit 2; }\ngit lfs pre-push \"$@\""
+	prePushHook     = "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-push.\\n\"; exit 2; }\ngit lfs pre-push \"$@\""
 	prePushUpgrades = map[string]bool{
 		"#!/bin/sh\ngit lfs push --stdin $*":     true,
 		"#!/bin/sh\ngit lfs push --stdin \"$@\"": true,

--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -17,11 +17,13 @@ var (
 	valueRegexp           = regexp.MustCompile("\\Agit[\\-\\s]media")
 	NotInARepositoryError = errors.New("Not in a repository")
 
-	prePushHook     = "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 2; }\ngit lfs pre-push \"$@\""
+	prePushHook     = "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\nDelete $0 if this repository no longer uses Git LFS.\\n\"; exit 2; }\ngit lfs pre-push \"$@\""
 	prePushUpgrades = map[string]bool{
 		"#!/bin/sh\ngit lfs push --stdin $*":     true,
 		"#!/bin/sh\ngit lfs push --stdin \"$@\"": true,
 		"#!/bin/sh\ngit lfs pre-push \"$@\"":     true,
+		"#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 0; }\ngit lfs pre-push \"$@\"": true,
+		"#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 2; }\ngit lfs pre-push \"$@\"": true,
 	}
 )
 

--- a/test/test-init.sh
+++ b/test/test-init.sh
@@ -51,7 +51,7 @@ begin_test "init updates repo hooks"
   git init
 
   pre_push_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\nDelete \$0 if this repository no longer uses Git LFS.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-push.\\n\"; exit 2; }
 git lfs pre-push \"\$@\""
 
   [ "Updated pre-push hook.

--- a/test/test-init.sh
+++ b/test/test-init.sh
@@ -41,3 +41,47 @@ begin_test "init with old settings"
   [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
 )
 end_test
+
+begin_test "init updates repo hooks"
+(
+  set -e
+
+  mkdir init-repo-hooks
+  cd init-repo-hooks
+  git init
+
+  pre_push_hook="#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\nDelete \$0 if this repository no longer uses Git LFS.\\n\"; exit 2; }
+git lfs pre-push \"\$@\""
+
+  [ "Updated pre-push hook.
+Git LFS initialized." = "$(git lfs init)" ]
+  [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
+
+  # replace old hook
+  # more-comprehensive hook update tests are in test-update.sh
+  echo "#!/bin/sh
+git lfs push --stdin \$*" > .git/hooks/pre-push
+  [ "Updated pre-push hook.
+Git LFS initialized." = "$(git lfs init)" ]
+  [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
+
+  # don't replace unexpected hook
+  expected="Hook already exists: pre-push
+
+test
+
+Run \`git lfs update --force\` to overwrite this hook.
+Git LFS initialized."
+
+  echo "test" > .git/hooks/pre-push
+  [ "test" = "$(cat .git/hooks/pre-push)" ]
+  [ "$expected" = "$(git lfs init 2>&1)" ]
+  [ "test" = "$(cat .git/hooks/pre-push)" ]
+
+  # force replace unexpected hook
+  [ "Updated pre-push hook.
+Git LFS initialized." = "$(git lfs init --force)" ]
+  [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
+)
+end_test

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -7,36 +7,50 @@ begin_test "update"
   set -e
 
   pre_push_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\nDelete \$0 if this repository no longer uses Git LFS.\\n\"; exit 2; }
 git lfs pre-push \"\$@\""
 
   mkdir without-pre-push
   cd without-pre-push
   git init
 
-  [ "Updated pre-push hook" = "$(git lfs update)" ]
+  [ "Updated pre-push hook." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # run it again
-  [ "Updated pre-push hook" = "$(git lfs update)" ]
+  [ "Updated pre-push hook." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 1
   echo "#!/bin/sh
 git lfs push --stdin \$*" > .git/hooks/pre-push
-  [ "Updated pre-push hook" = "$(git lfs update)" ]
+  [ "Updated pre-push hook." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 2
   echo "#!/bin/sh
 git lfs push --stdin \"\$@\"" > .git/hooks/pre-push
-  [ "Updated pre-push hook" = "$(git lfs update)" ]
+  [ "Updated pre-push hook." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 3
   echo "#!/bin/sh
 git lfs pre-push \"\$@\"" > .git/hooks/pre-push
-  [ "Updated pre-push hook" = "$(git lfs update)" ]
+  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
+
+  # replace old hook 4
+  echo "#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 0; }
+git lfs pre-push \"$@\""
+  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
+
+  # replace old hook 5
+  echo "#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 2; }
+git lfs pre-push \"$@\""
+  [ "Updated pre-push hook." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # don't replace unexpected hook
@@ -51,7 +65,7 @@ Run \`git lfs update --force\` to overwrite this hook."
   [ "test" = "$(cat .git/hooks/pre-push)" ]
 
   # force replace unexpected hook
-  [ "Updated pre-push hook" = "$(git lfs update --force)" ]
+  [ "Updated pre-push hook." = "$(git lfs update --force)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 )
 end_test

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -7,7 +7,7 @@ begin_test "update"
   set -e
 
   pre_push_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\nDelete \$0 if this repository no longer uses Git LFS.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-push.\\n\"; exit 2; }
 git lfs pre-push \"\$@\""
 
   mkdir without-pre-push


### PR DESCRIPTION
This adds some tests to confirm that `git lfs update` can automatically update the former pre-push hooks. Also taught `git lfs init --force` how to update the pre-push hook too.