### PR TITLE
Stop testing Go 1.3 and 1.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
 go:
-  - 1.3
-  - 1.4.2
   - 1.5
 install: true
 script: script/cibuild


### PR DESCRIPTION
This removes Go 1.3 and 1.4.2 from the tests. As of v0.6.0, we're now shipping all binaries compiled with Go 1.5.1. The linux packages also bundle Go 1.5.1 to compile.

Obviously, our tests will run in about 1/3rd the time. We can also start supporting newer std lib features and code syntax that we couldn't with Go 1.3.

Any objections? This should only affect git lfs contributors and homebrew users. I think we can configure the git lfs recipe to require Go 1.5+ though.