### PR TITLE
Update install.sh.example

### DIFF
--- a/script/install.sh.example
+++ b/script/install.sh.example
@@ -16,5 +16,5 @@ for g in git*; do
   install $g "$prefix/bin/$g"
 done
 
-PATH+=:$prefix/bin
+PATH=$PATH:$prefix/bin
 git lfs init


### PR DESCRIPTION
Install script was failing in ubuntu when PATH+=:$prefix/bin