### PR TITLE
Include the username in the creds call if present

### DIFF
--- a/lfs/credentials.go
+++ b/lfs/credentials.go
@@ -105,6 +105,9 @@ func getCredURLForAPI(req *http.Request) (*url.URL, error) {
 func fillCredentials(u *url.URL) (Creds, error) {
 	path := strings.TrimPrefix(u.Path, "/")
 	creds := Creds{"protocol": u.Scheme, "host": u.Host, "path": path}
+	if u.User != nil && u.User.Username() != "" {
+		creds["username"] = u.User.Username()
+	}
 	return execCreds(creds, "fill")
 }
 

--- a/lfs/credentials_test.go
+++ b/lfs/credentials_test.go
@@ -20,7 +20,16 @@ func TestGetCredentialsForApi(t *testing.T) {
 			Password: "monkey",
 		},
 		{
-			Desc:          "auth header",
+			Desc:     "username in url",
+			Config:   map[string]string{"lfs.url": "https://user@git-server.com"},
+			Method:   "GET",
+			Href:     "https://git-server.com/foo",
+			Protocol: "https",
+			Host:     "git-server.com",
+			Username: "user",
+			Password: "monkey",
+		},
+		{Desc: "auth header",
 			Config:        map[string]string{"lfs.url": "https://git-server.com"},
 			Header:        map[string]string{"Authorization": "Test monkey"},
 			Method:        "GET",
@@ -77,6 +86,16 @@ func TestGetCredentialsForApi(t *testing.T) {
 			Method:        "GET",
 			Href:          "https://git-server.com/foo",
 			Authorization: "Basic " + base64.URLEncoding.EncodeToString([]byte("gituser:gitpass")),
+		},
+		{
+			Desc:     "username in url",
+			Config:   map[string]string{"lfs.url": "https://user@git-server.com"},
+			Method:   "GET",
+			Href:     "https://git-server.com/foo",
+			Protocol: "https",
+			Host:     "git-server.com",
+			Username: "user",
+			Password: "monkey",
 		},
 	})
 }
@@ -216,7 +235,9 @@ func init() {
 		for key, value := range input {
 			output[key] = value
 		}
-		output["username"] = input["host"]
+		if _, ok := output["username"]; !ok {
+			output["username"] = input["host"]
+		}
 		output["password"] = "monkey"
 		return output, nil
 	}


### PR DESCRIPTION
This is needed to disambiguate cases where a user has multiple usernames
on the same host. Without this the first item will be silently used
which might be wrong & cause a loop of incorrect password prompts (&
possibly a lockout on the server)