### PR TITLE
Handle 401 for the legacy api path the same way batch does

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -202,11 +202,13 @@ func Batch(objects []*objectResource, operation string) ([]*objectResource, erro
 			return nil, err
 		}
 
-		switch res.StatusCode {
-		case 401:
+		if IsAuthError(err) {
 			Config.SetAccess(AuthTypeBasic)
 			tracerx.Printf("api: batch not authorized, submitting with auth")
 			return Batch(objects, operation)
+		}
+
+		switch res.StatusCode {
 		case 404, 410:
 			tracerx.Printf("api: batch not implemented: %d", res.StatusCode)
 			return nil, newNotImplementedError(nil)
@@ -254,6 +256,12 @@ func UploadCheck(oidPath string) (*objectResource, error) {
 	tracerx.Printf("api: uploading (%s)", oid)
 	res, obj, err := doLegacyApiRequest(req)
 	if err != nil {
+		if IsAuthError(err) {
+			Config.SetAccess(AuthTypeBasic)
+			tracerx.Printf("api: upload check not authorized, submitting with auth")
+			return UploadCheck(oidPath)
+		}
+
 		return nil, err
 	}
 	LogTransfer("lfs.api.upload", res)
@@ -378,6 +386,9 @@ func doApiBatchRequest(req *http.Request) (*http.Response, []*objectResource, er
 	res, err := doAPIRequest(req)
 
 	if err != nil {
+		if res.StatusCode == 401 {
+			return res, nil, newAuthError(err)
+		}
 		return res, nil, err
 	}
 
@@ -522,6 +533,10 @@ func handleResponse(res *http.Response, creds Creds) error {
 		} else {
 			err = Error(cliErr)
 		}
+	}
+
+	if res.StatusCode == 401 {
+		return newAuthError(err)
 	}
 
 	if res.StatusCode > 499 && res.StatusCode != 501 && res.StatusCode != 509 {

--- a/lfs/errors.go
+++ b/lfs/errors.go
@@ -81,6 +81,20 @@ func IsNotImplementedError(err error) bool {
 	return false
 }
 
+// IsAuthError indicates the client provided a request with invalid or no
+// authentication credentials when credentials are required (e.g. HTTP 401).
+func IsAuthError(err error) bool {
+	if e, ok := err.(interface {
+		AuthError() bool
+	}); ok {
+		return e.AuthError()
+	}
+	if e, ok := err.(errorWrapper); ok {
+		return IsAuthError(e.InnerError())
+	}
+	return false
+}
+
 // IsInvalidPointerError indicates an attempt to parse data that was not a
 // valid pointer.
 func IsInvalidPointerError(err error) bool {
@@ -339,6 +353,24 @@ func (e notImplementedError) NotImplemented() bool {
 
 func newNotImplementedError(err error) error {
 	return notImplementedError{newWrappedError(err, "Not implemented")}
+}
+
+// Definitions for IsAuthError()
+
+type authError struct {
+	errorWrapper
+}
+
+func (e authError) InnerError() error {
+	return e.errorWrapper
+}
+
+func (e authError) AuthError() bool {
+	return true
+}
+
+func newAuthError(err error) error {
+	return authError{newWrappedError(err, "Authentication required")}
 }
 
 // Definitions for IsInvalidPointerError()


### PR DESCRIPTION
Raised in #609

The legacy api path had no 401 handling, so the call would be treated as a success, allowing `git push` to exit cleanly. This PR handles a 401 in the legacy path the same way the batch path handles it, i.e. re-prompting for credentials.