### PR TITLE
Fix spec: tree entry for pointer file preserves exec bit

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -17,7 +17,8 @@ only a pointer file is written.
 * Lines of key/value pairs MUST be sorted alphabetically in ascending order
 (with the exception of `version`, which is always first).
 * Values MUST NOT contain return or newline characters.
-* Pointer files SHOULD NOT have the executable bit set when checked out from Git.
+* Pointer files MUST be stored in Git with their executable bit matching that
+of the replaced file.
 
 The required keys are:
 


### PR DESCRIPTION
In practice, Git LFS preserves the executable status of files when they are cleaned-to/smudged-from pointer files - in fact the [git attributes clean/smudge filter mechanism](http://git-scm.com/docs/gitattributes#__code_filter_code) doesn't actually provide any support for changing the executable status of a file, they just work on the file's contents with standard input & output.

This is good behaviour, because users don't want their big *.exe files to stop being executable when they start using Git LFS, and the executable status is not preserved anywhere else (eg. rightly, it is not stored within the pointer file).

As an example, here are two *.exe files that have been stored with Git LFS, which has preserved their exec bit in the file tree object. Note that `bar.exe` has it's exec bit _set_ (`100755`), contrary to the spec:

```
$ git cat-file -p HEAD^{tree}
100644 blob ce8828c1134a1f9feb8177e9e2b988d94a94d951	.gitattributes
100644 blob 9242c60b11d49b42e829070feef1c5b7cf7a6159	foo.exe
100755 blob 25637885004ac19bd1e0404e2bb0d2247de37805	bar.exe
$ git cat-file -p 25637885004ac19bd1e0404e2bb0d2247de37805
version https://git-lfs.github.com/spec/v1
oid sha256:364ea686b8d77dbf49d1c1ce28023e818954574310b68c61433fbb02596744e2
size 51200
```

I think the spec just needs correcting here. The wording was introduced with https://github.com/github/git-lfs/pull/246, tweaked with https://github.com/github/git-lfs/commit/4bdecf, but I couldn't find any justification in those for the statement that the executable bit should always be cleared.
