### PR TITLE
Fix worktree test now that batch is enabled by default

### DIFF
--- a/test/test-worktree.sh
+++ b/test/test-worktree.sh
@@ -24,7 +24,7 @@ LocalGitStorageDir=$TRASHDIR/$reponame/.git
 LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
 TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
-BatchTransfer=false
+BatchTransfer=true
 $(env | grep "^GIT")
 " "$(git lfs version)" "$(git version)")
     actual=$(git lfs env)
@@ -44,7 +44,7 @@ LocalGitStorageDir=$TRASHDIR/$reponame/.git
 LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
 TempDir=$TRASHDIR/$reponame/.git/worktrees/$worktreename/lfs/tmp
 ConcurrentTransfers=3
-BatchTransfer=false
+BatchTransfer=true
 $(env | grep "^GIT")
 " "$(git lfs version)" "$(git version)")
     actual=$(git lfs env)


### PR DESCRIPTION
Travis didn't spot this because it's using a git version < 2.5.0