### PR TITLE
batch API changes for v0.6.0

### DIFF
--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -16,7 +16,6 @@ var (
 
 func envCommand(cmd *cobra.Command, args []string) {
 	config := lfs.Config
-
 	endpoint := config.Endpoint()
 
 	gitV, err := git.Config.Version()
@@ -29,7 +28,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 	Print("")
 
 	if len(endpoint.Url) > 0 {
-		Print("Endpoint=%s", endpoint.Url)
+		Print("Endpoint=%s (auth=%s)", endpoint.Url, config.Access())
 		if len(endpoint.SshUserAndHost) > 0 {
 			Print("  SSH=%s:%s", endpoint.SshUserAndHost, endpoint.SshPath)
 		}
@@ -37,7 +36,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 
 	for _, remote := range config.Remotes() {
 		remoteEndpoint := config.RemoteEndpoint(remote)
-		Print("Endpoint (%s)=%s", remote, remoteEndpoint.Url)
+		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, config.EndpointAccess(remoteEndpoint))
 		if len(endpoint.SshUserAndHost) > 0 {
 			Print("  SSH=%s:%s", endpoint.SshUserAndHost, endpoint.SshPath)
 		}

--- a/docs/api/http-v1-batch.md
+++ b/docs/api/http-v1-batch.md
@@ -8,18 +8,16 @@ endpoint that accepts multiple OIDs. All requests should have the following:
 
 [v1]: ./http-v1-original.md
 
-This is an experimental API introduced in Git LFS v0.5.2, and only used if the
-`lfs.batch` config value is true. You can toggle support for any local
-repository like this:
+This is a newer API introduced in Git LFS v0.5.2, and made the default in
+Git LFS v0.6.0. The client automatically detects if the server does not
+implement the API yet, and falls back to the legacy API. You can toggle support
+manually through the Git config:
 
     # enable batch support
-    $ git config lfs.batch true
-
-    # disable batch support
     $ git config --unset lfs.batch
 
-The Batch API is subject to change until it becomes the _default_ API used by
-Git LFS v0.6.0.
+    # disable batch support
+    $ git config lfs.batch false
 
 ## Authentication
 

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -24,7 +24,8 @@ lfs option can be scoped inside the configuration for a remote.
 * `lfs.batch`
 
   Whether to use the batch API instead of requesting objects individually.
-  Default false.
+  Default true. This setting transitions clients from the legacy to the newer
+  batch API and will be gone in Git LFS v1.0.
 
 ### Fetch settings
 
@@ -83,9 +84,9 @@ lfs option can be scoped inside the configuration for a remote.
 * `lfs.<url>.access`
 
   Note: this setting is normally set by LFS itself on receiving a 401 response
-  (authentication required), you don't normally need to set it manually. 
+  (authentication required), you don't normally need to set it manually.
 
-  If set to "private" then credentials will be requested before making batch
+  If set to "basic" then credentials will be requested before making batch
   requests to this url, otherwise a public request will initially be attempted.
 
 ## SEE ALSO

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -5,7 +5,7 @@ git-lfs-config(5) -- Configuration options for git-lfs
 
 git-lfs uses the same configuration files as git-config(1) with the same
 precedence. Most options pertaining to git-lfs are contained in the `[lfs]`
-section, meaning they all named `lfs.foo` or similar, although occasionally an 
+section, meaning they all named `lfs.foo` or similar, although occasionally an
 lfs option can be scoped inside the configuration for a remote.
 
 ## LIST OF OPTIONS
@@ -13,16 +13,16 @@ lfs option can be scoped inside the configuration for a remote.
 ### General settings
 
 * `lfs.url` / `<remote>.lfsurl`
-  
+
   The url used to call the Git LFS remote API. Default blank (derive from clone
   URL).
-  
+
 * `lfs.concurrenttransfers`
-  
+
   The number of concurrent uploads/downloads. Default 3.
 
 * `lfs.batch`
-  
+
   Whether to use the batch API instead of requesting objects individually.
   Default false.
 
@@ -30,40 +30,40 @@ lfs option can be scoped inside the configuration for a remote.
 
 * `lfs.fetchinclude`
 
-  When fetching, only download objects which match any entry on this 
-  comma-separated list of paths/filenames. Wildcard matching is as per 
+  When fetching, only download objects which match any entry on this
+  comma-separated list of paths/filenames. Wildcard matching is as per
   git-ignore(1). See git-lfs-fetch(1) for examples.
 
 * `lfs.fetchexclude`
 
   When fetching, do not download objects which match any item on this
-  comma-separated list of paths/filenames. Wildcard matching is as per 
+  comma-separated list of paths/filenames. Wildcard matching is as per
   git-ignore(1). See git-lfs-fetch(1) for examples.
 
 
 * `lfs.fetchrecentrefsdays`
-  
-  If non-zero, fetches refs which have commits within N days of the current 
+
+  If non-zero, fetches refs which have commits within N days of the current
   date. Only local refs are included unless lfs.fetchrecentremoterefs is true.
   The default is 7 days.
 
 * `lfs.fetchrecentremoterefs`
-  
+
   If true, fetches remote refs (for the remote you're fetching) as well as local
-  refs in the recent window. This is useful to fetch objects for remote branches 
-  you might want to check out later. The default is true; if you set this to 
-  false, fetching for those branches will only occur when you either check them 
-  out (losing the advantage of fetch --recent), or create a tracking local 
+  refs in the recent window. This is useful to fetch objects for remote branches
+  you might want to check out later. The default is true; if you set this to
+  false, fetching for those branches will only occur when you either check them
+  out (losing the advantage of fetch --recent), or create a tracking local
   branch separately then fetch again.
 
 * `lfs.fetchrecentcommitsdays`
-  
-  In addition to fetching at refs, also fetches previous changes made within N 
+
+  In addition to fetching at refs, also fetches previous changes made within N
   days of the latest commit on the ref. This is useful if you're often reviewing
   recent changes. The default is 0 (no previous changes).
 
 * `lfs.fetchrecentalways`
-  
+
   Always operate as if --recent was included in a `git lfs fetch` call. Default
   false.
 
@@ -71,7 +71,7 @@ lfs option can be scoped inside the configuration for a remote.
 
 * `lfs.extension.<name>.<setting>`
 
-  Git LFS extensions enable the manipulation of files streams during smudge and 
+  Git LFS extensions enable the manipulation of files streams during smudge and
   clean. `name` groups the settings for a single extension, and the settings
   are:
   * `clean` The command which runs when files are added to the index
@@ -81,12 +81,12 @@ lfs option can be scoped inside the configuration for a remote.
 ### Other settings
 
 * `lfs.<url>.access`
-  
+
   Note: this setting is normally set by LFS itself on receiving a 401 response
   (authentication required), you don't normally need to set it manually. 
 
   If set to "private" then credentials will be requested before making batch
-  requests to this url, otherwise a public request will initially be attempted. 
+  requests to this url, otherwise a public request will initially be attempted.
 
 ## SEE ALSO
 

--- a/git/git.go
+++ b/git/git.go
@@ -122,7 +122,7 @@ func (c *gitConfig) Find(val string) string {
 
 // SetGlobal sets the git config value for the key in the global config
 func (c *gitConfig) SetGlobal(key, val string) {
-	simpleExec("git", "config", "--global", "--add", key, val)
+	simpleExec("git", "config", "--global", key, val)
 }
 
 // UnsetGlobal removes the git config value for the key from the global config
@@ -136,7 +136,7 @@ func (c *gitConfig) UnsetGlobalSection(key string) {
 
 // SetLocal sets the git config value for the key in the specified config file
 func (c *gitConfig) SetLocal(file, key, val string) {
-	simpleExec("git", "config", "--file", file, "--add", key, val)
+	simpleExec("git", "config", "--file", file, key, val)
 }
 
 // UnsetLocalKey removes the git config value for the key from the specified config file

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -204,7 +204,7 @@ func Batch(objects []*objectResource, operation string) ([]*objectResource, erro
 
 		switch res.StatusCode {
 		case 401:
-			Config.SetPrivateAccess()
+			Config.SetAccess(AuthTypeBasic)
 			tracerx.Printf("api: batch not authorized, submitting with auth")
 			return Batch(objects, operation)
 		case 404, 410:

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -184,7 +184,7 @@ func Batch(objects []*objectResource, operation string) ([]*objectResource, erro
 		return nil, Error(err)
 	}
 
-	req, err := newBatchApiRequest()
+	req, err := newBatchApiRequest(operation)
 	if err != nil {
 		return nil, Error(err)
 	}
@@ -613,13 +613,13 @@ func newClientRequest(method, rawurl string, header map[string]string) (*http.Re
 	return req, nil
 }
 
-func newBatchApiRequest() (*http.Request, error) {
+func newBatchApiRequest(operation string) (*http.Request, error) {
 	endpoint := Config.Endpoint()
 
-	res, err := sshAuthenticate(endpoint, "download", "")
+	res, err := sshAuthenticate(endpoint, operation, "")
 	if err != nil {
-		tracerx.Printf("ssh: attempted with %s.  Error: %s",
-			endpoint.SshUserAndHost, err.Error(),
+		tracerx.Printf("ssh: %s attempted with %s.  Error: %s",
+			operation, endpoint.SshUserAndHost, err.Error(),
 		)
 	}
 

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -133,11 +133,10 @@ func (c *Configuration) BatchTransfer() bool {
 		}
 
 		// Any numeric value except 0 is considered true
-		if n, err := strconv.Atoi(v); err == nil && n != 0 {
-			return true
-		}
+		n, _ := strconv.Atoi(v)
+		return n != 0
 	}
-	return false
+	return true
 }
 
 // PrivateAccess will retrieve the access value and return true if

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -166,7 +166,7 @@ func (c *Configuration) SetAccess(authType AuthType) {
 
 func (c *Configuration) EndpointAccess(e Endpoint) AuthType {
 	key := fmt.Sprintf("lfs.%s.access", e.Url)
-	if v, ok := c.GitConfig(key); ok {
+	if v, ok := c.GitConfig(key); ok && len(v) > 0 {
 		return AuthType(strings.ToLower(v))
 	}
 	return AuthTypeNone

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -156,17 +156,25 @@ func (c *Configuration) PrivateAccess() bool {
 
 // Access returns the access auth type.
 func (c *Configuration) Access() AuthType {
-	key := fmt.Sprintf("lfs.%s.access", c.Endpoint().Url)
+	return c.EndpointAccess(c.Endpoint())
+}
+
+// SetAccess will set the private access flag in .git/config.
+func (c *Configuration) SetAccess(authType AuthType) {
+	c.SetEndpointAccess(c.Endpoint(), authType)
+}
+
+func (c *Configuration) EndpointAccess(e Endpoint) AuthType {
+	key := fmt.Sprintf("lfs.%s.access", e.Url)
 	if v, ok := c.GitConfig(key); ok {
 		return AuthType(strings.ToLower(v))
 	}
 	return AuthTypeNone
 }
 
-// SetAccess will set the private access flag in .git/config.
-func (c *Configuration) SetAccess(authType AuthType) {
+func (c *Configuration) SetEndpointAccess(e Endpoint, authType AuthType) {
 	tracerx.Printf("setting repository access to %s", authType)
-	key := fmt.Sprintf("lfs.%s.access", c.Endpoint().Url)
+	key := fmt.Sprintf("lfs.%s.access", e.Url)
 	configFile := filepath.Join(LocalGitDir, "config")
 
 	// Modify the config cache because it's checked again in this process

--- a/lfs/config_test.go
+++ b/lfs/config_test.go
@@ -279,81 +279,27 @@ func TestConcurrentTransfersNegativeValue(t *testing.T) {
 	assert.Equal(t, 3, n)
 }
 
-func TestBatchTrue(t *testing.T) {
-	config := &Configuration{
-		gitConfig: map[string]string{
-			"lfs.batch": "true",
-		},
+func TestBatch(t *testing.T) {
+	tests := map[string]bool{
+		"true":     true,
+		"1":        true,
+		"42":       true,
+		"-1":       true,
+		"":         true,
+		"0":        false,
+		"false":    false,
+		"elephant": false,
 	}
 
-	v := config.BatchTransfer()
-	assert.Equal(t, true, v)
-}
+	for value, expected := range tests {
+		config := &Configuration{
+			gitConfig: map[string]string{"lfs.batch": value},
+		}
 
-func TestBatchNumeric1IsTrue(t *testing.T) {
-	config := &Configuration{
-		gitConfig: map[string]string{
-			"lfs.batch": "1",
-		},
+		if actual := config.BatchTransfer(); actual != expected {
+			t.Errorf("lfs.batch %q == %v, not %v", value, actual, expected)
+		}
 	}
-
-	v := config.BatchTransfer()
-	assert.Equal(t, true, v)
-}
-
-func TestBatchNumeric0IsFalse(t *testing.T) {
-	config := &Configuration{
-		gitConfig: map[string]string{
-			"lfs.batch": "0",
-		},
-	}
-
-	v := config.BatchTransfer()
-	assert.Equal(t, false, v)
-}
-
-func TestBatchOtherNumericsAreTrue(t *testing.T) {
-	config := &Configuration{
-		gitConfig: map[string]string{
-			"lfs.batch": "42",
-		},
-	}
-
-	v := config.BatchTransfer()
-	assert.Equal(t, true, v)
-}
-
-func TestBatchNegativeNumericsAreTrue(t *testing.T) {
-	config := &Configuration{
-		gitConfig: map[string]string{
-			"lfs.batch": "-1",
-		},
-	}
-
-	v := config.BatchTransfer()
-	assert.Equal(t, true, v)
-}
-
-func TestBatchNonBooleanIsFalse(t *testing.T) {
-	config := &Configuration{
-		gitConfig: map[string]string{
-			"lfs.batch": "elephant",
-		},
-	}
-
-	v := config.BatchTransfer()
-	assert.Equal(t, false, v)
-}
-
-func TestBatchPresentButBlankIsTrue(t *testing.T) {
-	config := &Configuration{
-		gitConfig: map[string]string{
-			"lfs.batch": "",
-		},
-	}
-
-	v := config.BatchTransfer()
-	assert.Equal(t, true, v)
 }
 
 func TestBatchAbsentIsTrue(t *testing.T) {

--- a/lfs/config_test.go
+++ b/lfs/config_test.go
@@ -353,11 +353,11 @@ func TestBatchPresentButBlankIsTrue(t *testing.T) {
 	assert.Equal(t, true, v)
 }
 
-func TestBatchAbsentIsFalse(t *testing.T) {
+func TestBatchAbsentIsTrue(t *testing.T) {
 	config := &Configuration{}
 
 	v := config.BatchTransfer()
-	assert.Equal(t, false, v)
+	assert.Equal(t, true, v)
 }
 
 func TestLoadValidExtension(t *testing.T) {

--- a/test/test-env.sh
+++ b/test/test-env.sh
@@ -35,7 +35,7 @@ begin_test "env with origin remote"
   git remote add origin "$GITSERVER/env-origin-remote"
 
   expected=$(printf "%s\n%s\n
-Endpoint=$GITSERVER/$reponame.git/info/lfs
+Endpoint=$GITSERVER/$reponame.git/info/lfs (auth=none)
 LocalWorkingDir=$TRASHDIR/$reponame
 LocalGitDir=$TRASHDIR/$reponame/.git
 LocalGitStorageDir=$TRASHDIR/$reponame/.git
@@ -66,8 +66,8 @@ begin_test "env with multiple remotes"
   git remote add other "$GITSERVER/env-other-remote"
 
   expected=$(printf "%s\n%s\n
-Endpoint=$GITSERVER/env-origin-remote.git/info/lfs
-Endpoint (other)=$GITSERVER/env-other-remote.git/info/lfs
+Endpoint=$GITSERVER/env-origin-remote.git/info/lfs (auth=none)
+Endpoint (other)=$GITSERVER/env-other-remote.git/info/lfs (auth=none)
 LocalWorkingDir=$TRASHDIR/$reponame
 LocalGitDir=$TRASHDIR/$reponame/.git
 LocalGitStorageDir=$TRASHDIR/$reponame/.git
@@ -97,7 +97,7 @@ begin_test "env with other remote"
   git remote add other "$GITSERVER/env-other-remote"
 
   expected=$(printf "%s\n%s\n
-Endpoint (other)=$GITSERVER/env-other-remote.git/info/lfs
+Endpoint (other)=$GITSERVER/env-other-remote.git/info/lfs (auth=none)
 LocalWorkingDir=$TRASHDIR/$reponame
 LocalGitDir=$TRASHDIR/$reponame/.git
 LocalGitStorageDir=$TRASHDIR/$reponame/.git
@@ -129,8 +129,8 @@ begin_test "env with multiple remotes and lfs.url config"
   git config lfs.url "http://foo/bar"
 
   expected=$(printf "%s\n%s\n
-Endpoint=http://foo/bar
-Endpoint (other)=$GITSERVER/env-other-remote.git/info/lfs
+Endpoint=http://foo/bar (auth=none)
+Endpoint (other)=$GITSERVER/env-other-remote.git/info/lfs (auth=none)
 LocalWorkingDir=$TRASHDIR/$reponame
 LocalGitDir=$TRASHDIR/$reponame/.git
 LocalGitStorageDir=$TRASHDIR/$reponame/.git
@@ -164,8 +164,8 @@ begin_test "env with multiple remotes and lfs configs"
   git config remote.other.lfsurl "http://custom/other"
 
   expected=$(printf "%s\n%s\n
-Endpoint=http://foo/bar
-Endpoint (other)=http://custom/other
+Endpoint=http://foo/bar (auth=none)
+Endpoint (other)=http://custom/other (auth=none)
 LocalWorkingDir=$TRASHDIR/$reponame
 LocalGitDir=$TRASHDIR/$reponame/.git
 LocalGitStorageDir=$TRASHDIR/$reponame/.git
@@ -201,8 +201,8 @@ begin_test "env with multiple remotes and lfs url and batch configs"
   git config remote.other.lfsurl "http://custom/other"
 
   expected=$(printf "%s\n%s\n
-Endpoint=http://foo/bar
-Endpoint (other)=http://custom/other
+Endpoint=http://foo/bar (auth=none)
+Endpoint (other)=http://custom/other (auth=none)
 LocalWorkingDir=$TRASHDIR/$reponame
 LocalGitDir=$TRASHDIR/$reponame/.git
 LocalGitStorageDir=$TRASHDIR/$reponame/.git
@@ -239,7 +239,7 @@ begin_test "env with .gitconfig"
 ' > .gitconfig
 
   expected=$(printf "%s\n%s\n
-Endpoint=http://foobar:8080/
+Endpoint=http://foobar:8080/ (auth=none)
 LocalWorkingDir=$TRASHDIR/$reponame
 LocalGitDir=$TRASHDIR/$reponame/.git
 LocalGitStorageDir=$TRASHDIR/$reponame/.git

--- a/test/test-env.sh
+++ b/test/test-env.sh
@@ -17,7 +17,7 @@ LocalGitStorageDir=$TRASHDIR/$reponame/.git
 LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
 TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
-BatchTransfer=false
+BatchTransfer=true
 $(env | grep "^GIT")
 " "$(git lfs version)" "$(git version)")
   actual=$(git lfs env)
@@ -42,7 +42,7 @@ LocalGitStorageDir=$TRASHDIR/$reponame/.git
 LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
 TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
-BatchTransfer=false
+BatchTransfer=true
 $(env | grep "^GIT")
 " "$(git lfs version)" "$(git version)")
   actual=$(git lfs env)
@@ -74,7 +74,7 @@ LocalGitStorageDir=$TRASHDIR/$reponame/.git
 LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
 TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
-BatchTransfer=false
+BatchTransfer=true
 $(env | grep "^GIT")
 " "$(git lfs version)" "$(git version)")
   actual=$(git lfs env)
@@ -104,7 +104,7 @@ LocalGitStorageDir=$TRASHDIR/$reponame/.git
 LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
 TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
-BatchTransfer=false
+BatchTransfer=true
 $(env | grep "^GIT")
 " "$(git lfs version)" "$(git version)")
   actual=$(git lfs env)
@@ -137,7 +137,7 @@ LocalGitStorageDir=$TRASHDIR/$reponame/.git
 LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
 TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
-BatchTransfer=false
+BatchTransfer=true
 $(env | grep "^GIT")
 " "$(git lfs version)" "$(git version)")
   actual=$(git lfs env)
@@ -172,7 +172,7 @@ LocalGitStorageDir=$TRASHDIR/$reponame/.git
 LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
 TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
-BatchTransfer=false
+BatchTransfer=true
 $(env | grep "^GIT")
 " "$(git lfs version)" "$(git version)")
   actual=$(git lfs env)
@@ -195,7 +195,7 @@ begin_test "env with multiple remotes and lfs url and batch configs"
   git remote add origin "$GITSERVER/env-origin-remote"
   git remote add other "$GITSERVER/env-other-remote"
   git config lfs.url "http://foo/bar"
-  git config lfs.batch true
+  git config lfs.batch false
   git config lfs.concurrenttransfers 5
   git config remote.origin.lfsurl "http://custom/origin"
   git config remote.other.lfsurl "http://custom/other"
@@ -209,7 +209,7 @@ LocalGitStorageDir=$TRASHDIR/$reponame/.git
 LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
 TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=5
-BatchTransfer=true
+BatchTransfer=false
 $(env | grep "^GIT")
 " "$(git lfs version)" "$(git version)")
   actual=$(git lfs env)
@@ -277,7 +277,7 @@ LocalGitStorageDir=$TRASHDIR/$reponame/.git
 LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
 TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
-BatchTransfer=false
+BatchTransfer=true
 $(GIT_DIR=$gitDir GIT_WORK_TREE=$workTree env | grep "^GIT")
 " "$(git lfs version)" "$(git version)")
 
@@ -303,7 +303,7 @@ LocalGitStorageDir=$TRASHDIR/$reponame/.git
 LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
 TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
-BatchTransfer=false
+BatchTransfer=true
 $(GIT_DIR=$gitDir GIT_WORK_TREE=a/b env | grep "^GIT")
 " "$(git lfs version)" "$(git version)")
   actual5=$(GIT_DIR=$gitDir GIT_WORK_TREE=a/b git lfs env)
@@ -316,7 +316,7 @@ LocalGitStorageDir=$TRASHDIR/$reponame/.git
 LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
 TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
-BatchTransfer=false
+BatchTransfer=true
 $(GIT_WORK_TREE=a/b env | grep "^GIT")
 " "$(git lfs version)" "$(git version)")
   actual6=$(GIT_WORK_TREE=a/b git lfs env)
@@ -330,7 +330,7 @@ LocalGitStorageDir=$TRASHDIR/$reponame/.git
 LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
 TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
-BatchTransfer=false
+BatchTransfer=true
 $(GIT_DIR=$gitDir env | grep "^GIT")
 " "$(git lfs version)" "$(git version)")
   actual7=$(GIT_DIR=$gitDir git lfs env)
@@ -344,7 +344,7 @@ LocalGitStorageDir=$TRASHDIR/$reponame/.git
 LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
 TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
-BatchTransfer=false
+BatchTransfer=true
 $(GIT_WORK_TREE=$workTree env | grep "^GIT")
 " "$(git lfs version)" "$(git version)")
   actual8=$(GIT_WORK_TREE=$workTree git lfs env)

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -100,7 +100,7 @@ begin_test "pre-push 307 redirects"
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/redirect307/rel/$reponame.git/info/lfs" 2>&1 |
     tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "(0 of 1 files, 1 skipped)" push.log
 
   assert_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4
 
@@ -116,9 +116,7 @@ begin_test "pre-push 307 redirects"
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/redirect307/abs/$reponame.git/info/lfs" 2>&1 |
     tee push.log
-  grep "(1 of 1 files)" push.log
-
-
+  grep "(0 of 1 files, 1 skipped)" push.log
 )
 end_test
 

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -24,7 +24,7 @@ begin_test "push"
   git commit -m "add b.dat"
 
   git lfs push origin push-b 2>&1 | tee push.log
-  grep "(2 of 2 files)" push.log
+  grep "(1 of 2 files, 1 skipped)" push.log
 )
 end_test
 
@@ -73,7 +73,7 @@ begin_test "push object id(s)"
   git lfs push --object-id origin \
     4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
     2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "(0 of 1 files, 1 skipped)" push.log
 
   echo "push b" > b.dat
   git add b.dat
@@ -83,7 +83,7 @@ begin_test "push object id(s)"
     4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
     82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 \
     2>&1 | tee push.log
-  grep "(2 of 2 files)" push.log
+  grep "(0 of 2 files, 2 skipped)" push.log
 )
 end_test
 
@@ -107,7 +107,7 @@ begin_test "push modified files"
   oid3=$(printf "$content3" | shasum -a 256 | cut -f 1 -d " ")
   oid4=$(printf "$content4" | shasum -a 256 | cut -f 1 -d " ")
   oid5=$(printf "$content5" | shasum -a 256 | cut -f 1 -d " ")
-  
+
   echo "[
   {
     \"CommitDate\":\"$(get_date -6m)\",
@@ -143,5 +143,3 @@ begin_test "push modified files"
   assert_server_object "$reponame" "$oid5"
 )
 end_test
-
-

--- a/test/test-submodule.sh
+++ b/test/test-submodule.sh
@@ -40,7 +40,7 @@ begin_test "submodule env"
   cd repo
 
   git lfs env | tee env.log
-  grep "Endpoint=$GITSERVER/$reponame.git/info/lfs$" env.log
+  grep "Endpoint=$GITSERVER/$reponame.git/info/lfs (auth=none)$" env.log
   grep "LocalWorkingDir=$TRASHDIR/repo$" env.log
   grep "LocalGitDir=$TRASHDIR/repo/.git$" env.log
   grep "LocalGitStorageDir=$TRASHDIR/repo/.git$" env.log
@@ -51,7 +51,7 @@ begin_test "submodule env"
 
   echo "./.git"
   git lfs env | tee env.log
-  grep "Endpoint=$GITSERVER/$reponame.git/info/lfs$" env.log
+  grep "Endpoint=$GITSERVER/$reponame.git/info/lfs (auth=none)$" env.log
   grep "LocalWorkingDir=$" env.log
   grep "LocalGitDir=$TRASHDIR/repo/.git$" env.log
   grep "LocalGitStorageDir=$TRASHDIR/repo/.git$" env.log
@@ -62,7 +62,7 @@ begin_test "submodule env"
 
   echo "./sub"
   git lfs env | tee env.log
-  grep "Endpoint=$GITSERVER/$submodname.git/info/lfs$" env.log
+  grep "Endpoint=$GITSERVER/$submodname.git/info/lfs (auth=none)$" env.log
   grep "LocalWorkingDir=$TRASHDIR/repo/sub$" env.log
   grep "LocalGitDir=$TRASHDIR/repo/.git/modules/sub$" env.log
   grep "LocalGitStorageDir=$TRASHDIR/repo/.git/modules/sub$" env.log
@@ -73,7 +73,7 @@ begin_test "submodule env"
 
   echo "./sub/dir"
   git lfs env | tee env.log
-  grep "Endpoint=$GITSERVER/$submodname.git/info/lfs$" env.log
+  grep "Endpoint=$GITSERVER/$submodname.git/info/lfs (auth=none)$" env.log
   grep "LocalWorkingDir=$TRASHDIR/repo/sub$" env.log
   grep "LocalGitDir=$TRASHDIR/repo/.git/modules/sub$" env.log
   grep "LocalGitStorageDir=$TRASHDIR/repo/.git/modules/sub$" env.log


### PR DESCRIPTION
This makes two changes for a Git LFS v0.6.0 release:

1. It now sets `lfs.{endpoint}.access` to "basic", not "private". This is an attempt to make the config forward compatible with possible alternate authentication methods, such as NTLM #617.
2. It now tries the batch API by default, setting `lfs.batch` to "false" if it has to fall back to the legacy API.