### PR TITLE
Better readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,22 @@ page][impl]. You can chat with the team at: https://gitter.im/github/git-lfs
 
 ## Getting Started
 
-Download the [latest client][rel] and run the included install script.  The
-installer should run `git lfs init` for you, which sets up Git's global
-configuration settings for Git LFS.
+You can install Git LFS several different ways, depending on your setup and
+preferences.
+
+* Linux users can install Debian or RPM packages from [PackageCloud](https://packagecloud.io/github/git-lfs).
+* Mac users can install from [Homebrew](https://github.com/Homebrew/homebrew) with `brew install git-lfs`.
+* [Binary packages are available][rel] for Windows, Mac, Linux, and FreeBSD.
+
+Once installed, you can run `git lfs init` to setup the global Git hooks
+necessary for Git LFS to work. You can get help on specific commands directly:
+
+```bash
+$ git lfs help <subcommand>
+```
+
+The [official documentation](docs) has command references and specifications for
+the tool.
 
 Note: Git LFS requires Git v1.8.2 or higher.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,10 @@ these can be viewed from the command also:
 $ git lfs help <command>
 $ git lfs <command> -h
 ```
+## Videos
+
+* [How to Work with Big Files](https://www.youtube.com/watch?v=uLR1RNqJ1Mw) -
+Quick intro to Git LFS.
 
 ## Developer Docs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,16 @@
-# Documentation TOC
+# Git LFS Documentation
 
-* The Client
-  * [Specification](spec.md)
-  * [Commands](man)
-* The Server
-  * [API](api/README.md)
+## Reference Manual
+
+Each Git LFS subcommand is documented in the [official man pages](man). Any of
+these can be viewed from the command also:
+
+```bash
+$ git lfs help <command>
+$ git lfs <command> -h
+```
+
+## Developer Docs
+
+Details of how the Git LFS client work are in the [official specification](spec.md).
+There is also an [API specification](api) that describes how the server works.


### PR DESCRIPTION
This adds a few more crucial details. This is just a start.

1. PackageCloud and Homebrew are listed as official release channels for Git LFS now.
2. The doc homepage is expanded a bit and includes a spot for video tutorials.
3. The new `help` command is featured.