### PR TITLE
Backport #519 for v0.5.x: Fix install.sh for OS X, FreeBSD, etc.

### DIFF
--- a/script/install.sh.example
+++ b/script/install.sh.example
@@ -8,9 +8,11 @@ elif [ "${BOXEN_HOME:-}" != "" ] ; then
   prefix=${BOXEN_HOME:-}
 fi
 
+mkdir -p $prefix/bin
+
 rm -rf $prefix/bin/git-lfs*
 for g in git*; do
-  install -D $g "$prefix/bin/$g"
+  install $g "$prefix/bin/$g"
 done
 
 PATH+=:$prefix/bin


### PR DESCRIPTION
This backports #519.