### PR TITLE
Access types

### DIFF
--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"regexp"
+
+	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
 )
@@ -23,6 +26,24 @@ func updateCommand(cmd *cobra.Command, args []string) {
 		Print("Run `git lfs update --force` to overwrite this hook.")
 	} else {
 		Print("Updated pre-push hook.")
+	}
+
+	lfsAccessRE := regexp.MustCompile(`\Alfs\.(.*)\.access\z`)
+	for key, value := range lfs.Config.AllGitConfig() {
+		matches := lfsAccessRE.FindStringSubmatch(key)
+		if len(matches) < 2 {
+			continue
+		}
+
+		switch value {
+		case "basic":
+		case "private":
+			git.Config.SetLocal("", key, "basic")
+			Print("Updated %s access from %s to %s.", matches[1], value, "basic")
+		default:
+			git.Config.UnsetLocalKey("", key)
+			Print("Removed invalid %s access of %s.", matches[1], value)
+		}
 	}
 }
 

--- a/git/git.go
+++ b/git/git.go
@@ -136,12 +136,24 @@ func (c *gitConfig) UnsetGlobalSection(key string) {
 
 // SetLocal sets the git config value for the key in the specified config file
 func (c *gitConfig) SetLocal(file, key, val string) {
-	simpleExec("git", "config", "--file", file, key, val)
+	args := make([]string, 1, 5)
+	args[0] = "config"
+	if len(file) > 0 {
+		args = append(args, "--file", file)
+	}
+	args = append(args, key, val)
+	simpleExec("git", args...)
 }
 
 // UnsetLocalKey removes the git config value for the key from the specified config file
 func (c *gitConfig) UnsetLocalKey(file, key string) {
-	simpleExec("git", "config", "--file", file, "--unset", key)
+	args := make([]string, 1, 5)
+	args[0] = "config"
+	if len(file) > 0 {
+		args = append(args, "--file", file)
+	}
+	args = append(args, "--unset", key)
+	simpleExec("git", args...)
 }
 
 // List lists all of the git config values

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -204,7 +204,7 @@ func Batch(objects []*objectResource, operation string) ([]*objectResource, erro
 
 		switch res.StatusCode {
 		case 401:
-			Config.SetAccess(AuthTypeBasic)
+			Config.SetAccess("basic")
 			tracerx.Printf("api: batch not authorized, submitting with auth")
 			return Batch(objects, operation)
 		case 404, 410:

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -161,7 +161,11 @@ func (c *Configuration) SetAccess(authType string) {
 func (c *Configuration) EndpointAccess(e Endpoint) string {
 	key := fmt.Sprintf("lfs.%s.access", e.Url)
 	if v, ok := c.GitConfig(key); ok && len(v) > 0 {
-		return strings.ToLower(v)
+		lower := strings.ToLower(v)
+		if lower == "private" {
+			return "basic"
+		}
+		return lower
 	}
 	return "none"
 }

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -233,6 +233,11 @@ func (c *Configuration) GitConfig(key string) (string, bool) {
 	return value, ok
 }
 
+func (c *Configuration) AllGitConfig() map[string]string {
+	c.loadGitConfig()
+	return c.gitConfig
+}
+
 func (c *Configuration) ObjectUrl(oid string) (*url.URL, error) {
 	return ObjectUrl(c.Endpoint(), oid)
 }

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -173,19 +173,18 @@ func (c *Configuration) EndpointAccess(e Endpoint) string {
 func (c *Configuration) SetEndpointAccess(e Endpoint, authType string) {
 	tracerx.Printf("setting repository access to %s", authType)
 	key := fmt.Sprintf("lfs.%s.access", e.Url)
-	configFile := filepath.Join(LocalGitDir, "config")
 
 	// Modify the config cache because it's checked again in this process
 	// without being reloaded.
 	switch authType {
 	case "", "none":
-		git.Config.UnsetLocalKey(configFile, key)
+		git.Config.UnsetLocalKey("", key)
 
 		c.loading.Lock()
 		delete(c.gitConfig, key)
 		c.loading.Unlock()
 	default:
-		git.Config.SetLocal(configFile, key, authType)
+		git.Config.SetLocal("", key, authType)
 
 		c.loading.Lock()
 		c.gitConfig[key] = authType

--- a/lfs/config_test.go
+++ b/lfs/config_test.go
@@ -309,6 +309,46 @@ func TestBatchAbsentIsTrue(t *testing.T) {
 	assert.Equal(t, true, v)
 }
 
+func TestAccessConfig(t *testing.T) {
+	type accessTest struct {
+		Access        string
+		PrivateAccess bool
+	}
+
+	tests := map[string]accessTest{
+		"":            {"none", false},
+		"basic":       {"basic", true},
+		"BASIC":       {"basic", true},
+		"private":     {"basic", true},
+		"PRIVATE":     {"basic", true},
+		"invalidauth": {"invalidauth", true},
+	}
+
+	for value, expected := range tests {
+		config := &Configuration{
+			gitConfig: map[string]string{
+				"lfs.url":                        "http://example.com",
+				"lfs.http://example.com.access":  value,
+				"lfs.https://example.com.access": "bad",
+			},
+		}
+
+		if access := config.Access(); access != expected.Access {
+			t.Errorf("Expected Access() with value %q to be %v, got %v", value, expected.Access, access)
+		}
+
+		if priv := config.PrivateAccess(); priv != expected.PrivateAccess {
+			t.Errorf("Expected PrivateAccess() with value %q to be %v, got %v", value, expected.PrivateAccess, priv)
+		}
+	}
+}
+
+func TestAccessAbsentConfig(t *testing.T) {
+	config := &Configuration{}
+	assert.Equal(t, "none", config.Access())
+	assert.Equal(t, false, config.PrivateAccess())
+}
+
 func TestLoadValidExtension(t *testing.T) {
 	config := &Configuration{
 		gitConfig: map[string]string{},

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -1,7 +1,6 @@
 package lfs
 
 import (
-	"path/filepath"
 	"sync"
 
 	"github.com/github/git-lfs/git"
@@ -170,8 +169,7 @@ func (q *TransferQueue) batchApiRoutine() {
 		objects, err := Batch(transfers, q.transferKind)
 		if err != nil {
 			if IsNotImplementedError(err) {
-				configFile := filepath.Join(LocalGitDir, "config")
-				git.Config.SetLocal(configFile, "lfs.batch", "false")
+				git.Config.SetLocal("", "lfs.batch", "false")
 
 				go q.legacyFallback(batch)
 				return

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -69,3 +69,27 @@ Run \`git lfs update --force\` to overwrite this hook."
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 )
 end_test
+
+begin_test "update lfs.{url}.access"
+(
+  set -e
+
+  mkdir update-access
+  cd update-access
+  git init
+  git config lfs.http://example.com.access private
+  git config lfs.https://example.com.access private
+  git config lfs.https://example2.com.access basic
+  git config lfs.https://example3.com.access other
+
+  [ "private" = "$(git config lfs.http://example.com.access)" ]
+  [ "private" = "$(git config lfs.https://example.com.access)" ]
+  [ "basic" = "$(git config lfs.https://example2.com.access)" ]
+  [ "other" = "$(git config lfs.https://example3.com.access)" ]
+
+  expected="Updated pre-push hook.
+Updated http://example.com access from private to basic.
+Updated https://example.com access from private to basic.
+Removed invalid https://example3.com access of other."
+)
+end_test


### PR DESCRIPTION
This removes the `AuthType` type in favor of strings. Also adds some unit tests. The only behavior change is that `Config.Access()` returns "basic" if `lfs.{url}.access` is still using the legacy "private" value.