### PR TITLE
lfs/batcher: introduce test cases

### DIFF
--- a/lfs/batcher_test.go
+++ b/lfs/batcher_test.go
@@ -7,28 +7,66 @@ import (
 )
 
 func TestBatcherSizeMet(t *testing.T) {
-	b := NewBatcher(2)
-
-	for i := 0; i < 4; i++ {
-		b.Add(&Downloadable{})
-	}
-
-	group := b.Next()
-	assert.Equal(t, 2, len(group))
-
-	group = b.Next()
-	assert.Equal(t, 2, len(group))
+	assertAll([]batcherTestCase{
+		{2, 4, false},
+		{3, 5, false},
+		{0, 0, false},
+	}, t)
 }
 
 func TestBatcherExit(t *testing.T) {
-	b := NewBatcher(4)
+	assertAll([]batcherTestCase{
+		{2, 4, true},
+		{3, 5, true},
+		{0, 0, true},
+	}, t)
+}
 
-	for i := 0; i < 2; i++ {
-		b.Add(&Downloadable{})
+// Type batcherTestCase specifies information about how to run a particular test
+// around the type lfs.Batcher.
+type batcherTestCase struct {
+	BatchSize  int
+	ItemCount  int
+	ShouldExit bool
+}
+
+// Func Batcher makes and retunrs a lfs.Batcher according to the specification
+// given in this instance of batcherTestCase. When returned, it is filled with
+// the given amount of items, and has exited if it was told to.
+func (b batcherTestCase) Batcher() *Batcher {
+	batcher := NewBatcher(b.BatchSize)
+	for i := 0; i < b.ItemCount; i++ {
+		batcher.Add(&Downloadable{})
 	}
 
-	b.Exit()
+	if b.ShouldExit {
+		batcher.Exit()
+	}
 
-	group := b.Next()
-	assert.Equal(t, 2, len(group))
+	return batcher
+}
+
+// Func Batches returns the number of individual batches expected to be
+// processed by the batcher under test.
+func (b batcherTestCase) Batches() int {
+	if b.BatchSize == 0 {
+		return 0
+	}
+
+	return b.ItemCount / b.BatchSize
+}
+
+// Func assertAll processes all test cases, throwing assertion errors if they
+// fail.
+func assertAll(cases []batcherTestCase, t *testing.T) {
+	for _, c := range cases {
+		b := c.Batcher()
+
+		items := c.ItemCount
+		for i := 0; i < c.Batches(); i++ {
+			group := b.Next()
+			assert.Equal(t, c.BatchSize, len(group))
+			items -= c.BatchSize
+		}
+	}
 }

--- a/lfs/batcher_test.go
+++ b/lfs/batcher_test.go
@@ -22,7 +22,7 @@ func TestBatcherExit(t *testing.T) {
 	}, t)
 }
 
-// Type batcherTestCase specifies information about how to run a particular test
+// batcherTestCase specifies information about how to run a particular test
 // around the type lfs.Batcher.
 type batcherTestCase struct {
 	BatchSize  int
@@ -30,9 +30,9 @@ type batcherTestCase struct {
 	ShouldExit bool
 }
 
-// Func Batcher makes and retunrs a lfs.Batcher according to the specification
-// given in this instance of batcherTestCase. When returned, it is filled with
-// the given amount of items, and has exited if it was told to.
+// Batcher makes and retunrs a lfs.Batcher according to the specification given
+// in this instance of batcherTestCase. When returned, it is filled with the
+// given amount of items, and has exited if it was told to.
 func (b batcherTestCase) Batcher() *Batcher {
 	batcher := NewBatcher(b.BatchSize)
 	for i := 0; i < b.ItemCount; i++ {
@@ -46,17 +46,17 @@ func (b batcherTestCase) Batcher() *Batcher {
 	return batcher
 }
 
-// Func Batches returns the number of individual batches expected to be
-// processed by the batcher under test.
+// Batches returns the number of individual batches expected to be processed by
+// the batcher under test.
 func (b batcherTestCase) Batches() int {
 	if b.BatchSize == 0 {
-		return 0
+		return b.ItemCount
 	}
 
 	return b.ItemCount / b.BatchSize
 }
 
-// Func assertAll processes all test cases, throwing assertion errors if they
+// assertAll processes all test cases, throwing assertion errors if they
 // fail.
 func assertAll(cases []batcherTestCase, t *testing.T) {
 	for _, c := range cases {

--- a/lfs/batcher_test.go
+++ b/lfs/batcher_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestBatcherSizeMet(t *testing.T) {
-	assertAll([]batcherTestCase{
+	runBatcherTests([]batcherTestCase{
 		{2, 4, false},
 		{3, 5, false},
 		{0, 0, false},
@@ -15,7 +15,7 @@ func TestBatcherSizeMet(t *testing.T) {
 }
 
 func TestBatcherExit(t *testing.T) {
-	assertAll([]batcherTestCase{
+	runBatcherTests([]batcherTestCase{
 		{2, 4, true},
 		{3, 5, true},
 		{0, 0, true},
@@ -56,9 +56,9 @@ func (b batcherTestCase) Batches() int {
 	return b.ItemCount / b.BatchSize
 }
 
-// assertAll processes all test cases, throwing assertion errors if they
+// runBatcherTests processes all test cases, throwing assertion errors if they
 // fail.
-func assertAll(cases []batcherTestCase, t *testing.T) {
+func runBatcherTests(cases []batcherTestCase, t *testing.T) {
 	for _, c := range cases {
 		b := c.Batcher()
 


### PR DESCRIPTION
This commit adds the notion of a test case into the `lfs.Batcher` tests. Each
test case has three parameters: a batch size, the number of items to add to that
batcher, and whether or not it should exit the batcher after adding all items.

This commit also adds a helper func called `assertAll` which processes a set of
test cases, throwing assertion errors into the `*testing.T` along the way.

On the other hand, this commit does not contain any utilities to assert that a
deadlock will occur when feeding items into a Batcher, i.e., when the batch size
is set to 0.