### PR TITLE
Fixed git lfs ls-files then index out of range error.

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -64,6 +64,10 @@ func ResolveRef(ref string) (*Ref, error) {
 		return nil, err
 	}
 	lines := strings.Split(outp, "\n")
+	if len(lines) <= 1 {
+		err := errors.New("git can't resolve ref : " + ref)
+		return nil, err
+	}
 	fullref := &Ref{Sha: lines[0]}
 	fullref.Type, fullref.Name = ParseRefToTypeAndName(lines[1])
 	return fullref, nil

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -172,3 +172,15 @@ func TestRecentBranches(t *testing.T) {
 	sort.Sort(test.RefsByName(refs))
 	assert.Equal(t, expectedRefs, refs, "Refs should be correct")
 }
+
+func TestResolveEmptyCurrentRef(t *testing.T) {
+	repo := test.NewRepo(t)
+	repo.Pushd()
+	defer func() {
+		repo.Popd()
+		repo.Cleanup()
+	}()
+
+	_, err := CurrentRef()
+	assert.NotEqual(t, nil, err)
+}


### PR DESCRIPTION
This PR for command `git lfs ls-files` and then error `index out of range` issue according #664 