### PR TITLE
teach 'update' cmd how to install hooks in bare repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ notifications:
 before_install:
   - repo=`basename $PWD`; localDir=`dirname $PWD`; cfDir="`dirname $localDir`/github"
   - if [[ "$localDir" != "$cfDir" ]]; then mv "$localDir" "$cfDir"; cd ../../github/$repo; export TRAVIS_BUILD_DIR=`dirname $TRAVIS_BUILD_DIR`/$repo; fi
+  - export GIT_LFS_TEST_DIR="$localDir/git-lfs-tests"

--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -27,10 +27,7 @@ func initCommand(cmd *cobra.Command, args []string) {
 		Exit("Run `git lfs init --force` to reset git config.")
 	}
 
-	if lfs.InRepo() {
-		initHooksCommand(cmd, args)
-	}
-
+	initHooksCommand(cmd, args)
 	Print("Git LFS initialized.")
 }
 

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"os"
 	"regexp"
 
 	"github.com/github/git-lfs/git"
@@ -23,13 +22,8 @@ var (
 // .git/lfs.
 func updateCommand(cmd *cobra.Command, args []string) {
 	if err := lfs.InstallHooks(updateForce); err != nil {
-		if lfs.IsInvalidRepoError(err) {
-			Print(err.Error())
-			os.Exit(128)
-		} else {
-			Error(err.Error())
-			Print("Run `git lfs update --force` to overwrite this hook.")
-		}
+		Error(err.Error())
+		Print("Run `git lfs update --force` to overwrite this hook.")
 	} else {
 		Print("Updated pre-push hook.")
 	}

--- a/lfs/hook.go
+++ b/lfs/hook.go
@@ -34,10 +34,6 @@ func (h *Hook) Path() string {
 // directory. It returns and halts at any errors, and returns nil if the
 // operation was a success.
 func (h *Hook) Install(force bool) error {
-	if !InRepo() {
-		return newInvalidRepoError(nil)
-	}
-
 	if err := os.MkdirAll(filepath.Join(LocalGitDir, "hooks"), 0755); err != nil {
 		return err
 	}

--- a/test/test-init.sh
+++ b/test/test-init.sh
@@ -89,7 +89,9 @@ Git LFS initialized." = "$(git lfs init --force)" ]
   cd ..
   git clone --mirror init-repo-hooks bare-init-repo-hooks
   cd bare-init-repo-hooks
+  git lfs env
   git lfs init
+  ls -al hooks
   [ "$pre_push_hook" = "$(cat hooks/pre-push)" ]
 )
 end_test

--- a/test/test-init.sh
+++ b/test/test-init.sh
@@ -84,5 +84,12 @@ Git LFS initialized."
   [ "Updated pre-push hook.
 Git LFS initialized." = "$(git lfs init --force)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
+
+  echo "test with bare repository"
+  cd ..
+  git clone --mirror init-repo-hooks bare-init-repo-hooks
+  cd bare-init-repo-hooks
+  git lfs init
+  [ "$pre_push_hook" = "$(cat hooks/pre-push)" ]
 )
 end_test

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -67,6 +67,13 @@ Run \`git lfs update --force\` to overwrite this hook."
   # force replace unexpected hook
   [ "Updated pre-push hook." = "$(git lfs update --force)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
+
+  echo "test with bare repository"
+  cd ..
+  git clone --mirror without-pre-push bare
+  cd bare
+  git lfs update
+  [ "$pre_push_hook" = "$(cat hooks/pre-push)" ]
 )
 end_test
 

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -72,7 +72,9 @@ Run \`git lfs update --force\` to overwrite this hook."
   cd ..
   git clone --mirror without-pre-push bare
   cd bare
+  git lfs env
   git lfs update
+  ls -al hooks
   [ "$pre_push_hook" = "$(cat hooks/pre-push)" ]
 )
 end_test


### PR DESCRIPTION
Instead of requiring `git lfs update` to be run inside a git working directory, this relies on `lfs.LocalGitDir` to install the hooks in the correct place.

/cc @ttaylorr since you touched hook code recently. Though I'm pretty sure I'm the one that added the invalid repo error. 