### PR TITLE
always consult PrivateAccess() for batch API calls

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -357,7 +357,7 @@ func UploadObject(o *objectResource, cb CopyCallback) error {
 	req.Header.Set("Content-Length", strconv.Itoa(len(by)))
 	req.ContentLength = int64(len(by))
 	req.Body = ioutil.NopCloser(bytes.NewReader(by))
-	res, err = doAPIRequest(req)
+	res, err = doAPIRequest(req, true)
 	if err != nil {
 		return err
 	}
@@ -393,7 +393,7 @@ func doLegacyApiRequest(req *http.Request) (*http.Response, *objectResource, err
 // re-run. When the repo is marked as having private access, credentials will
 // be retrieved.
 func doApiBatchRequest(req *http.Request) (*http.Response, []*objectResource, error) {
-	res, err := doAPIRequest(req)
+	res, err := doAPIRequest(req, Config.PrivateAccess())
 
 	if err != nil {
 		if res.StatusCode == 401 {
@@ -427,12 +427,8 @@ func doStorageRequest(req *http.Request) (*http.Response, error) {
 // body. If the API returns a 401, the repo will be marked as having private
 // access and the request will be re-run. When the repo is marked as having
 // private access, credentials will be retrieved.
-func doAPIRequest(req *http.Request) (*http.Response, error) {
+func doAPIRequest(req *http.Request, useCreds bool) (*http.Response, error) {
 	via := make([]*http.Request, 0, 4)
-	useCreds := true
-	if req.Method == "GET" || req.Method == "HEAD" {
-		useCreds = Config.PrivateAccess()
-	}
 	return doApiRequestWithRedirects(req, via, useCreds)
 }
 


### PR DESCRIPTION
While running my QA checks, I noticed that the auth type wasn't being set at all:

```
$ git lfs env
git-lfs/0.6.0 (GitHub; darwin amd64; go 1.5; git 19105ed)
git version 2.3.0

Endpoint=https://github.com/github/git-lfs.git/info/lfs (auth=none)
```

#611 introduced various constructors for different types of requests that the client makes:

* `doApiBatchRequest()` - LFS Batch API requests
* `doLegacyApiRequest()` - Legacy LFS API requests.
* `doAPIRequest()` - Common function for ALL LFS API requests.
* `doStorageRequest()` - Storage requests (these actually upload and download the objects).

`doAPIRequest()` requires credentials for all non-GET requests. But all Batch API requests are POST. This is a pretty small change, but highlights that the project needs better tests around this stuff.