### PR TITLE
Properly handle retries when using "legacy" API

### DIFF
--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -90,12 +90,14 @@ func (q *TransferQueue) Wait() {
 	q.retrywait.Wait()
 	atomic.StoreUint32(&q.retrying, 1)
 
-	if len(q.retries) > 0 && q.batcher != nil {
+	if len(q.retries) > 0 {
 		tracerx.Printf("tq: retrying %d failed transfers", len(q.retries))
 		for _, t := range q.retries {
 			q.Add(t)
 		}
-		q.batcher.Exit()
+		if q.batcher != nil {
+			q.batcher.Exit()
+		}
 		q.wait.Wait()
 	}
 


### PR DESCRIPTION
Reported in #673 

A nil check in the wrong place was preventing the retry mechanism from working in the older single mode API which had the side effect of allowing git-lfs to exit cleanly even though it failed to push.