### PR TITLE
Config bool checks

### DIFF
--- a/lfs/config.go
+++ b/lfs/config.go
@@ -135,14 +135,9 @@ func (c *Configuration) ConcurrentTransfers() int {
 }
 
 func (c *Configuration) BatchTransfer() bool {
-	if v, ok := c.GitConfig("lfs.batch"); ok {
-		if v == "true" || v == "" {
-			return true
-		}
-
-		// Any numeric value except 0 is considered true
-		n, _ := strconv.Atoi(v)
-		return n != 0
+	switch c.GitConfig("lfs.batch") {
+	case "false", "no", "off", "0":
+		return false
 	}
 	return true
 }

--- a/lfs/config_test.go
+++ b/lfs/config_test.go
@@ -281,11 +281,11 @@ func TestConcurrentTransfersNegativeValue(t *testing.T) {
 
 func TestBatch(t *testing.T) {
 	tests := map[string]bool{
+		"":         true,
 		"true":     true,
 		"1":        true,
-		"42":       true,
-		"-1":       true,
-		"":         true,
+		"42":       false,
+		"-1":       false,
 		"0":        false,
 		"false":    false,
 		"elephant": false,


### PR DESCRIPTION
Adds a more explicit bool parser based on `strconv.ParseBool()`. May want to write to stderr if a config value is invalid (such as `42` or `-1`).