### PR TITLE
A nicer network error

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -446,7 +446,7 @@ func doHttpRequest(req *http.Request, creds Creds) (*http.Response, error) {
 	}
 
 	if err != nil {
-		err = Errorf(err, "Error for %s %s", res.Request.Method, res.Request.URL)
+		err = Error(err)
 	} else {
 		err = handleResponse(res, creds)
 	}


### PR DESCRIPTION
This simple change goes from errors like this:

```
$ git push origin master
(0 of 1 files) 0 B / 33 B
Error for POST http://localhost:8124/rubyist/foo3/objects/batch
error: failed to push some refs to 'http://github.com/rubyist/foo3.git'
```

To this:

```
$ git push origin master
(0 of 1 files) 0 B / 33 B
Post http://localhost:8124/rubyist/foo3/objects/batch: read tcp 127.0.0.1:8124: connection reset by peer
error: failed to push some refs to 'http://github.com/rubyist/foo3.git'
```

This error path can be triggered by a number of network issues, this lets the original error message bubble through which can help in debugging. The data from the message we were providing is already included in the original error string.