### PR TITLE
Docgen fixes

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -14,9 +14,8 @@ import (
 
 var (
 	checkoutCmd = &cobra.Command{
-		Use:   "checkout",
-		Short: "Checks out LFS files into the working copy",
-		Run:   checkoutCommand,
+		Use: "checkout",
+		Run: checkoutCommand,
 	}
 )
 

--- a/commands/command_clean.go
+++ b/commands/command_clean.go
@@ -9,9 +9,8 @@ import (
 
 var (
 	cleanCmd = &cobra.Command{
-		Use:   "clean",
-		Short: "Implements the Git clean filter",
-		Run:   cleanCommand,
+		Use: "clean",
+		Run: cleanCommand,
 	}
 )
 

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -8,9 +8,8 @@ import (
 
 var (
 	envCmd = &cobra.Command{
-		Use:   "env",
-		Short: "Show the current environment",
-		Run:   envCommand,
+		Use: "env",
+		Run: envCommand,
 	}
 )
 

--- a/commands/command_ext.go
+++ b/commands/command_ext.go
@@ -9,9 +9,8 @@ import (
 
 var (
 	extCmd = &cobra.Command{
-		Use:   "ext",
-		Short: "View details for all extensions",
-		Run:   extCommand,
+		Use: "ext",
+		Run: extCommand,
 	}
 
 	extListCmd = &cobra.Command{

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -12,9 +12,8 @@ import (
 
 var (
 	fetchCmd = &cobra.Command{
-		Use:   "fetch",
-		Short: "Downloads LFS files",
-		Run:   fetchCommand,
+		Use: "fetch",
+		Run: fetchCommand,
 	}
 	fetchIncludeArg string
 	fetchExcludeArg string

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -16,9 +16,8 @@ var (
 	fsckDryRun bool
 
 	fsckCmd = &cobra.Command{
-		Use:   "fsck",
-		Short: "Verifies validity of Git LFS files",
-		Run:   fsckCommand,
+		Use: "fsck",
+		Run: fsckCommand,
 	}
 )
 

--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -7,15 +7,13 @@ import (
 
 var (
 	initCmd = &cobra.Command{
-		Use:   "init",
-		Short: "Initialize the default Git LFS configuration",
-		Run:   initCommand,
+		Use: "init",
+		Run: initCommand,
 	}
 
 	initHooksCmd = &cobra.Command{
-		Use:   "hooks",
-		Short: "Initialize hooks for the current repository",
-		Run:   initHooksCommand,
+		Use: "hooks",
+		Run: initHooksCommand,
 	}
 
 	forceInit = false

--- a/commands/command_logs.go
+++ b/commands/command_logs.go
@@ -12,33 +12,28 @@ import (
 
 var (
 	logsCmd = &cobra.Command{
-		Use:   "logs",
-		Short: "View error logs",
-		Run:   logsCommand,
+		Use: "logs",
+		Run: logsCommand,
 	}
 
 	logsLastCmd = &cobra.Command{
-		Use:   "last",
-		Short: "View latest error log",
-		Run:   logsLastCommand,
+		Use: "last",
+		Run: logsLastCommand,
 	}
 
 	logsShowCmd = &cobra.Command{
-		Use:   "show",
-		Short: "View a single error log",
-		Run:   logsShowCommand,
+		Use: "show",
+		Run: logsShowCommand,
 	}
 
 	logsClearCmd = &cobra.Command{
-		Use:   "clear",
-		Short: "Clear all logs",
-		Run:   logsClearCommand,
+		Use: "clear",
+		Run: logsClearCommand,
 	}
 
 	logsBoomtownCmd = &cobra.Command{
-		Use:   "boomtown",
-		Short: "Trigger a sample error",
-		Run:   logsBoomtownCommand,
+		Use: "boomtown",
+		Run: logsBoomtownCommand,
 	}
 )
 

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -8,9 +8,8 @@ import (
 
 var (
 	lsFilesCmd = &cobra.Command{
-		Use:   "ls-files",
-		Short: "Show information about Git LFS files",
-		Run:   lsFilesCommand,
+		Use: "ls-files",
+		Run: lsFilesCommand,
 	}
 )
 

--- a/commands/command_pointer.go
+++ b/commands/command_pointer.go
@@ -19,9 +19,8 @@ var (
 	pointerCompare string
 	pointerStdin   bool
 	pointerCmd     = &cobra.Command{
-		Use:   "pointer",
-		Short: "Build and compare pointers between different Git LFS implementations",
-		Run:   pointerCommand,
+		Use: "pointer",
+		Run: pointerCommand,
 	}
 )
 

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -11,9 +11,8 @@ import (
 
 var (
 	prePushCmd = &cobra.Command{
-		Use:   "pre-push",
-		Short: "Implements the Git pre-push hook",
-		Run:   prePushCommand,
+		Use: "pre-push",
+		Run: prePushCommand,
 	}
 	prePushDryRun        = false
 	prePushDeleteBranch  = "(delete)"

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -8,9 +8,8 @@ import (
 
 var (
 	pullCmd = &cobra.Command{
-		Use:   "pull",
-		Short: "Downloads LFS files for the current ref, and checks out",
-		Run:   pullCommand,
+		Use: "pull",
+		Run: pullCommand,
 	}
 	pullIncludeArg string
 	pullExcludeArg string

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -11,9 +11,8 @@ import (
 
 var (
 	pushCmd = &cobra.Command{
-		Use:   "push",
-		Short: "Push files to the Git LFS server",
-		Run:   pushCommand,
+		Use: "push",
+		Run: pushCommand,
 	}
 	pushDryRun       = false
 	pushDeleteBranch = "(delete)"

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -13,9 +13,8 @@ import (
 var (
 	smudgeInfo = false
 	smudgeCmd  = &cobra.Command{
-		Use:   "smudge",
-		Short: "Implements the Git smudge filter",
-		Run:   smudgeCommand,
+		Use: "smudge",
+		Run: smudgeCommand,
 	}
 )
 

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -10,9 +10,8 @@ import (
 
 var (
 	statusCmd = &cobra.Command{
-		Use:   "status",
-		Short: "Show information about Git LFS objects that would be pushed",
-		Run:   statusCommand,
+		Use: "status",
+		Run: statusCommand,
 	}
 	porcelain = false
 )

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -14,9 +14,8 @@ import (
 
 var (
 	trackCmd = &cobra.Command{
-		Use:   "track",
-		Short: "Manipulate .gitattributes",
-		Run:   trackCommand,
+		Use: "track",
+		Run: trackCommand,
 	}
 )
 

--- a/commands/command_uninit.go
+++ b/commands/command_uninit.go
@@ -8,16 +8,14 @@ import (
 var (
 	// uninitCmd removes any configuration and hooks set by Git LFS.
 	uninitCmd = &cobra.Command{
-		Use:   "uninit",
-		Short: "Clear the Git LFS configuration",
-		Run:   uninitCommand,
+		Use: "uninit",
+		Run: uninitCommand,
 	}
 
 	// uninitHooksCmd removes any hooks created by Git LFS.
 	uninitHooksCmd = &cobra.Command{
-		Use:   "hooks",
-		Short: "Clear only the Git hooks for the current repository",
-		Run:   uninitHooksCommand,
+		Use: "hooks",
+		Run: uninitHooksCommand,
 	}
 )
 

--- a/commands/command_untrack.go
+++ b/commands/command_untrack.go
@@ -12,9 +12,8 @@ import (
 
 var (
 	untrackCmd = &cobra.Command{
-		Use:   "untrack",
-		Short: "Remove an entry from .gitattributes",
-		Run:   untrackCommand,
+		Use: "untrack",
+		Run: untrackCommand,
 	}
 )
 

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -11,9 +11,8 @@ import (
 
 var (
 	updateCmd = &cobra.Command{
-		Use:   "update",
-		Short: "Update local Git LFS configuration",
-		Run:   updateCommand,
+		Use: "update",
+		Run: updateCommand,
 	}
 
 	updateForce = false

--- a/commands/command_version.go
+++ b/commands/command_version.go
@@ -9,9 +9,8 @@ var (
 	lovesComics bool
 
 	versionCmd = &cobra.Command{
-		Use:   "version",
-		Short: "Show the version number",
-		Run:   versionCommand,
+		Use: "version",
+		Run: versionCommand,
 	}
 )
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -25,8 +25,7 @@ var (
 	ErrorWriter  = io.MultiWriter(os.Stderr, ErrorBuffer)
 	OutputWriter = io.MultiWriter(os.Stdout, ErrorBuffer)
 	RootCmd      = &cobra.Command{
-		Use:   "git-lfs",
-		Short: "Git LFS provides large file storage to Git.",
+		Use: "git-lfs",
 		Run: func(cmd *cobra.Command, args []string) {
 			versionCommand(cmd, args)
 			cmd.Usage()

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -224,7 +224,7 @@ func determineIncludeExcludePaths(includeArg, excludeArg string) (include, exclu
 
 func printHelp(commandName string) {
 	if txt, ok := ManPages[commandName]; ok {
-		fmt.Fprintf(os.Stderr, txt)
+		fmt.Fprintf(os.Stderr, "%s\n", strings.TrimSpace(txt))
 	} else {
 		fmt.Fprintf(os.Stderr, "Sorry, no usage text found for %q\n", commandName)
 	}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -250,5 +250,6 @@ func init() {
 	log.SetOutput(ErrorWriter)
 	// Set up help/usage funcs based on manpage text
 	RootCmd.SetHelpFunc(help)
+	RootCmd.SetHelpTemplate("{{.UsageString}}")
 	RootCmd.SetUsageFunc(usage)
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -240,7 +240,7 @@ func help(cmd *cobra.Command, args []string) {
 
 }
 
-// usage is used for 'git-lfs <command> --help' or wen invoked manually
+// usage is used for 'git-lfs <command> --help' or when invoked manually
 func usage(cmd *cobra.Command) error {
 	printHelp(cmd.Name())
 	return nil

--- a/docs/man/git-lfs-pull.1.ronn
+++ b/docs/man/git-lfs-pull.1.ronn
@@ -37,14 +37,11 @@ will have objects fetched for them.
 ## DEFAULT REMOTE
 
 Without arguments, pull downloads from the default remote. The default remote is
-the same as for `git pull`, i.e. based on the remote branch you're tracking 
+the same as for `git pull`, i.e. based on the remote branch you're tracking
 first, or origin otherwise.
-
-## EXAMPLES
 
 ## SEE ALSO
 
 git-lfs-fetch(1), git-lfs-checkout(1).
 
 Part of the git-lfs(1) suite.
-

--- a/docs/man/git-lfs.1.ronn
+++ b/docs/man/git-lfs.1.ronn
@@ -27,7 +27,7 @@ version is about to be pushed to the corresponding Git server.
 Like Git, Git LFS commands are separated into high level ("porcelain")
 commands and low level ("plumbing") commands.
 
-### High-level commands (porcelain)
+### High level commands (porcelain)
 
 * git-lfs-env(1):
     Display the Git LFS environment.

--- a/docs/man/mangen.go
+++ b/docs/man/mangen.go
@@ -109,8 +109,11 @@ func main() {
 				}
 				// OK, content here
 
-				// Remove backticks since it won't format & that's delimiting the string
-				line = strings.Replace(line, "`", "", -1)
+				// remove characters that markdown would render invisible in a text env.
+				for _, invis := range []string{"`", "<br>"} {
+					line = strings.Replace(line, invis, "", -1)
+				}
+
 				// indent bullets
 				if strings.HasPrefix(line, "*") {
 					lastLineWasBullet = true


### PR DESCRIPTION
A few minor tweaks. The output of `help subcmd` and `subcmd -h` are now identical. Also, leading and ending linebreaks are consistent.

/cc @sinbad