### PR TITLE
In repo check

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -21,6 +21,11 @@ var (
 )
 
 func checkoutCommand(cmd *cobra.Command, args []string) {
+	if !lfs.InRepo() {
+		Print("Not in a git repository.")
+		os.Exit(128)
+	}
+
 	// Parameters are filters
 	// firstly convert any pathspecs to the root of the repo, in case this is being executed in a sub-folder
 	var rootedpaths []string

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -21,10 +21,7 @@ var (
 )
 
 func checkoutCommand(cmd *cobra.Command, args []string) {
-	if !lfs.InRepo() {
-		Print("Not in a git repository.")
-		os.Exit(128)
-	}
+	requireInRepo()
 
 	// Parameters are filters
 	// firstly convert any pathspecs to the root of the repo, in case this is being executed in a sub-folder

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/github/git-lfs/git"
@@ -25,6 +26,11 @@ var (
 func fetchCommand(cmd *cobra.Command, args []string) {
 	var refs []*git.Ref
 
+	if !lfs.InRepo() {
+		Print("Not in a git repository.")
+		os.Exit(128)
+	}
+
 	if len(args) > 0 {
 		// Remote is first arg
 		lfs.Config.CurrentRemote = args[0]
@@ -34,6 +40,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 			lfs.Config.CurrentRemote = trackedRemote
 		} // otherwise leave as default (origin)
 	}
+
 	if len(args) > 1 {
 		for _, r := range args[1:] {
 			ref, err := git.ResolveRef(r)
@@ -63,7 +70,6 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		fetchAll()
 
 	} else { // !all
-
 		includePaths, excludePaths := determineIncludeExcludePaths(fetchIncludeArg, fetchExcludeArg)
 
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/github/git-lfs/git"
@@ -24,12 +23,9 @@ var (
 )
 
 func fetchCommand(cmd *cobra.Command, args []string) {
-	var refs []*git.Ref
+	requireInRepo()
 
-	if !lfs.InRepo() {
-		Print("Not in a git repository.")
-		os.Exit(128)
-	}
+	var refs []*git.Ref
 
 	if len(args) > 0 {
 		// Remote is first arg

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -23,6 +23,11 @@ var (
 )
 
 func doFsck() (bool, error) {
+	if !lfs.InRepo() {
+		Print("Not in a git repository.")
+		os.Exit(128)
+	}
+
 	ref, err := git.CurrentRef()
 	if err != nil {
 		return false, err

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -23,10 +23,7 @@ var (
 )
 
 func doFsck() (bool, error) {
-	if !lfs.InRepo() {
-		Print("Not in a git repository.")
-		os.Exit(128)
-	}
+	requireInRepo()
 
 	ref, err := git.CurrentRef()
 	if err != nil {

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
@@ -15,6 +17,11 @@ var (
 )
 
 func lsFilesCommand(cmd *cobra.Command, args []string) {
+	if !lfs.InRepo() {
+		Print("Not in a git repository.")
+		os.Exit(128)
+	}
+
 	var ref string
 	var err error
 

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"os"
-
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
@@ -17,10 +15,7 @@ var (
 )
 
 func lsFilesCommand(cmd *cobra.Command, args []string) {
-	if !lfs.InRepo() {
-		Print("Not in a git repository.")
-		os.Exit(128)
-	}
+	requireInRepo()
 
 	var ref string
 	var err error

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
@@ -17,6 +19,10 @@ var (
 )
 
 func pullCommand(cmd *cobra.Command, args []string) {
+	if !lfs.InRepo() {
+		Print("Not in a git repository.")
+		os.Exit(128)
+	}
 
 	if len(args) > 0 {
 		// Remote is first arg

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"os"
-
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
@@ -19,10 +17,7 @@ var (
 )
 
 func pullCommand(cmd *cobra.Command, args []string) {
-	if !lfs.InRepo() {
-		Print("Not in a git repository.")
-		os.Exit(128)
-	}
+	requireInRepo()
 
 	if len(args) > 0 {
 		// Remote is first arg

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
@@ -19,10 +18,7 @@ var (
 )
 
 func statusCommand(cmd *cobra.Command, args []string) {
-	if !lfs.InRepo() {
-		Print("Not in a git repository.")
-		os.Exit(128)
-	}
+	requireInRepo()
 
 	ref, err := git.CurrentRef()
 	if err != nil {

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
@@ -18,6 +19,11 @@ var (
 )
 
 func statusCommand(cmd *cobra.Command, args []string) {
+	if !lfs.InRepo() {
+		Print("Not in a git repository.")
+		os.Exit(128)
+	}
+
 	ref, err := git.CurrentRef()
 	if err != nil {
 		Panic(err, "Could not get the current ref")

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -25,6 +25,7 @@ func trackCommand(cmd *cobra.Command, args []string) {
 		Print("Not a git repository.")
 		os.Exit(128)
 	}
+
 	if lfs.LocalWorkingDir == "" {
 		Print("This operation must be run in a work tree.")
 		os.Exit(128)

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -23,7 +23,9 @@ var (
 func updateCommand(cmd *cobra.Command, args []string) {
 	if err := lfs.InstallHooks(updateForce); err != nil {
 		Error(err.Error())
-		Print("Run `git lfs update --force` to overwrite this hook.")
+		if !lfs.IsInvalidRepoError(err) {
+			Print("Run `git lfs update --force` to overwrite this hook.")
+		}
 	} else {
 		Print("Updated pre-push hook.")
 	}

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"os"
 	"regexp"
 
 	"github.com/github/git-lfs/git"
@@ -22,8 +23,11 @@ var (
 // .git/lfs.
 func updateCommand(cmd *cobra.Command, args []string) {
 	if err := lfs.InstallHooks(updateForce); err != nil {
-		Error(err.Error())
-		if !lfs.IsInvalidRepoError(err) {
+		if lfs.IsInvalidRepoError(err) {
+			Print(err.Error())
+			os.Exit(128)
+		} else {
+			Error(err.Error())
 			Print("Run `git lfs update --force` to overwrite this hook.")
 		}
 	} else {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -105,6 +105,13 @@ func requireStdin(msg string) {
 	}
 }
 
+func requireInRepo() {
+	if !lfs.InRepo() {
+		Print("Not in a git repository.")
+		os.Exit(128)
+	}
+}
+
 func handlePanic(err error) string {
 	if err == nil {
 		return ""

--- a/lfs/errors.go
+++ b/lfs/errors.go
@@ -406,7 +406,7 @@ func (e invalidRepoError) InvalidRepo() bool {
 }
 
 func newInvalidRepoError(err error) error {
-	return invalidRepoError{newWrappedError(err, "Not in a repository")}
+	return invalidRepoError{newWrappedError(err, "Not in a git repository")}
 }
 
 // Definitions for IsSmudgeError()

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 script/test
-script/integration
+VERBOSE_LOGS=1 script/integration

--- a/script/integration
+++ b/script/integration
@@ -14,7 +14,7 @@ atexit() {
     SHOW_LOGS=no
   fi
 
-  if [ "$SHOW_LOGS" = "yes" ]; then
+  if [ "$SHOW_LOGS" = "yes" ] && [ "$VERBOSE_LOGS" = "1" ]; then
     if [ -s "$REMOTEDIR/gitserver.log" ]; then
       echo ""
       echo "gitserver.log:"

--- a/test/test-checkout.sh
+++ b/test/test-checkout.sh
@@ -74,7 +74,7 @@ begin_test "checkout"
   # test '.' in current dir
   rm nested.dat
   git lfs checkout .
-  [ "$contents" = "$(cat nested.dat)" ]  
+  [ "$contents" = "$(cat nested.dat)" ]
   popd
 
   # test folder param
@@ -101,5 +101,12 @@ begin_test "checkout"
   [ "$contents" = "$(cat folder1/nested.dat)" ]
   [ "$contents" = "$(cat folder2/nested.dat)" ]
 
+)
+end_test
+
+begin_test "checkout: outside git repository"
+(
+  set -e
+  git lfs checkout | grep "Not in a git repository"
 )
 end_test

--- a/test/test-checkout.sh
+++ b/test/test-checkout.sh
@@ -106,7 +106,12 @@ end_test
 
 begin_test "checkout: outside git repository"
 (
+  set +e
+  git lfs checkout 2>&1 > checkout.log
+  res=$?
+
   set -e
-  git lfs checkout | grep "Not in a git repository"
+  [ "$res" = "128" ]
+  grep "Not in a git repository" checkout.log
 )
 end_test

--- a/test/test-checkout.sh
+++ b/test/test-checkout.sh
@@ -111,6 +111,10 @@ begin_test "checkout: outside git repository"
   res=$?
 
   set -e
+  if [ "$res" = "0" ]; then
+    echo "Passes because $GIT_LFS_TEST_DIR is unset."
+    exit 0
+  fi
   [ "$res" = "128" ]
   grep "Not in a git repository" checkout.log
 )

--- a/test/test-credentials.sh
+++ b/test/test-credentials.sh
@@ -2,7 +2,7 @@
 
 . "test/testlib.sh"
 
-begin_test "credentials without useHttpPath, with wrong path password"
+begin_test "credentials without useHttpPath, with bad path password"
 (
   set -e
 

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -396,6 +396,10 @@ begin_test "fetch: outside git repository"
   res=$?
 
   set -e
+  if [ "$res" = "0" ]; then
+    echo "Passes because $GIT_LFS_TEST_DIR is unset."
+    exit 0
+  fi
   [ "$res" = "128" ]
   grep "Not in a git repository" fetch.log
 )

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -391,7 +391,12 @@ end_test
 
 begin_test "fetch: outside git repository"
 (
+  set +e
+  git lfs fetch 2>&1 > fetch.log
+  res=$?
+
   set -e
-  git lfs fetch | grep "Not in a git repository"
+  [ "$res" = "128" ]
+  grep "Not in a git repository" fetch.log
 )
 end_test

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -86,7 +86,7 @@ begin_test "fetch"
   git lfs fetch origin master newbranch
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid"
-  
+
   rm -rf .git/lfs/objects
   git config --unset "lfs.fetchinclude"
   git config "lfs.fetchexclude" "a*"
@@ -100,7 +100,7 @@ begin_test "fetch"
   git lfs fetch origin master newbranch
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
-  
+
   rm -rf .git/lfs/objects
   git config "lfs.fetchinclude" "c*,d*"
   git config "lfs.fetchexclude" "a*,b*"
@@ -115,7 +115,7 @@ begin_test "fetch"
   git lfs fetch --include="a*" origin master newbranch
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid"
-  
+
   rm -rf .git/lfs/objects
   git lfs fetch --exclude="a*" origin master newbranch
   refute_local_object "$contents_oid"
@@ -125,7 +125,7 @@ begin_test "fetch"
   git lfs fetch -I "a*,b*" -X "c*,d*" origin master newbranch
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
-  
+
   rm -rf .git/lfs/objects
   git lfs fetch --include="c*,d*" --exclude="a*,b*" origin master newbranch
   refute_local_object "$contents_oid"
@@ -158,7 +158,7 @@ begin_test "fetch-recent"
   oid3=$(printf "$content3" | shasum -a 256 | cut -f 1 -d " ")
   oid4=$(printf "$content4" | shasum -a 256 | cut -f 1 -d " ")
   oid5=$(printf "$content5" | shasum -a 256 | cut -f 1 -d " ")
-  
+
   echo "[
   {
     \"CommitDate\":\"$(get_date -18d)\",
@@ -295,7 +295,7 @@ begin_test "fetch-all"
     content[$a]="filecontent$a"
     oid[$a]=$(printf "${content[$a]}" | shasum -a 256 | cut -f 1 -d " ")
   done
-    
+
   echo "[
   {
     \"CommitDate\":\"$(get_date -180d)\",
@@ -361,10 +361,10 @@ begin_test "fetch-all"
   }
   ]" | lfstest-testutils addcommits
 
-  git push origin master 
-  git push origin branch1 
+  git push origin master
+  git push origin branch1
   git push origin branch3
-  git push origin remote_branch_only 
+  git push origin remote_branch_only
   git push origin tag_only
   for ((a=0; a < NUMFILES ; a++))
   do
@@ -386,5 +386,12 @@ begin_test "fetch-all"
     assert_local_object "${oid[$a]}" "${#content[$a]}"
   done
 
+)
+end_test
+
+begin_test "fetch: outside git repository"
+(
+  set -e
+  git lfs fetch | grep "Not in a git repository"
 )
 end_test

--- a/test/test-fsck.sh
+++ b/test/test-fsck.sh
@@ -102,3 +102,10 @@ begin_test "fsck dry run"
   fi
 )
 end_test
+
+begin_test "fsck: outside git repository"
+(
+  set -e
+  git lfs fsck | grep "Not in a git repository"
+)
+end_test

--- a/test/test-fsck.sh
+++ b/test/test-fsck.sh
@@ -110,6 +110,10 @@ begin_test "fsck: outside git repository"
   res=$?
 
   set -e
+  if [ "$res" = "0" ]; then
+    echo "Passes because $GIT_LFS_TEST_DIR is unset."
+    exit 0
+  fi
   [ "$res" = "128" ]
   grep "Not in a git repository" fsck.log
 )

--- a/test/test-fsck.sh
+++ b/test/test-fsck.sh
@@ -105,7 +105,12 @@ end_test
 
 begin_test "fsck: outside git repository"
 (
+  set +e
+  git lfs fsck 2>&1 > fsck.log
+  res=$?
+
   set -e
-  git lfs fsck | grep "Not in a git repository"
+  [ "$res" = "128" ]
+  grep "Not in a git repository" fsck.log
 )
 end_test

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -34,6 +34,10 @@ begin_test "ls-files: outside git repository"
   res=$?
 
   set -e
+  if [ "$res" = "0" ]; then
+    echo "Passes because $GIT_LFS_TEST_DIR is unset."
+    exit 0
+  fi
   [ "$res" = "128" ]
   grep "Not in a git repository" ls-files.log
 )

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -26,3 +26,10 @@ begin_test "ls-files"
   [ `wc -l < ls.log` = 1 ]
 )
 end_test
+
+begin_test "ls-files: outside git repository"
+(
+  set -e
+  git lfs ls-files | grep "Not in a git repository"
+)
+end_test

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -29,7 +29,12 @@ end_test
 
 begin_test "ls-files: outside git repository"
 (
+  set +e
+  git lfs ls-files 2>&1 > ls-files.log
+  res=$?
+
   set -e
-  git lfs ls-files | grep "Not in a git repository"
+  [ "$res" = "128" ]
+  grep "Not in a git repository" ls-files.log
 )
 end_test

--- a/test/test-pull.sh
+++ b/test/test-pull.sh
@@ -75,7 +75,7 @@ begin_test "pull"
   git config "lfs.fetchinclude" "a*"
   git lfs pull
   assert_local_object "$contents_oid" 1
-  
+
   rm -rf .git/lfs/objects
   git config --unset "lfs.fetchinclude"
   git config "lfs.fetchexclude" "a*"
@@ -87,11 +87,18 @@ begin_test "pull"
   rm -rf .git/lfs/objects
   git lfs pull --include="a*"
   assert_local_object "$contents_oid" 1
-  
+
   rm -rf .git/lfs/objects
   git lfs pull --exclude="a*"
   refute_local_object "$contents_oid"
 
 
+)
+end_test
+
+begin_test "pull: outside git repository"
+(
+  set -e
+  git lfs pull | grep "Not in a git repository"
 )
 end_test

--- a/test/test-pull.sh
+++ b/test/test-pull.sh
@@ -103,6 +103,10 @@ begin_test "pull: outside git repository"
   res=$?
 
   set -e
+  if [ "$res" = "0" ]; then
+    echo "Passes because $GIT_LFS_TEST_DIR is unset."
+    exit 0
+  fi
   [ "$res" = "128" ]
   grep "Not in a git repository" pull.log
 )

--- a/test/test-pull.sh
+++ b/test/test-pull.sh
@@ -98,7 +98,12 @@ end_test
 
 begin_test "pull: outside git repository"
 (
+  set +e
+  git lfs pull 2>&1 > pull.log
+  res=$?
+
   set -e
-  git lfs pull | grep "Not in a git repository"
+  [ "$res" = "128" ]
+  grep "Not in a git repository" pull.log
 )
 end_test

--- a/test/test-status.sh
+++ b/test/test-status.sh
@@ -66,3 +66,11 @@ A  file3.dat 11"
   [ "$expected" = "$(git lfs status --porcelain)" ]
 )
 end_test
+
+
+begin_test "status: outside git repository"
+(
+  set -e
+  git lfs status | grep "Not in a git repository"
+)
+end_test

--- a/test/test-status.sh
+++ b/test/test-status.sh
@@ -70,7 +70,12 @@ end_test
 
 begin_test "status: outside git repository"
 (
+  set +e
+  git lfs status 2>&1 > status.log
+  res=$?
+
   set -e
-  git lfs status | grep "Not in a git repository"
+  [ "$res" = "128" ]
+  grep "Not in a git repository" status.log
 )
 end_test

--- a/test/test-status.sh
+++ b/test/test-status.sh
@@ -75,6 +75,10 @@ begin_test "status: outside git repository"
   res=$?
 
   set -e
+  if [ "$res" = "0" ]; then
+    echo "Passes because $GIT_LFS_TEST_DIR is unset."
+    exit 0
+  fi
   [ "$res" = "128" ]
   grep "Not in a git repository" status.log
 )

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -102,8 +102,10 @@ begin_test "update: outside git repository"
   overwrite="$(grep "overwrite" check.log)"
 
   set -e
-  echo "actual:"
-  cat check.log
+  if [ "$res" = "0" ]; then
+    echo "Passes because $GIT_LFS_TEST_DIR is unset."
+    exit 0
+  fi
   [ "$res" = "128" ]
   [ -z "$overwrite" ]
   grep "Not in a git repository" check.log

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -96,11 +96,16 @@ end_test
 
 begin_test "update: outside git repository"
 (
+  set +e
+  git lfs update 2>&1 > check.log
+  res=$?
+  overwrite="$(grep "overwrite" check.log)"
+
   set -e
-  git lfs update 2>&1 | tee update.log
-  grep "Not in a git repository" update.log
-  if [ "$(grep "overwrite" update.log)" ]; then
-    exit 1
-  fi
+  echo "actual:"
+  cat check.log
+  [ "$res" = "128" ]
+  [ -z "$overwrite" ]
+  grep "Not in a git repository" check.log
 )
 end_test

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -93,3 +93,14 @@ Updated https://example.com access from private to basic.
 Removed invalid https://example3.com access of other."
 )
 end_test
+
+begin_test "update: outside git repository"
+(
+  set -e
+  git lfs update 2>&1 | tee update.log
+  grep "Not in a git repository" update.log
+  if [ "$(grep "overwrite" update.log)" ]; then
+    exit 1
+  fi
+)
+end_test

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -75,11 +75,11 @@ begin_test () {
     err="$TRASHDIR/err"
     trace="$TRASHDIR/trace"
 
-    exec 1>"$out" 2>"$err" 3>"$trace"
+    exec 1>"$out" 2>"$err" 5>"$trace"
 
     # reset global git config
     HOME="$TRASHDIR/home"
-    export GIT_TRACE=3
+    export GIT_TRACE=5
     rm -rf "$TRASHDIR/home"
     mkdir "$HOME"
     cp "$TESTHOME/.gitconfig" "$HOME/.gitconfig"

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -75,13 +75,11 @@ begin_test () {
     err="$TRASHDIR/err"
     trace="$TRASHDIR/trace"
 
-    exec 1>"$out" 2>"$err"
+    exec 1>"$out" 2>"$err" 3>"$trace"
 
     # reset global git config
     HOME="$TRASHDIR/home"
-    export GIT_TRACE=$trace
-    rm -rf "$trace"
-    touch "$trace"
+    export GIT_TRACE=3
     rm -rf "$TRASHDIR/home"
     mkdir "$HOME"
     cp "$TESTHOME/.gitconfig" "$HOME/.gitconfig"

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -80,6 +80,8 @@ begin_test () {
     # reset global git config
     HOME="$TRASHDIR/home"
     export GIT_TRACE=$trace
+    rm -rf "$trace"
+    touch "$trace"
     rm -rf "$TRASHDIR/home"
     mkdir "$HOME"
     cp "$TESTHOME/.gitconfig" "$HOME/.gitconfig"

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -112,6 +112,7 @@ end_test () {
             echo "-- git trace --"
             sed 's/^/   /' <"$TRASHDIR/trace"
         ) 1>&2
+        echo
     fi
     unset test_description
 }


### PR DESCRIPTION
This prevents 7 commands from blowing up because they're not run from inside of a repository. It also makes a couple slight tweaks to the integration test suite:

1. The verbose logs at the end of a failure (server logs and your local env) are ONLY shown from `script/cibuild`. We care about this output on CI servers, but probably not on our local machines.
2. The trace file is truncated after every individual test. This way a test failure will show just its own git trace log, not the trace log for every test that has run in the file.