### PR TITLE
Use man content for `help <cmd>' and '<cmd> --help'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ repos
 docker/*.key
 
 src
+commands/mancontent_gen.go

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -222,22 +222,27 @@ func determineIncludeExcludePaths(includeArg, excludeArg string) (include, exclu
 	return includePaths, excludePaths
 }
 
-// help is used for 'git-lfs help <command>'
-func help(cmd *cobra.Command, args []string) {
-	if txt, ok := ManPages[cmd.Use]; ok {
+func printHelp(commandName string) {
+	if txt, ok := ManPages[commandName]; ok {
 		fmt.Fprintf(os.Stderr, txt)
 	} else {
-		fmt.Fprintf(os.Stderr, "Sorry, no help text found\n")
+		fmt.Fprintf(os.Stderr, "Sorry, no usage text found for %q\n", commandName)
 	}
+}
+
+// help is used for 'git-lfs help <command>'
+func help(cmd *cobra.Command, args []string) {
+	if len(args) == 0 {
+		printHelp("git-lfs")
+	} else {
+		printHelp(args[0])
+	}
+
 }
 
 // usage is used for 'git-lfs <command> --help' or wen invoked manually
 func usage(cmd *cobra.Command) error {
-	if txt, ok := ManPages[cmd.Use]; ok {
-		fmt.Fprintf(os.Stderr, txt)
-	} else {
-		fmt.Fprintf(os.Stderr, "Sorry, no usage text found\n")
-	}
+	printHelp(cmd.Name())
 	return nil
 }
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -16,6 +16,9 @@ import (
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
 )
 
+// Populate man pages
+//go:generate go run ../docs/man/mangen.go
+
 var (
 	Debugging    = false
 	ErrorBuffer  = &bytes.Buffer{}
@@ -29,6 +32,7 @@ var (
 			cmd.Usage()
 		},
 	}
+	ManPages = make(map[string]string, 20)
 )
 
 // Error prints a formatted message to Stderr.  It also gets printed to the
@@ -218,6 +222,28 @@ func determineIncludeExcludePaths(includeArg, excludeArg string) (include, exclu
 	return includePaths, excludePaths
 }
 
+// help is used for 'git-lfs help <command>'
+func help(cmd *cobra.Command, args []string) {
+	if txt, ok := ManPages[cmd.Use]; ok {
+		fmt.Fprintf(os.Stderr, txt)
+	} else {
+		fmt.Fprintf(os.Stderr, "Sorry, no help text found\n")
+	}
+}
+
+// usage is used for 'git-lfs <command> --help' or wen invoked manually
+func usage(cmd *cobra.Command) error {
+	if txt, ok := ManPages[cmd.Use]; ok {
+		fmt.Fprintf(os.Stderr, txt)
+	} else {
+		fmt.Fprintf(os.Stderr, "Sorry, no usage text found\n")
+	}
+	return nil
+}
+
 func init() {
 	log.SetOutput(ErrorWriter)
+	// Set up help/usage funcs based on manpage text
+	RootCmd.SetHelpFunc(help)
+	RootCmd.SetUsageFunc(usage)
 }

--- a/docs/man/mangen.go
+++ b/docs/man/mangen.go
@@ -35,6 +35,8 @@ func main() {
 	headerregex := regexp.MustCompile(`^###?\s+([A-Za-z0-9 ]+)`)
 	// only pick up caps in links to avoid matching optional args
 	linkregex := regexp.MustCompile(`\[([A-Z\- ]+)\]`)
+	// man links
+	manlinkregex := regexp.MustCompile(`(git)(?:-(lfs))?-([a-z\-]+)\(\d\)`)
 	count := 0
 	for _, f := range fs {
 		if match := fileregex.FindStringSubmatch(f.Name()); match != nil {
@@ -87,12 +89,20 @@ func main() {
 					firstHeaderDone = true
 					lastLineWasBullet = false
 					continue
-				} else if lmatches := linkregex.FindAllStringSubmatch(line, -1); lmatches != nil {
+				}
+
+				if lmatches := linkregex.FindAllStringSubmatch(line, -1); lmatches != nil {
 					for _, lmatch := range lmatches {
 						linktext := strings.ToLower(lmatch[1])
 						line = strings.Replace(line, lmatch[0], `"`+strings.ToUpper(linktext[:1])+linktext[1:]+`"`, 1)
 					}
 				}
+				if manmatches := manlinkregex.FindAllStringSubmatch(line, -1); manmatches != nil {
+					for _, manmatch := range manmatches {
+						line = strings.Replace(line, manmatch[0], strings.Join(manmatch[1:], " "), 1)
+					}
+				}
+
 				// Skip content until after first header
 				if !firstHeaderDone {
 					continue

--- a/docs/man/mangen.go
+++ b/docs/man/mangen.go
@@ -33,6 +33,8 @@ func main() {
 	out.WriteString("// Use 'go generate ./commands' to update\n")
 	fileregex := regexp.MustCompile(`git-lfs(?:-([A-Za-z\-]+))?.\d.ronn`)
 	headerregex := regexp.MustCompile(`^###?\s+([A-Za-z0-9 ]+)`)
+	// only pick up caps in links to avoid matching optional args
+	linkregex := regexp.MustCompile(`\[([A-Z\- ]+)\]`)
 	count := 0
 	for _, f := range fs {
 		if match := fileregex.FindStringSubmatch(f.Name()); match != nil {
@@ -85,6 +87,11 @@ func main() {
 					firstHeaderDone = true
 					lastLineWasBullet = false
 					continue
+				} else if lmatches := linkregex.FindAllStringSubmatch(line, -1); lmatches != nil {
+					for _, lmatch := range lmatches {
+						linktext := strings.ToLower(lmatch[1])
+						line = strings.Replace(line, lmatch[0], `"`+strings.ToUpper(linktext[:1])+linktext[1:]+`"`, 1)
+					}
 				}
 				// Skip content until after first header
 				if !firstHeaderDone {

--- a/docs/man/mangen.go
+++ b/docs/man/mangen.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Reads all .ronn files & and converts them to string literals
+// triggered by "go generate" comment
+// Literals are inserted into a map using an init function, this means
+// that there are no compilation errors if 'go generate' hasn't been run, just
+// blank man files.
+func main() {
+	fmt.Fprintf(os.Stderr, "Converting man pages into code...\n")
+	mandir := "../docs/man"
+	fs, err := ioutil.ReadDir(mandir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to open man dir: %v\n", err)
+		os.Exit(2)
+	}
+	out, err := os.Create("../commands/mancontent_gen.go")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create go file: %v\n", err)
+		os.Exit(2)
+	}
+	out.WriteString("package commands\n\nfunc init() {\n")
+	out.WriteString("// THIS FILE IS GENERATED, DO NOT EDIT\n")
+	out.WriteString("// Use 'go generate ./commands' to update\n")
+	r := regexp.MustCompile(`git-lfs(?:-([A-Za-z\-]+))?.\d.ronn`)
+	count := 0
+	for _, f := range fs {
+		if match := r.FindStringSubmatch(f.Name()); match != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", f.Name())
+			cmd := match[1]
+			if len(cmd) == 0 {
+				// This is git-lfs.1.ronn
+				cmd = "git-lfs"
+			}
+			out.WriteString("ManPages[\"" + cmd + "\"] = `")
+			contentf, err := os.Open(filepath.Join(mandir, f.Name()))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to open %v: %v\n", f.Name(), err)
+				os.Exit(2)
+			}
+			// Process the ronn to make it nicer as help text
+			scanner := bufio.NewScanner(contentf)
+			for scanner.Scan() {
+				line := strings.TrimSpace(scanner.Text())
+				// Remove backticks since it won't format & that's delimiting the string
+				line = strings.Replace(line, "`", "", -1)
+				// Maybe more e.g. ## ?
+				out.WriteString(line + "\n")
+			}
+			out.WriteString("`\n")
+			contentf.Close()
+			count++
+		}
+	}
+	out.WriteString("}\n")
+	fmt.Fprintf(os.Stderr, "Successfully processed %d man pages.\n", count)
+
+}

--- a/script/build.go
+++ b/script/build.go
@@ -38,6 +38,11 @@ func mainBuild() {
 
 	fmt.Printf("Using %s\n", runtime.Version())
 
+	genOut, err := exec.Command("go", "generate", "./commands").CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "go generate failed:\n%v", genOut)
+		os.Exit(1)
+	}
 	cmd, _ := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
 
 	if len(cmd) > 0 {

--- a/script/build.go
+++ b/script/build.go
@@ -40,7 +40,7 @@ func mainBuild() {
 
 	genOut, err := exec.Command("go", "generate", "./commands").CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "go generate failed:\n%v", genOut)
+		fmt.Fprintf(os.Stderr, "go generate failed:\n%v", string(genOut))
 		os.Exit(1)
 	}
 	cmd, _ := exec.Command("git", "rev-parse", "--short", "HEAD").Output()


### PR DESCRIPTION
Call 'go generate ./commands' to generate code from .ronn files which the cobra command can then use. Added to the build scripts but needs to be done manually at least once to test it outside that. 

I've done the minimum re-formatting for now. The man format is pretty damn ugly on the command line and I'd like to do better but didn't want to spend time on that until the principle was approved. For now it just fixes the backtick issue, other things we could do:

* Strip off the 2-line headers
* Strip 'SYNOPSIS' and pull out the command summary as the first line
* Strip '##' section markers generally
* Use an abbreviated form for `command --help` (just contents of SYNOPSIS, DESCRIPTION and OPTIONS) and only print the full text for `help command`. Cobra splits this as Usage/Help, currently it's the same for both.

If you think this is a good idea I can hack on it some more.