### PR TITLE
test for bad clean or smudge attribute

### DIFF
--- a/test/test-init.sh
+++ b/test/test-init.sh
@@ -30,7 +30,8 @@ begin_test "init with old settings"
 
   [ "$res" = 2 ]
 
-  grep "clean attribute should be" init.log
+  cat init.log
+  grep -E "(clean|smudge) attribute should be" init.log
   [ `grep -c "(MISSING)" init.log` = "0" ]
 
   [ "git lfs smudge %f" = "$(git config filter.lfs.smudge)" ]


### PR DESCRIPTION
I think it's coming from [here](https://github.com/github/git-lfs/blob/10dbfb5da854b3a4a1aefbb073e4aef7d0f4e898/lfs/attribute.go#L32-L47). Sometimes it returns the smudge error before the clean error. This might be a slight regression from #619. I'll have to see if the older code returned errors for every attribute and not just the first one.