### PR TITLE
Don't hang when batch calls error

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -135,4 +135,12 @@ func fetchAndReportToChan(pointers []*lfs.WrappedPointer, include, exclude []str
 	processQueue := time.Now()
 	q.Wait()
 	tracerx.PerformanceSince("process queue", processQueue)
+
+	for _, err := range q.Errors() {
+		if Debugging || err.Panic {
+			LoggedError(err.Err, err.Error())
+		} else {
+			Error(err.Error())
+		}
+	}
 }

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -218,7 +218,7 @@ func Batch(objects []*objectResource, operation string) ([]*objectResource, *Wra
 	LogTransfer("lfs.api.batch", res)
 
 	if res.StatusCode != 200 {
-		return nil, Errorf(errors.New("batch error"), "Invalid status for %s %s: %d", req.Method, req.URL, res.StatusCode)
+		return nil, Error(fmt.Errorf("Invalid status for %s %s: %d", req.Method, req.URL, res.StatusCode))
 	}
 
 	return objs, nil

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -218,7 +218,7 @@ func Batch(objects []*objectResource, operation string) ([]*objectResource, *Wra
 	LogTransfer("lfs.api.batch", res)
 
 	if res.StatusCode != 200 {
-		return nil, Errorf(nil, "Invalid status for %s %s: %d", req.Method, req.URL, res.StatusCode)
+		return nil, Errorf(errors.New("batch error"), "Invalid status for %s %s: %d", req.Method, req.URL, res.StatusCode)
 	}
 
 	return objs, nil

--- a/lfs/errors.go
+++ b/lfs/errors.go
@@ -1,9 +1,12 @@
 package lfs
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 )
+
+var genericError = errors.New("Git LFS client error")
 
 type WrappedError struct {
 	Err     error
@@ -19,7 +22,7 @@ func Error(err error) *WrappedError {
 
 func Errorf(err error, format string, args ...interface{}) *WrappedError {
 	if err == nil {
-		return nil
+		err = genericError
 	}
 
 	e := &WrappedError{

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -177,9 +177,8 @@ func (q *TransferQueue) batchApiRoutine() {
 				return
 			}
 
-			q.wait.Add(-len(transfers))
-
 			q.errorc <- err
+			q.wait.Add(-len(transfers))
 			continue
 		}
 

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -176,6 +176,9 @@ func (q *TransferQueue) batchApiRoutine() {
 				go q.legacyFallback(batch)
 				return
 			}
+
+			q.wait.Add(-len(transfers))
+
 			q.errorc <- err
 			continue
 		}

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -206,6 +206,11 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, repo string) {
 		return
 	}
 
+	if repo == "badbatch" {
+		w.WriteHeader(203)
+		return
+	}
+
 	type batchReq struct {
 		Operation string      `json:"operation"`
 		Objects   []lfsObject `json:"objects"`

--- a/test/test-batch-error-handling.sh
+++ b/test/test-batch-error-handling.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# This is a sample Git LFS test.  See test/README.md and testhelpers.sh for
+# more documentation.
+
+. "test/testlib.sh"
+
+begin_test "batch error handling"
+(
+  set -e
+
+  # This initializes a new bare git repository in test/remote.
+  # These remote repositories are global to every test, so keep the names
+  # unique.
+  reponame="badbatch" # Server looks for the "badbatch" repo, returns a 203 status
+  setup_remote_repo "$reponame"
+
+  # Clone the repository from the test Git server.  This is empty, and will be
+  # used to test a "git pull" below. The repo is cloned to $TRASHDIR/clone
+  clone_repo "$reponame" clone
+
+  # Clone the repository again to $TRASHDIR/repo. This will be used to commit
+  # and push objects.
+  clone_repo "$reponame" repo
+
+  # This executes Git LFS from the local repo that was just cloned.
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \*.dat" track.log
+
+  contents="a"
+  contents_oid=$(printf "$contents" | shasum -a 256 | cut -f 1 -d " ")
+
+  printf "$contents" > a.dat
+  git add a.dat
+  git add .gitattributes
+  git commit -m "add a.dat" 2>&1 | tee commit.log
+  grep "master (root-commit)" commit.log
+  grep "2 files changed" commit.log
+  grep "create mode 100644 a.dat" commit.log
+  grep "create mode 100644 .gitattributes" commit.log
+
+  [ "a" = "$(cat a.dat)" ]
+
+  # This is a small shell function that runs several git commands together.
+  assert_pointer "master" "a.dat" "$contents_oid" 1
+
+  refute_server_object "$reponame" "$contents_oid"
+
+  # Ensure batch transfer is turned on for this repo
+  git config --add --local lfs.batch true
+
+  # This pushes to the remote repository set up at the top of the test.
+  git push origin master 2>&1 | tee push.log
+  grep "Invalid status for POST" push.log
+)
+end_test
+


### PR DESCRIPTION
A few problems with the batch code error handling can lead to a hang:

- [x] Actually return an error instead of nil
- [x] Properly manage the waitgroup when a batch call errors
- [x] Make sure we display errors instead of just a 0 count
- [x] Tests for this scenario

/cc #593 