### PR TITLE
smudge passthrough

### DIFF
--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -44,6 +44,11 @@ func envCommand(cmd *cobra.Command, args []string) {
 	for _, env := range lfs.Environ() {
 		Print(env)
 	}
+
+	for _, key := range []string{"filter.lfs.smudge", "filter.lfs.clean"} {
+		value, _ := lfs.Config.GitConfig(key)
+		Print("git config %s = %q", key, value)
+	}
 }
 
 func init() {

--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -16,9 +16,9 @@ var (
 		Run: initHooksCommand,
 	}
 
-	forceInit = false
-	localInit = false
-	passInit  = false
+	forceInit      = false
+	localInit      = false
+	skipSmudgeInit = false
 )
 
 func initCommand(cmd *cobra.Command, args []string) {
@@ -27,12 +27,12 @@ func initCommand(cmd *cobra.Command, args []string) {
 	}
 
 	opt := lfs.InstallOptions{Force: forceInit, Local: localInit}
-	if passInit {
+	if skipSmudgeInit {
 		// assume the user is changing their smudge mode, so enable force implicitly
 		opt.Force = true
 	}
 
-	if err := lfs.InstallFilters(opt, passInit); err != nil {
+	if err := lfs.InstallFilters(opt, skipSmudgeInit); err != nil {
 		Error(err.Error())
 		Exit("Run `git lfs init --force` to reset git config.")
 	}
@@ -49,7 +49,7 @@ func initHooksCommand(cmd *cobra.Command, args []string) {
 func init() {
 	initCmd.Flags().BoolVarP(&forceInit, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
 	initCmd.Flags().BoolVarP(&localInit, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
-	initCmd.Flags().BoolVarP(&passInit, "smudge-passthrough", "", false, "Skips automatic downloading of objects on clone or pull.")
+	initCmd.Flags().BoolVarP(&skipSmudgeInit, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
 	initCmd.AddCommand(initHooksCmd)
 	RootCmd.AddCommand(initCmd)
 }

--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -17,10 +17,16 @@ var (
 	}
 
 	forceInit = false
+	localInit = false
 )
 
 func initCommand(cmd *cobra.Command, args []string) {
-	if err := lfs.InstallFilters(forceInit); err != nil {
+	if localInit {
+		requireInRepo()
+	}
+
+	opt := lfs.InstallOptions{Force: forceInit, Local: localInit}
+	if err := lfs.InstallFilters(opt); err != nil {
 		Error(err.Error())
 		Exit("Run `git lfs init --force` to reset git config.")
 	}
@@ -36,6 +42,7 @@ func initHooksCommand(cmd *cobra.Command, args []string) {
 
 func init() {
 	initCmd.Flags().BoolVarP(&forceInit, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
+	initCmd.Flags().BoolVarP(&localInit, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
 	initCmd.AddCommand(initHooksCmd)
 	RootCmd.AddCommand(initCmd)
 }

--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -18,6 +18,7 @@ var (
 
 	forceInit = false
 	localInit = false
+	passInit  = false
 )
 
 func initCommand(cmd *cobra.Command, args []string) {
@@ -26,7 +27,12 @@ func initCommand(cmd *cobra.Command, args []string) {
 	}
 
 	opt := lfs.InstallOptions{Force: forceInit, Local: localInit}
-	if err := lfs.InstallFilters(opt); err != nil {
+	if passInit {
+		// assume the user is changing their smudge mode, so enable force implicitly
+		opt.Force = true
+	}
+
+	if err := lfs.InstallFilters(opt, passInit); err != nil {
 		Error(err.Error())
 		Exit("Run `git lfs init --force` to reset git config.")
 	}
@@ -43,6 +49,7 @@ func initHooksCommand(cmd *cobra.Command, args []string) {
 func init() {
 	initCmd.Flags().BoolVarP(&forceInit, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
 	initCmd.Flags().BoolVarP(&localInit, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
+	initCmd.Flags().BoolVarP(&passInit, "smudge-passthrough", "", false, "Skips automatic downloading of objects on clone or pull.")
 	initCmd.AddCommand(initHooksCmd)
 	RootCmd.AddCommand(initCmd)
 }

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	smudgeInfo = false
+	smudgeSkip = false
 	smudgeCmd  = &cobra.Command{
 		Use: "smudge",
 		Run: smudgeCommand,
@@ -22,7 +23,7 @@ func smudgeCommand(cmd *cobra.Command, args []string) {
 	requireStdin("This command should be run by the Git 'smudge' filter")
 	lfs.InstallHooks(false)
 
-	if lfs.Config.GetenvBool("GIT_LFS_SMUDGE_PASSTHROUGH", false) {
+	if smudgeSkip || lfs.Config.GetenvBool("GIT_LFS_SKIP_SMUDGE", false) {
 		_, err := io.Copy(os.Stdout, os.Stdin)
 		if err != nil {
 			Panic(err, "Error writing data to stdout:")
@@ -92,5 +93,6 @@ func smudgeFilename(args []string, err error) string {
 
 func init() {
 	smudgeCmd.Flags().BoolVarP(&smudgeInfo, "info", "i", false, "Display the local path and size of the smudged file.")
+	smudgeCmd.Flags().BoolVarP(&smudgeSkip, "skip", "s", false, "Skip automatic downloading of objects on clone or pull.")
 	RootCmd.AddCommand(smudgeCmd)
 }

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -92,7 +92,8 @@ func smudgeFilename(args []string, err error) string {
 }
 
 func init() {
-	smudgeCmd.Flags().BoolVarP(&smudgeInfo, "info", "i", false, "Display the local path and size of the smudged file.")
-	smudgeCmd.Flags().BoolVarP(&smudgeSkip, "skip", "s", false, "Skip automatic downloading of objects on clone or pull.")
+	// update man page
+	smudgeCmd.Flags().BoolVarP(&smudgeInfo, "info", "i", false, "")
+	smudgeCmd.Flags().BoolVarP(&smudgeSkip, "skip", "s", false, "")
 	RootCmd.AddCommand(smudgeCmd)
 }

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -22,6 +22,15 @@ func smudgeCommand(cmd *cobra.Command, args []string) {
 	requireStdin("This command should be run by the Git 'smudge' filter")
 	lfs.InstallHooks(false)
 
+	if lfs.Config.GetenvBool("GIT_LFS_SMUDGE_PASSTHROUGH", false) {
+		_, err := io.Copy(os.Stdout, os.Stdin)
+		if err != nil {
+			Panic(err, "Error writing data to stdout:")
+		}
+		return
+	}
+
+	// keeps the initial buffer from lfs.DecodePointer
 	b := &bytes.Buffer{}
 	r := io.TeeReader(os.Stdin, b)
 

--- a/docs/man/git-lfs-smudge.1.ronn
+++ b/docs/man/git-lfs-smudge.1.ronn
@@ -4,6 +4,8 @@ git-lfs-smudge(1) -- Git smudge filter that converts pointer in blobs to the act
 ## SYNOPSIS
 
 `git lfs smudge` [<path>]
+`git lfs smudge` --info [<path>]
+`git lfs smudge` --skip [<path>]
 
 ## DESCRIPTION
 
@@ -23,6 +25,9 @@ standard output.
 * `--info`:
     Display the file size and the local path to the Git LFS file.  If the file
     does not exist, show `--`.
+
+* `--skip`:
+    Skip automatic downloading of objects on clone or pull.
 
 ## SEE ALSO
 

--- a/git/git.go
+++ b/git/git.go
@@ -123,6 +123,12 @@ func (c *gitConfig) Find(val string) string {
 	return output
 }
 
+// Find returns the git config value for the key
+func (c *gitConfig) FindLocal(val string) string {
+	output, _ := simpleExec("git", "config", "--local", val)
+	return output
+}
+
 // SetGlobal sets the git config value for the key in the global config
 func (c *gitConfig) SetGlobal(key, val string) {
 	simpleExec("git", "config", "--global", key, val)

--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -57,8 +57,8 @@ func UninstallHooks() error {
 //
 // An error will be returned if a filter is unable to be set, or if the required
 // filters were not present.
-func InstallFilters(force bool) error {
-	return filters.Install(force)
+func InstallFilters(opt InstallOptions) error {
+	return filters.Install(opt)
 }
 
 // UninstallFilters proxies into the Uninstall method on the Filters type to

--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -26,6 +26,15 @@ var (
 			"required": "true",
 		},
 	}
+
+	passFilters = &Attribute{
+		Section: "filter.lfs",
+		Properties: map[string]string{
+			"clean":    "git-lfs clean %f",
+			"smudge":   "GIT_LFS_SMUDGE_PASSTHROUGH=1 git-lfs smudge %f",
+			"required": "true",
+		},
+	}
 )
 
 // InstallHooks installs all hooks in the `hooks` var.
@@ -57,7 +66,10 @@ func UninstallHooks() error {
 //
 // An error will be returned if a filter is unable to be set, or if the required
 // filters were not present.
-func InstallFilters(opt InstallOptions) error {
+func InstallFilters(opt InstallOptions, passThrough bool) error {
+	if passThrough {
+		return passFilters.Install(opt)
+	}
 	return filters.Install(opt)
 }
 

--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -31,7 +31,7 @@ var (
 		Section: "filter.lfs",
 		Properties: map[string]string{
 			"clean":    "git-lfs clean %f",
-			"smudge":   "GIT_LFS_SMUDGE_PASSTHROUGH=1 git-lfs smudge %f",
+			"smudge":   "git-lfs smudge --skip %f",
 			"required": "true",
 		},
 	}

--- a/test/test-env.sh
+++ b/test/test-env.sh
@@ -2,6 +2,9 @@
 
 . "test/testlib.sh"
 
+envInitConfig='git config filter.lfs.smudge = "git-lfs smudge %f"
+git config filter.lfs.clean = "git-lfs clean %f"'
+
 begin_test "env with no remote"
 (
   set -e
@@ -19,7 +22,8 @@ TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
 BatchTransfer=true
 $(env | grep "^GIT")
-" "$(git lfs version)" "$(git version)")
+%s
+" "$(git lfs version)" "$(git version)" "$envInitConfig")
   actual=$(git lfs env)
   [ "$expected" = "$actual" ]
 )
@@ -44,7 +48,8 @@ TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
 BatchTransfer=true
 $(env | grep "^GIT")
-" "$(git lfs version)" "$(git version)")
+%s
+" "$(git lfs version)" "$(git version)" "$envInitConfig")
   actual=$(git lfs env)
   [ "$expected" = "$actual" ]
 
@@ -76,7 +81,8 @@ TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
 BatchTransfer=true
 $(env | grep "^GIT")
-" "$(git lfs version)" "$(git version)")
+%s
+" "$(git lfs version)" "$(git version)" "$envInitConfig")
   actual=$(git lfs env)
   [ "$expected" = "$actual" ]
 
@@ -106,7 +112,8 @@ TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
 BatchTransfer=true
 $(env | grep "^GIT")
-" "$(git lfs version)" "$(git version)")
+%s
+" "$(git lfs version)" "$(git version)" "$envInitConfig")
   actual=$(git lfs env)
   [ "$expected" = "$actual" ]
 
@@ -139,7 +146,8 @@ TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
 BatchTransfer=true
 $(env | grep "^GIT")
-" "$(git lfs version)" "$(git version)")
+%s
+" "$(git lfs version)" "$(git version)" "$envInitConfig")
   actual=$(git lfs env)
   [ "$expected" = "$actual" ]
 
@@ -174,7 +182,8 @@ TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
 BatchTransfer=true
 $(env | grep "^GIT")
-" "$(git lfs version)" "$(git version)")
+%s
+" "$(git lfs version)" "$(git version)" "$envInitConfig")
   actual=$(git lfs env)
   [ "$expected" = "$actual" ]
 
@@ -211,7 +220,8 @@ TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=5
 BatchTransfer=false
 $(env | grep "^GIT")
-" "$(git lfs version)" "$(git version)")
+%s
+" "$(git lfs version)" "$(git version)" "$envInitConfig")
   actual=$(git lfs env)
   [ "$expected" = "$actual" ]
 
@@ -248,7 +258,8 @@ TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=5
 BatchTransfer=true
 $(env | grep "^GIT")
-" "$(git lfs version)" "$(git version)")
+%s
+" "$(git lfs version)" "$(git version)" "$envInitConfig")
 
   actual=$(git lfs env)
   [ "$expected" = "$actual" ]
@@ -279,7 +290,8 @@ TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
 BatchTransfer=true
 $(GIT_DIR=$gitDir GIT_WORK_TREE=$workTree env | grep "^GIT")
-" "$(git lfs version)" "$(git version)")
+%s
+" "$(git lfs version)" "$(git version)" "$envInitConfig")
 
   actual=$(GIT_DIR=$gitDir GIT_WORK_TREE=$workTree git lfs env)
   [ "$expected" = "$actual" ]
@@ -305,6 +317,8 @@ TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
 BatchTransfer=true
 $(GIT_DIR=$gitDir GIT_WORK_TREE=a/b env | grep "^GIT")
+git config filter.lfs.smudge = \"\"
+git config filter.lfs.clean = \"\"
 " "$(git lfs version)" "$(git version)")
   actual5=$(GIT_DIR=$gitDir GIT_WORK_TREE=a/b git lfs env)
   [ "$expected5" = "$actual5" ]
@@ -318,6 +332,8 @@ TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
 BatchTransfer=true
 $(GIT_WORK_TREE=a/b env | grep "^GIT")
+git config filter.lfs.smudge = \"\"
+git config filter.lfs.clean = \"\"
 " "$(git lfs version)" "$(git version)")
   actual6=$(GIT_WORK_TREE=a/b git lfs env)
   [ "$expected6" = "$actual6" ]
@@ -332,7 +348,8 @@ TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
 BatchTransfer=true
 $(GIT_DIR=$gitDir env | grep "^GIT")
-" "$(git lfs version)" "$(git version)")
+%s
+" "$(git lfs version)" "$(git version)" "$envInitConfig")
   actual7=$(GIT_DIR=$gitDir git lfs env)
   [ "$expected7" = "$actual7" ]
 
@@ -346,7 +363,8 @@ TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
 ConcurrentTransfers=3
 BatchTransfer=true
 $(GIT_WORK_TREE=$workTree env | grep "^GIT")
-" "$(git lfs version)" "$(git version)")
+%s
+" "$(git lfs version)" "$(git version)" "$envInitConfig")
   actual8=$(GIT_WORK_TREE=$workTree git lfs env)
   [ "$expected8" = "$actual8" ]
 )

--- a/test/test-init.sh
+++ b/test/test-init.sh
@@ -104,9 +104,9 @@ begin_test "init --smudge-passthrough"
   [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
   [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
 
-  git lfs init --smudge-passthrough
+  git lfs init --skip-smudge
   [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
-  [ "GIT_LFS_SMUDGE_PASSTHROUGH=1 git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
+  [ "git-lfs smudge --skip %f" = "$(git config filter.lfs.smudge)" ]
 
   git lfs init --force
   [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]

--- a/test/test-init.sh
+++ b/test/test-init.sh
@@ -96,7 +96,7 @@ Git LFS initialized." = "$(git lfs init --force)" ]
 )
 end_test
 
-begin_test "init --smudge-passthrough"
+begin_test "init --skip-smudge"
 (
   set -e
 

--- a/test/test-init.sh
+++ b/test/test-init.sh
@@ -96,6 +96,24 @@ Git LFS initialized." = "$(git lfs init --force)" ]
 )
 end_test
 
+begin_test "init --smudge-passthrough"
+(
+  set -e
+
+  git lfs init
+  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
+  [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
+
+  git lfs init --smudge-passthrough
+  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
+  [ "GIT_LFS_SMUDGE_PASSTHROUGH=1 git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
+
+  git lfs init --force
+  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
+  [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
+)
+end_test
+
 begin_test "init --local"
 (
   set -e

--- a/test/test-init.sh
+++ b/test/test-init.sh
@@ -95,3 +95,33 @@ Git LFS initialized." = "$(git lfs init --force)" ]
   [ "$pre_push_hook" = "$(cat hooks/pre-push)" ]
 )
 end_test
+
+begin_test "init --local"
+(
+  set -e
+
+  # old values that should be ignored by `init --local`
+  git config --global filter.lfs.smudge "git lfs smudge %f"
+  git config --global filter.lfs.clean "git lfs clean %f"
+
+  mkdir init-local-repo
+  cd init-local-repo
+  git init
+  git lfs init --local
+
+  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
+  [ "git-lfs clean %f" = "$(git config --local filter.lfs.clean)" ]
+  [ "git lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
+)
+end_test
+
+begin_test "init --local outside repository"
+(
+  set +e
+  git lfs init --local 2> err.log
+  res=$?
+
+  [ "Not in a git repository." = "$(cat err.log)" ]
+  [ "0" != "$res" ]
+)
+end_test

--- a/test/test-smudge.sh
+++ b/test/test-smudge.sh
@@ -75,13 +75,13 @@ begin_test "smudge include/exclude"
 )
 end_test
 
-begin_test "smudge with passthrough"
+begin_test "smudge with skip"
 (
   set -e
 
-  reponame="$(basename "$0" ".sh")-passthrough"
+  reponame="$(basename "$0" ".sh")-skip"
   setup_remote_repo "$reponame"
-  clone_repo "$reponame" "passthrough"
+  clone_repo "$reponame" "skip"
 
   git lfs track "*.dat"
   echo "smudge a" > a.dat
@@ -97,7 +97,7 @@ begin_test "smudge with passthrough"
   echo "test clone with env"
   export GIT_LFS_SKIP_SMUDGE=1
   env | grep LFS
-  clone_repo "$reponame" "passthrough-clone-env"
+  clone_repo "$reponame" "skip-clone-env"
   [ "$pointer" = "$(cat a.dat)" ]
   [ "0" = "$(grep -c "Downloading a.dat" clone.log)" ]
 
@@ -107,13 +107,13 @@ begin_test "smudge with passthrough"
   echo "test clone without env"
   unset GIT_LFS_SKIP_SMUDGE
   env | grep LFS
-  clone_repo "$reponame" "no-passhthrough"
+  clone_repo "$reponame" "no-skip"
   [ "smudge a" = "$(cat a.dat)" ]
   [ "1" = "$(grep -c "Downloading a.dat" clone.log)" ]
 
-  echo "test clone with init --smudge-passthrough"
+  echo "test clone with init --skip-smudge"
   git lfs init --skip-smudge
-  clone_repo "$reponame" "passthrough-clone-init"
+  clone_repo "$reponame" "skip-clone-init"
   [ "$pointer" = "$(cat a.dat)" ]
   [ "0" = "$(grep -c "Downloading a.dat" clone.log)" ]
 

--- a/test/test-smudge.sh
+++ b/test/test-smudge.sh
@@ -90,12 +90,12 @@ begin_test "smudge with passthrough"
 
   pointer="$(pointer fcf5015df7a9089a7aa7fe74139d4b8f7d62e52d5a34f9a87aeffc8e8c668254 9)"
   [ "smudge a" = "$(echo "$pointer" | git lfs smudge)" ]
-  [ "$pointer" = "$(echo "$pointer" | GIT_LFS_SMUDGE_PASSTHROUGH=1 git lfs smudge)" ]
+  [ "$pointer" = "$(echo "$pointer" | GIT_LFS_SKIP_SMUDGE=1 git lfs smudge)" ]
 
   git push origin master
 
   echo "test clone with env"
-  export GIT_LFS_SMUDGE_PASSTHROUGH=1
+  export GIT_LFS_SKIP_SMUDGE=1
   env | grep LFS
   clone_repo "$reponame" "passthrough-clone-env"
   [ "$pointer" = "$(cat a.dat)" ]
@@ -105,14 +105,14 @@ begin_test "smudge with passthrough"
   [ "smudge a" = "$(cat a.dat)" ]
 
   echo "test clone without env"
-  unset GIT_LFS_SMUDGE_PASSTHROUGH
+  unset GIT_LFS_SKIP_SMUDGE
   env | grep LFS
   clone_repo "$reponame" "no-passhthrough"
   [ "smudge a" = "$(cat a.dat)" ]
   [ "1" = "$(grep -c "Downloading a.dat" clone.log)" ]
 
   echo "test clone with init --smudge-passthrough"
-  git lfs init --smudge-passthrough
+  git lfs init --skip-smudge
   clone_repo "$reponame" "passthrough-clone-init"
   [ "$pointer" = "$(cat a.dat)" ]
   [ "0" = "$(grep -c "Downloading a.dat" clone.log)" ]

--- a/test/test-smudge.sh
+++ b/test/test-smudge.sh
@@ -96,22 +96,26 @@ begin_test "smudge with passthrough"
 
   echo "test clone with env"
   export GIT_LFS_SMUDGE_PASSTHROUGH=1
+  env | grep LFS
   clone_repo "$reponame" "passthrough-clone-env"
   [ "$pointer" = "$(cat a.dat)" ]
+  [ "0" = "$(grep -c "Downloading a.dat" clone.log)" ]
 
   git lfs pull
   [ "smudge a" = "$(cat a.dat)" ]
 
   echo "test clone without env"
   unset GIT_LFS_SMUDGE_PASSTHROUGH
-
+  env | grep LFS
   clone_repo "$reponame" "no-passhthrough"
   [ "smudge a" = "$(cat a.dat)" ]
+  [ "1" = "$(grep -c "Downloading a.dat" clone.log)" ]
 
   echo "test clone with init --smudge-passthrough"
   git lfs init --smudge-passthrough
   clone_repo "$reponame" "passthrough-clone-init"
   [ "$pointer" = "$(cat a.dat)" ]
+  [ "0" = "$(grep -c "Downloading a.dat" clone.log)" ]
 
   git lfs init --force
 )

--- a/test/test-smudge.sh
+++ b/test/test-smudge.sh
@@ -94,13 +94,25 @@ begin_test "smudge with passthrough"
 
   git push origin master
 
+  echo "test clone with env"
   export GIT_LFS_SMUDGE_PASSTHROUGH=1
-  clone_repo "$reponame" "passthrough-clone"
-
+  clone_repo "$reponame" "passthrough-clone-env"
   [ "$pointer" = "$(cat a.dat)" ]
 
   git lfs pull
-
   [ "smudge a" = "$(cat a.dat)" ]
+
+  echo "test clone without env"
+  unset GIT_LFS_SMUDGE_PASSTHROUGH
+
+  clone_repo "$reponame" "no-passhthrough"
+  [ "smudge a" = "$(cat a.dat)" ]
+
+  echo "test clone with init --smudge-passthrough"
+  git lfs init --smudge-passthrough
+  clone_repo "$reponame" "passthrough-clone-init"
+  [ "$pointer" = "$(cat a.dat)" ]
+
+  git lfs init --force
 )
 end_test

--- a/test/test-smudge.sh
+++ b/test/test-smudge.sh
@@ -51,18 +51,19 @@ begin_test "smudge include/exclude"
 (
   set -e
 
-  reponame="smudge_includeexclude"
+  reponame="$(basename "$0" ".sh")-includeexclude"
   setup_remote_repo "$reponame"
-  clone_repo "$reponame" repoincludeexclude
+  clone_repo "$reponame" includeexclude
 
   git lfs track "*.dat"
   echo "smudge a" > a.dat
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
+  pointer="$(pointer fcf5015df7a9089a7aa7fe74139d4b8f7d62e52d5a34f9a87aeffc8e8c668254 9)"
+
   # smudge works even though it hasn't been pushed, by reading from .git/lfs/objects
-  output="$(pointer fcf5015df7a9089a7aa7fe74139d4b8f7d62e52d5a34f9a87aeffc8e8c668254 9 | git lfs smudge)"
-  [ "smudge a" = "$output" ]
+  [ "smudge a" = "$(echo "$pointer" | git lfs smudge)" ]
 
   git push origin master
 
@@ -70,9 +71,36 @@ begin_test "smudge include/exclude"
   rm -rf .git/lfs/objects
   git config "lfs.fetchexclude" "a*"
 
-  output="$(pointer fcf5015df7a9089a7aa7fe74139d4b8f7d62e52d5a34f9a87aeffc8e8c668254 9 | git lfs smudge a.dat)"
-  # because download was not allowed, contents will be a pointer ie unchanged
-  [ "$(pointer fcf5015df7a9089a7aa7fe74139d4b8f7d62e52d5a34f9a87aeffc8e8c668254 9)" = "$output" ]
+  [ "$pointer" = "$(echo "$pointer" | git lfs smudge a.dat)" ]
 )
 end_test
 
+begin_test "smudge with passthrough"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")-passthrough"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "passthrough"
+
+  git lfs track "*.dat"
+  echo "smudge a" > a.dat
+  git add .gitattributes a.dat
+  git commit -m "add a.dat"
+
+  pointer="$(pointer fcf5015df7a9089a7aa7fe74139d4b8f7d62e52d5a34f9a87aeffc8e8c668254 9)"
+  [ "smudge a" = "$(echo "$pointer" | git lfs smudge)" ]
+  [ "$pointer" = "$(echo "$pointer" | GIT_LFS_SMUDGE_PASSTHROUGH=1 git lfs smudge)" ]
+
+  git push origin master
+
+  export GIT_LFS_SMUDGE_PASSTHROUGH=1
+  clone_repo "$reponame" "passthrough-clone"
+
+  [ "$pointer" = "$(cat a.dat)" ]
+
+  git lfs pull
+
+  [ "smudge a" = "$(cat a.dat)" ]
+)
+end_test

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -149,7 +149,8 @@ setup_alternate_remote() {
 }
 
 # clone_repo clones a repository from the test Git server to the subdirectory
-# $dir under $TRASHDIR. setup_remote_repo() needs to be run first.
+# $dir under $TRASHDIR. setup_remote_repo() needs to be run first. Output is
+# written to clone.log.
 clone_repo() {
   cd "$TRASHDIR"
 
@@ -160,6 +161,7 @@ clone_repo() {
   cd "$dir"
 
   git config credential.helper lfstest
+  echo "$out" > clone.log
   echo "$out"
 }
 


### PR DESCRIPTION
This is an attempt at a workaround for #616. It's not ideal, but it gives users a way to optimize their downloads at the cost of complicating the git workflow a bit.

```bash
# downloads all files through smudge
$ git clone foo/bar.git

# downloads all files in a single batch command instead
$ GIT_LFS_SKIP_SMUDGE=1 git clone foo/bar.git
$ git lfs pull
```

That workaround sucks. We can make this better for users with:

```bash
# update smudge filter for all repos
$ git lfs init --skip-smudge

# update smudge filter for only the local repo
$ git lfs init --skip-smudge --local
```