### PR TITLE
Push all to remote

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -95,7 +95,7 @@ func prePushRef(left, right string) {
 
 	for _, pointer := range pointers {
 		if prePushDryRun {
-			Print("push %s [%s]", pointer.Name, pointer.Oid)
+			Print("push %s => %s", pointer.Oid, pointer.Name)
 			continue
 		}
 

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -151,7 +151,7 @@ func prePushCheckForMissingObjects(pointers []*lfs.WrappedPointer) (objectsOnSer
 		return nil
 	}
 
-	checkQueue := lfs.NewDownloadCheckQueue(len(missingLocalObjects), missingSize, false)
+	checkQueue := lfs.NewDownloadCheckQueue(len(missingLocalObjects), missingSize, true)
 	for _, p := range missingLocalObjects {
 		checkQueue.Add(lfs.NewDownloadCheckable(p))
 	}

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -43,23 +42,7 @@ func uploadsBetweenRefAndRemote(remote string, refs []string) *lfs.TransferQueue
 
 	if pushAll {
 		if len(refs) == 0 {
-			// no ref given as an arg, so scan all refs
-			opts := &lfs.ScanRefsOptions{ScanMode: lfs.ScanAllMode, SkipDeletedBlobs: false}
-			// This could be a long process so use the chan version & report progress
-			Print("Scanning for all objects ever referenced...")
-			spinner := lfs.NewSpinner()
-			var numObjs int64
-			pointerchan, err := lfs.ScanRefsToChan("", "", opts)
-			if err != nil {
-				Panic(err, "Could not scan for Git LFS files")
-			}
-			pointers := make([]*lfs.WrappedPointer, 0)
-			for p := range pointerchan {
-				numObjs++
-				spinner.Print(OutputWriter, fmt.Sprintf("%d objects found", numObjs))
-				pointers = append(pointers, p)
-			}
-			spinner.Finish(OutputWriter, fmt.Sprintf("%d objects found", numObjs))
+			pointers := scanAll()
 			Print("Pushing objects...")
 			return uploadPointers(pointers)
 		} else {

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -43,10 +44,23 @@ func uploadsBetweenRefAndRemote(remote string, refs []string) *lfs.TransferQueue
 	if pushAll {
 		if len(refs) == 0 {
 			// no ref given as an arg, so scan all refs
-			pointers, err := lfs.ScanRefs("", "", scanOpt)
+			opts := &lfs.ScanRefsOptions{ScanMode: lfs.ScanAllMode, SkipDeletedBlobs: false}
+			// This could be a long process so use the chan version & report progress
+			Print("Scanning for all objects ever referenced...")
+			spinner := lfs.NewSpinner()
+			var numObjs int64
+			pointerchan, err := lfs.ScanRefsToChan("", "", opts)
 			if err != nil {
-				Panic(err, "Error scanning for all Git LFS files")
+				Panic(err, "Could not scan for Git LFS files")
 			}
+			pointers := make([]*lfs.WrappedPointer, 0)
+			for p := range pointerchan {
+				numObjs++
+				spinner.Print(OutputWriter, fmt.Sprintf("%d objects found", numObjs))
+				pointers = append(pointers, p)
+			}
+			spinner.Finish(OutputWriter, fmt.Sprintf("%d objects found", numObjs))
+			Print("Pushing objects...")
 			return uploadPointers(pointers)
 		} else {
 			scanOpt.ScanMode = lfs.ScanRefsMode

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -57,7 +57,7 @@ func uploadPointers(pointers []*lfs.WrappedPointer) *lfs.TransferQueue {
 	uploadQueue := lfs.NewUploadQueue(len(pointers), totalSize, pushDryRun)
 	for i, pointer := range pointers {
 		if pushDryRun {
-			Print("push %s [%s]", pointer.Name, pointer.Oid)
+			Print("push %s => %s", pointer.Oid, pointer.Name)
 			continue
 		}
 

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -93,7 +93,6 @@ func uploadPointers(pointers []*lfs.WrappedPointer) *lfs.TransferQueue {
 		}
 
 		if _, skip := skipObjects[pointer.Oid]; skip {
-			tracerx.Printf("SKIP OBJECT %s", pointer.Oid)
 			// object missing locally but on server, don't bother
 			continue
 		}

--- a/docs/man/git-lfs-push.1.ronn
+++ b/docs/man/git-lfs-push.1.ronn
@@ -3,8 +3,9 @@ git-lfs-push(1) -- Push queued large files to the Git LFS endpoint
 
 ## SYNOPSIS
 
-`git lfs push` <remote> [ref]<br>
-`git lfs push` --object-id <remote> <oid1> <oid2> ...
+`git lfs push` [options] <remote> [<ref>...]<br>
+`git lfs push` <remote> [<ref>...]<br>
+`git lfs push` --object-id <remote> [<oid>...]
 
 ## DESCRIPTION
 
@@ -18,8 +19,8 @@ of the remote.
     Print the files that would be pushed, without actually pushing them.
 
 * `--all`:
-    This pushes all objects for the given ref or current branch, regardless of
-    whether they are referenced in the local clone of the remote.
+    This pushes all objects to the remote that are referenced by any reachable
+    commit. If no ref is provided, then all refs are pushed.
 
 * `--object-id`:
     This pushes only the object OIDs listed at the end of the command, separated

--- a/docs/man/git-lfs-push.1.ronn
+++ b/docs/man/git-lfs-push.1.ronn
@@ -3,24 +3,27 @@ git-lfs-push(1) -- Push queued large files to the Git LFS endpoint
 
 ## SYNOPSIS
 
-`git lfs push` <remote> [branch]<br>
+`git lfs push` <remote> [ref]<br>
 `git lfs push` --object-id <remote> <oid1> <oid2> ...
 
 ## DESCRIPTION
 
-Upload Git LFS files to the configured endpoint for the current Git remote.
-
-This command shouldn't be necessary since Git LFS automatically sets up a
-pre-push hook for each repository.
+Upload Git LFS files to the configured endpoint for the current Git remote.  By
+default, it filters out objects that are already referenced by the local clone
+of the remote.
 
 ## OPTIONS
+
+* `--dry-run`:
+    Print the files that would be pushed, without actually pushing them.
+
+* `--all`:
+    This pushes all objects for the given ref or current branch, regardless of
+    whether they are referenced in the local clone of the remote.
 
 * `--object-id`:
     This pushes only the object OIDs listed at the end of the command, separated
     by spaces.
-
-* `--dry-run`:
-    Print the files that would be pushed, without actually pushing them.
 
 * `--stdin`:
     Read the remote and branch on stdin. This is used in conjunction with the

--- a/test/test-commit-delete-push.sh
+++ b/test/test-commit-delete-push.sh
@@ -17,7 +17,7 @@ begin_test "commit, delete, then push"
   git add deleted.dat .gitattributes
   git commit -m "add deleted file"
 
-  git lfs push origin master --dry-run | grep "push deleted.dat"
+  git lfs push origin master --dry-run | grep "push ee31ef227442936872744b50d3297385c08b40ffc7baeaf34a39e6d81d6cd9ee => deleted.dat"
 
   assert_pointer "master" "deleted.dat" "$deleted_oid" 8
 
@@ -27,15 +27,15 @@ begin_test "commit, delete, then push"
   git commit -m "add file"
 
   git lfs push origin master --dry-run | tee dryrun.log
-  grep "push deleted.dat" dryrun.log
-  grep "push added.dat" dryrun.log
+  grep "push ee31ef227442936872744b50d3297385c08b40ffc7baeaf34a39e6d81d6cd9ee => deleted.dat" dryrun.log
+  grep "push 3428719b7688c78a0cc8ba4b9e80b4e464c815fbccfd4b20695a15ffcefc22af => added.dat" dryrun.log
 
   git rm deleted.dat
   git commit -m "did not need deleted.dat after all"
 
   GIT_TRACE=1 git lfs push origin master --dry-run 2>&1 | tee dryrun.log
-  grep "push deleted.dat" dryrun.log
-  grep "push added.dat" dryrun.log
+  grep "push ee31ef227442936872744b50d3297385c08b40ffc7baeaf34a39e6d81d6cd9ee => deleted.dat" dryrun.log
+  grep "push 3428719b7688c78a0cc8ba4b9e80b4e464c815fbccfd4b20695a15ffcefc22af => added.dat" dryrun.log
 
   git log
   GIT_TRACE=1 git push origin master 2>&1 > push.log || {

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -67,7 +67,7 @@ begin_test "pre-push dry-run"
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
     git lfs pre-push --dry-run origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
-  grep "push hi.dat" push.log
+  grep "push 2840e0eafda1d0760771fe28b91247cf81c76aa888af28a850b5648a338dc15b => hi.dat" push.log
   cat push.log
   [ `wc -l < push.log` = 1 ]
 
@@ -321,7 +321,7 @@ begin_test "pre-push multiple branches"
     content[$a]="filecontent$a"
     oid[$a]=$(printf "${content[$a]}" | shasum -a 256 | cut -f 1 -d " ")
   done
-    
+
   echo "[
   {
     \"CommitDate\":\"$(get_date -10d)\",

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -54,6 +54,18 @@ begin_test "push dry-run"
   grep "push 4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 => a.dat" push.log
   grep "push 82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 => b.dat" push.log
   [ $(wc -l < push.log) -eq 2 ]
+
+  # simulate remote ref
+  mkdir -p .git/refs/remotes/origin
+  git rev-parse HEAD > .git/refs/remotes/origin/HEAD
+
+  git lfs push --dry-run origin push-b 2>&1 | tee push.log
+  [ $(wc -l < push.log) -eq 0 ]
+
+  git lfs push --dry-run --all origin push-b 2>&1 | tee push.log
+  grep "push 4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 => a.dat" push.log
+  grep "push 82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 => b.dat" push.log
+  [ $(wc -l < push.log) -eq 2 ]
 )
 end_test
 

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -17,7 +17,7 @@ begin_test "push"
 
   git lfs push --dry-run origin master 2>&1 | tee push.log
   grep "push 4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 => a.dat" push.log
-  [ $(wc -l < push.log) -eq 1 ]
+  [ $(grep -c "push" push.log) -eq 1 ]
 
   git lfs push origin master 2>&1 | tee push.log
   grep "(1 of 1 files)" push.log
@@ -30,14 +30,14 @@ begin_test "push"
   git lfs push --dry-run origin push-b 2>&1 | tee push.log
   grep "push 4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 => a.dat" push.log
   grep "push 82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 => b.dat" push.log
-  [ $(wc -l < push.log) -eq 2 ]
+  [ $(grep -c "push" < push.log) -eq 2 ]
 
   # simulate remote ref
   mkdir -p .git/refs/remotes/origin
   git rev-parse HEAD > .git/refs/remotes/origin/HEAD
 
   git lfs push --dry-run origin push-b 2>&1 | tee push.log
-  [ $(wc -l < push.log) -eq 0 ]
+  [ $(grep -c "push" push.log) -eq 0 ]
 
   rm -rf .git/refs/remotes
 
@@ -129,7 +129,7 @@ begin_test "push --all (no ref args)"
   grep "push $oid4 => file1.dat" push.log
   grep "push $oid5 => file1.dat" push.log
   grep "push $extraoid => file2.dat" push.log
-  [ $(wc -l < push.log) -eq 6 ]
+  [ $(grep -c "push" < push.log) -eq 6 ]
 
   git push --all origin 2>&1 | tee push.log
   grep "5 files" push.log # should be 6?
@@ -181,7 +181,7 @@ begin_test "push --all (1 ref arg)"
   grep "push $oid1 => file1.dat" push.log
   grep "push $oid2 => file1.dat" push.log
   grep "push $oid3 => file1.dat" push.log
-  [ $(wc -l < push.log) -eq 3 ]
+  [ $(grep -c "push" < push.log) -eq 3 ]
 
   git lfs push --all origin branch 2>&1 | tee push.log
   grep "3 files" push.log
@@ -231,7 +231,7 @@ begin_test "push --all (multiple ref args)"
   grep "push $oid2 => file1.dat" push.log
   grep "push $oid3 => file1.dat" push.log
   grep "push $oid4 => file1.dat" push.log
-  [ $(wc -l < push.log) -eq 4 ]
+  [ $(grep -c "push" push.log) -eq 4 ]
 
   git lfs push --all origin branch tag 2>&1 | tee push.log
   grep "4 files" push.log
@@ -283,7 +283,7 @@ begin_test "push --all (ref with deleted files)"
   grep "push $oid4 => file1.dat" push.log
   grep "push $oid5 => file1.dat" push.log
   grep "push $extraoid => file2.dat" push.log
-  [ $(wc -l < push.log) -eq 5 ]
+  [ $(grep -c "push" push.log) -eq 5 ]
 
   git lfs push --all origin master 2>&1 | tee push.log
   grep "5 files" push.log

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -15,6 +15,10 @@ begin_test "push"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
+  git lfs push --dry-run origin master 2>&1 | tee push.log
+  grep "push 4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 => a.dat" push.log
+  [ $(wc -l < push.log) -eq 1 ]
+
   git lfs push origin master 2>&1 | tee push.log
   grep "(1 of 1 files)" push.log
 
@@ -23,8 +27,175 @@ begin_test "push"
   git add b.dat
   git commit -m "add b.dat"
 
+  git lfs push --dry-run origin push-b 2>&1 | tee push.log
+  grep "push 4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 => a.dat" push.log
+  grep "push 82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 => b.dat" push.log
+  [ $(wc -l < push.log) -eq 2 ]
+
   git lfs push origin push-b 2>&1 | tee push.log
   grep "(1 of 2 files, 1 skipped)" push.log
+)
+end_test
+
+# sets up the tests for the next few push --all tests
+push_all_setup() {
+  local suffix="$1"
+  reponame="$(basename "$0" ".sh")-all"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "repo-all-$suffix"
+
+  git lfs track "*.dat"
+  content1="initial"
+  content2="update"
+  content3="branch"
+  content4="tagged"
+  content5="master"
+  extracontent="extra"
+  oid1=$(printf "$content1" | shasum -a 256 | cut -f 1 -d " ")
+  oid2=$(printf "$content2" | shasum -a 256 | cut -f 1 -d " ")
+  oid3=$(printf "$content3" | shasum -a 256 | cut -f 1 -d " ")
+  oid4=$(printf "$content4" | shasum -a 256 | cut -f 1 -d " ")
+  oid5=$(printf "$content5" | shasum -a 256 | cut -f 1 -d " ")
+  extraoid=$(printf "$extracontent" | shasum -a 256 | cut -f 1 -d " ")
+
+  echo "[
+  {
+    \"CommitDate\":\"$(get_date -6m)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":${#content1},\"Data\":\"$content1\"}
+    ]
+  },
+  {
+    \"CommitDate\":\"$(get_date -5m)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":${#content2},\"Data\":\"$content2\"}
+    ]
+  },
+  {
+    \"CommitDate\":\"$(get_date -4m)\",
+    \"NewBranch\":\"branch\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":${#content3},\"Data\":\"$content3\"}
+    ]
+  },
+  {
+    \"CommitDate\":\"$(get_date -4m)\",
+    \"ParentBranches\":[\"master\"],
+    \"Tags\":[\"tag\"],
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":${#content4},\"Data\":\"$content4\"}
+    ]
+  },
+  {
+    \"CommitDate\":\"$(get_date -2m)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":${#content5},\"Data\":\"$content5\"},
+      {\"Filename\":\"file2.dat\",\"Size\":${#extracontent},\"Data\":\"$extracontent\"}
+    ]
+  }
+  ]" | lfstest-testutils addcommits
+
+  git rm file2.dat
+  git commit -m "remove file2.dat"
+
+  setup_alternate_remote "$reponame-$suffix"
+}
+
+begin_test "push --all (no ref args)"
+(
+  set -e
+
+  push_all_setup "everything"
+
+  git lfs push --dry-run --all origin 2>&1 | tee push.log
+  grep "push $oid1 => file1.dat" push.log
+  grep "push $oid2 => file1.dat" push.log
+  grep "push $oid3 => file1.dat" push.log
+  grep "push $oid4 => file1.dat" push.log
+  grep "push $oid5 => file1.dat" push.log
+  grep "push $extraoid => file2.dat" push.log
+  [ $(wc -l < push.log) -eq 6 ]
+
+  git push --all origin 2>&1 | tee push.log
+  grep "5 files" push.log # should be 6?
+  assert_server_object "$reponame-everything" "$oid1"
+  assert_server_object "$reponame-everything" "$oid2"
+  assert_server_object "$reponame-everything" "$oid3"
+  assert_server_object "$reponame-everything" "$oid4"
+  assert_server_object "$reponame-everything" "$oid5"
+  assert_server_object "$reponame-everything" "$extraoid"
+)
+end_test
+
+begin_test "push --all (1 ref arg)"
+(
+  set -e
+
+  push_all_setup "ref"
+
+  git lfs push --dry-run --all origin branch 2>&1 | tee push.log
+  grep "push $oid1 => file1.dat" push.log
+  grep "push $oid2 => file1.dat" push.log
+  grep "push $oid3 => file1.dat" push.log
+  [ $(wc -l < push.log) -eq 3 ]
+
+  git lfs push --all origin branch 2>&1 | tee push.log
+  grep "3 files" push.log
+  assert_server_object "$reponame-ref" "$oid1"
+  assert_server_object "$reponame-ref" "$oid2"
+  assert_server_object "$reponame-ref" "$oid3"
+  refute_server_object "$reponame-ref" "$oid4"     # in master and the tag
+  refute_server_object "$reponame-ref" "$oid5"
+  refute_server_object "$reponame-ref" "$extraoid"
+)
+end_test
+
+begin_test "push --all (multiple ref args)"
+(
+  set -e
+
+  push_all_setup "multiple-refs"
+
+  git lfs push --dry-run --all origin branch tag 2>&1 | tee push.log
+  grep "push $oid1 => file1.dat" push.log
+  grep "push $oid2 => file1.dat" push.log
+  grep "push $oid3 => file1.dat" push.log
+  grep "push $oid4 => file1.dat" push.log
+  [ $(wc -l < push.log) -eq 4 ]
+
+  git lfs push --all origin branch tag 2>&1 | tee push.log
+  grep "4 files" push.log
+  assert_server_object "$reponame-multiple-refs" "$oid1"
+  assert_server_object "$reponame-multiple-refs" "$oid2"
+  assert_server_object "$reponame-multiple-refs" "$oid3"
+  assert_server_object "$reponame-multiple-refs" "$oid4"
+  refute_server_object "$reponame-multiple-refs" "$oid5"     # only in master
+  refute_server_object "$reponame-multiple-refs" "$extraoid"
+)
+end_test
+
+begin_test "push --all (ref with deleted files)"
+(
+  set -e
+
+  push_all_setup "ref-with-deleted"
+
+  git lfs push --dry-run --all origin master 2>&1 | tee push.log
+  grep "push $oid1 => file1.dat" push.log
+  grep "push $oid2 => file1.dat" push.log
+  grep "push $oid4 => file1.dat" push.log
+  grep "push $oid5 => file1.dat" push.log
+  grep "push $extraoid => file2.dat" push.log
+  [ $(wc -l < push.log) -eq 5 ]
+
+  git lfs push --all origin master 2>&1 | tee push.log
+  grep "5 files" push.log
+  assert_server_object "$reponame-ref-with-deleted" "$oid1"
+  assert_server_object "$reponame-ref-with-deleted" "$oid2"
+  refute_server_object "$reponame-ref-with-deleted" "$oid3" # only in the branch
+  assert_server_object "$reponame-ref-with-deleted" "$oid4"
+  assert_server_object "$reponame-ref-with-deleted" "$oid5"
+  assert_server_object "$reponame-ref-with-deleted" "$extraoid"
 )
 end_test
 

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -42,7 +42,7 @@ begin_test "push dry-run"
   git commit -m "add a.dat"
 
   git lfs push --dry-run origin master 2>&1 | tee push.log
-  grep "push a.dat" push.log
+  grep "push 4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 => a.dat" push.log
   [ $(wc -l < push.log) -eq 1 ]
 
   git checkout -b push-b
@@ -51,8 +51,8 @@ begin_test "push dry-run"
   git commit -m "add b.dat"
 
   git lfs push --dry-run origin push-b 2>&1 | tee push.log
-  grep "push a.dat" push.log
-  grep "push b.dat" push.log
+  grep "push 4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 => a.dat" push.log
+  grep "push 82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 => b.dat" push.log
   [ $(wc -l < push.log) -eq 2 ]
 )
 end_test

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -130,6 +130,24 @@ setup_remote_repo() {
   git config receive.denyCurrentBranch ignore
 }
 
+# creates a bare remote repository for a local clone. Useful to test pushing to
+# a fresh remote server.
+#
+#   $ setup_alternate_remote "$reponame-whatever"
+#   $ setup_alternate_remote "$reponame-whatever" "other-remote-name"
+#
+setup_alternate_remote() {
+  local newRemoteName=$1
+  local remote=${2:-origin}
+
+  wd=`pwd`
+
+  setup_remote_repo "$newRemoteName"
+  cd $wd
+  git remote rm "$remote"
+  git remote add "$remote" "$GITSERVER/$newRemoteName"
+}
+
 # clone_repo clones a repository from the test Git server to the subdirectory
 # $dir under $TRASHDIR. setup_remote_repo() needs to be run first.
 clone_repo() {


### PR DESCRIPTION
This uses the `lfs.ScanRefsMode` scan mode when pushing if the `--all` flag is given. This lets you confirm that everything referenced in the given ref has been pushed to the given remote.