### PR TITLE
Ls files fixes

### DIFF
--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -30,13 +30,27 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	}
 
 	scanOpt := &lfs.ScanRefsOptions{SkipDeletedBlobs: true}
+	listFiles := make(map[string][]string)
+	fileTree, err := lfs.ScanTree(ref)
+	if err != nil {
+		Panic(err, "Could not scan for Git LFS tree")
+	}
+	for _, p := range fileTree {
+		listFiles[p.Sha1] = append(listFiles[p.Sha1], p.Name)
+	}
+
 	pointers, err := lfs.ScanRefs(ref, "", scanOpt)
 	if err != nil {
 		Panic(err, "Could not scan for Git LFS files")
 	}
-
 	for _, p := range pointers {
 		Print(p.Name)
+		if len(listFiles[p.Sha1]) > 1 {
+			for _, v := range listFiles[p.Sha1][1:] {
+				Print(v + " (duplicate of " + p.Name + ")")
+			}
+		}
+		delete(listFiles, p.Sha1)
 	}
 }
 

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -1,12 +1,15 @@
 package commands
 
 import (
+	"strings"
+
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
 )
 
 var (
+	longOIDs   = false
 	lsFilesCmd = &cobra.Command{
 		Use: "ls-files",
 		Run: lsFilesCommand,
@@ -29,6 +32,11 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 		ref = fullref.Sha
 	}
 
+	showShaLen := 7
+	if longOIDs {
+		showShaLen = 40
+	}
+
 	scanOpt := &lfs.ScanRefsOptions{SkipDeletedBlobs: true}
 	listFiles := make(map[string][]string)
 	fileTree, err := lfs.ScanTree(ref)
@@ -44,16 +52,12 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 		Panic(err, "Could not scan for Git LFS files")
 	}
 	for _, p := range pointers {
-		Print(p.Name)
-		if len(listFiles[p.Sha1]) > 1 {
-			for _, v := range listFiles[p.Sha1][1:] {
-				Print(v + " (duplicate of " + p.Name + ")")
-			}
-		}
+		Print(p.Sha1[0:showShaLen] + " ==> [ " + strings.Join(listFiles[p.Sha1], ",") + " ]")
 		delete(listFiles, p.Sha1)
 	}
 }
 
 func init() {
+	lsFilesCmd.Flags().BoolVarP(&longOIDs, "long", "l", false, "Show object ID(s) 40 characters")
 	RootCmd.AddCommand(lsFilesCmd)
 }

--- a/docs/man/git-lfs-ls-files.1.ronn
+++ b/docs/man/git-lfs-ls-files.1.ronn
@@ -3,12 +3,17 @@ git-lfs-ls-files(1) -- Show information about Git LFS files in the index and wor
 
 ## SYNOPSIS
 
-`git lfs ls-files` [<reference>]
+`git lfs ls-files` [<ref>]
 
 ## DESCRIPTION
 
-Display paths of Git LFS files that are found in the given reference.  If no
-reference is given, scan the currently checked-out branch.
+Display paths of Git LFS files that are found in the tree at the given
+reference.  If no reference is given, scan the currently checked-out branch.
+
+## OPTIONS
+
+* `-l` `--long`:
+  Show the entire 64 character OID, instead of just first 10.
 
 ## SEE ALSO
 

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -65,3 +65,22 @@ begin_test "ls-files: with zero files"
   [ "$(git lfs ls-files)" = "" ]
 )
 end_test
+
+begin_test "ls-files: show duplicate files"
+(
+  set -e
+
+  mkdir dupRepo
+  cd dupRepo
+  git init
+
+  git lfs track "*.tgz" | grep "Tracking \*.tgz"
+  echo "test content" > one.tgz
+  echo "test content" > two.tgz
+  git add one.tgz
+  git add two.tgz
+  git commit -m "add duplicate files"
+  [ "$(git lfs ls-files)" = "$(printf 'one.tgz\ntwo.tgz (duplicate of one.tgz)')" ]
+
+)
+end_test

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -15,7 +15,7 @@ begin_test "ls-files"
   echo "missing" > missing.dat
   git add missing.dat
   git commit -m "add missing file"
-  [ "missing.dat" = "$(git lfs ls-files)" ]
+  [ "74f2f1c ==> [ missing.dat ]" = "$(git lfs ls-files)" ]
 
   git rm missing.dat
   git add some.dat some.txt
@@ -70,8 +70,8 @@ begin_test "ls-files: show duplicate files"
 (
   set -e
 
-  mkdir dupRepo
-  cd dupRepo
+  mkdir dupRepoShort
+  cd dupRepoShort
   git init
 
   git lfs track "*.tgz" | grep "Tracking \*.tgz"
@@ -80,7 +80,24 @@ begin_test "ls-files: show duplicate files"
   git add one.tgz
   git add two.tgz
   git commit -m "add duplicate files"
-  [ "$(git lfs ls-files)" = "$(printf 'one.tgz\ntwo.tgz (duplicate of one.tgz)')" ]
+  [ "67f58a4 ==> [ one.tgz,two.tgz ]" = "$(git lfs ls-files)" ]
+)
+end_test
 
+begin_test "ls-files: show duplicate files with long OID"
+(
+  set -e
+
+  mkdir dupRepoLong
+  cd dupRepoLong
+  git init
+
+  git lfs track "*.tgz" | grep "Tracking \*.tgz"
+  echo "test content" > one.tgz
+  echo "test content" > two.tgz
+  git add one.tgz
+  git add two.tgz
+  git commit -m "add duplicate files with long OID"
+  [ "67f58a40df1e32b439f55e722178c337042d2148 ==> [ one.tgz,two.tgz ]" = "$(git lfs ls-files --long)" ]
 )
 end_test

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -15,7 +15,7 @@ begin_test "ls-files"
   echo "missing" > missing.dat
   git add missing.dat
   git commit -m "add missing file"
-  [ "74f2f1c ==> [ missing.dat ]" = "$(git lfs ls-files)" ]
+  [ "6bbd052ab0 * missing.dat" = "$(git lfs ls-files)" ]
 
   git rm missing.dat
   git add some.dat some.txt
@@ -80,7 +80,11 @@ begin_test "ls-files: show duplicate files"
   git add one.tgz
   git add two.tgz
   git commit -m "add duplicate files"
-  [ "67f58a4 ==> [ one.tgz,two.tgz ]" = "$(git lfs ls-files)" ]
+
+  expected="$(echo "a1fff0ffef * one.tgz
+a1fff0ffef * two.tgz")"
+
+  [ "$expected" = "$(git lfs ls-files)" ]
 )
 end_test
 
@@ -98,6 +102,10 @@ begin_test "ls-files: show duplicate files with long OID"
   git add one.tgz
   git add two.tgz
   git commit -m "add duplicate files with long OID"
-  [ "67f58a40df1e32b439f55e722178c337042d2148 ==> [ one.tgz,two.tgz ]" = "$(git lfs ls-files --long)" ]
+
+  expected="$(echo "a1fff0ffefb9eace7230c24e50731f0a91c62f9cefdfe77121c2f607125dffae * one.tgz
+a1fff0ffefb9eace7230c24e50731f0a91c62f9cefdfe77121c2f607125dffae * two.tgz")"
+
+  [ "$expected" = "$(git lfs ls-files --long)" ]
 )
 end_test


### PR DESCRIPTION
This builds on #680:

* `lfs.ScanTree()` is used _instead of_ `lfs.ScanRefs()`. Duplicate files are now shown.
* The output includes the LFS OID and whether the file has the lfs pointer or the actual contents.