### PR TITLE
add an integration test to prove #668 works

### DIFF
--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -25,7 +25,7 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	} else {
 		fullref, err := git.CurrentRef()
 		if err != nil {
-			Panic(err, "Could not ls-files")
+			Exit(err.Error())
 		}
 		ref = fullref.Sha
 	}

--- a/git/git.go
+++ b/git/git.go
@@ -58,16 +58,15 @@ func LsRemote(remote, remoteRef string) (string, error) {
 }
 
 func ResolveRef(ref string) (*Ref, error) {
-
 	outp, err := simpleExec("git", "rev-parse", ref, "--symbolic-full-name", ref)
 	if err != nil {
 		return nil, err
 	}
 	lines := strings.Split(outp, "\n")
 	if len(lines) <= 1 {
-		err := errors.New("git can't resolve ref : " + ref)
-		return nil, err
+		return nil, fmt.Errorf("Git can't resolve ref: %q", ref)
 	}
+
 	fullref := &Ref{Sha: lines[0]}
 	fullref.Type, fullref.Name = ParseRefToTypeAndName(lines[1])
 	return fullref, nil

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -42,3 +42,26 @@ begin_test "ls-files: outside git repository"
   grep "Not in a git repository" ls-files.log
 )
 end_test
+
+begin_test "ls-files: with zero files"
+(
+  set -e
+  mkdir empty
+  cd empty
+  git init
+  git lfs track "*.dat"
+  git add .gitattributes
+
+  set +e
+  git lfs ls-files 2> ls-files.log
+  res=$?
+  set -e
+
+  cat ls-files.log
+  [ "$res" = "2" ]
+  grep "Git can't resolve ref:" ls-files.log
+
+  git commit -m "initial commit"
+  [ "$(git lfs ls-files)" = "" ]
+)
+end_test


### PR DESCRIPTION
I like having integration tests for stuff like #668. Partly because it forces me to see how the error is handled externally. This changes the `git.CurrentRef()` error check to simply print an error and exit, as opposed to logging a stack trace.

@Aorjoa: This is just a bit of polish on your fix in #668