### PR TITLE
Fix Go 1.5 integration test issues

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -151,12 +151,16 @@ func prePushCheckForMissingObjects(pointers []*lfs.WrappedPointer) (objectsOnSer
 	}
 	// this channel is filled with oids for which Check() succeeded & Transfer() was called
 	transferc := checkQueue.Watch()
+	done := make(chan int)
 	go func() {
 		for oid := range transferc {
 			skipObjects[oid] = struct{}{}
 		}
+		done <- 1
 	}()
+	// Currently this is needed to flush the batch but is not enough to sync transferc completely
 	checkQueue.Wait()
+	<-done
 	return skipObjects
 }
 

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -25,7 +25,6 @@ var (
 	repoDir      string
 	largeObjects = newLfsStorage()
 	server       *httptest.Server
-	serveBatch   = true
 )
 
 func main() {
@@ -34,14 +33,6 @@ func main() {
 	mux := http.NewServeMux()
 	server = httptest.NewServer(mux)
 	stopch := make(chan bool)
-
-	mux.HandleFunc("/startbatch", func(w http.ResponseWriter, r *http.Request) {
-		serveBatch = true
-	})
-
-	mux.HandleFunc("/stopbatch", func(w http.ResponseWriter, r *http.Request) {
-		serveBatch = false
-	})
 
 	mux.HandleFunc("/shutdown", func(w http.ResponseWriter, r *http.Request) {
 		stopch <- true
@@ -201,7 +192,7 @@ func lfsGetHandler(w http.ResponseWriter, r *http.Request, repo string) {
 }
 
 func lfsBatchHandler(w http.ResponseWriter, r *http.Request, repo string) {
-	if !serveBatch {
+	if repo == "batchunsupported" {
 		w.WriteHeader(404)
 		return
 	}

--- a/test/test-batch-transfer-unsupported.sh
+++ b/test/test-batch-transfer-unsupported.sh
@@ -9,7 +9,7 @@ begin_test "batch transfer unsupported on server"
   # This initializes a new bare git repository in test/remote.
   # These remote repositories are global to every test, so keep the names
   # unique.
-  reponame="$(basename "$0" ".sh")"
+  reponame="batchunsupported"
   setup_remote_repo "$reponame"
 
   # Clone the repository again to $TRASHDIR/repo. This will be used to commit
@@ -42,22 +42,12 @@ begin_test "batch transfer unsupported on server"
   # Ensure batch transfer is turned on for this repo
   git config --add --local lfs.batch true
 
-  # Turn off batch support on the server
-  if [ -s "$LFS_URL_FILE" ]; then
-    curl "$(cat "$LFS_URL_FILE")/stopbatch"
-  fi
-
   # This pushes to the remote repository set up at the top of the test.
   git push origin master 2>&1 | tee push.log
   grep "(1 of 1 files)" push.log
   grep "master -> master" push.log
 
   assert_server_object "$reponame" "$contents_oid"
-
-  # Re-enable batch support on the server
-  if [ -s "$LFS_URL_FILE" ]; then
-    curl "$(cat "$LFS_URL_FILE")/startbatch"
-  fi
 
   # Assert that configuration was disabled
   set +e


### PR DESCRIPTION
The test for lack of batch support turned it off globally on the test server then turned it back on, but since the server is shared between parallel tests, this introduces a race condition which can break other batch tests randomly. Instead, use a specific repo name to flag it.

Found this while investigating #625 although this isn't the complete fix. [Edit]Now it is.