### PR TITLE
Better handling for tiny files below the blob size threshold that contain 'git-lfs'

### DIFF
--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -102,7 +102,7 @@ func DecodePointer(reader io.Reader) (*Pointer, error) {
 }
 
 func DecodeFrom(reader io.Reader) ([]byte, *Pointer, error) {
-	buf := make([]byte, 512)
+	buf := make([]byte, blobSizeCutoff)
 	written, err := reader.Read(buf)
 	output := buf[0:written]
 
@@ -116,7 +116,7 @@ func DecodeFrom(reader io.Reader) ([]byte, *Pointer, error) {
 
 func verifyVersion(version string) error {
 	if len(version) == 0 {
-		return errors.New("Missing version")
+		return newNotAPointerError(errors.New("Missing version"))
 	}
 
 	for _, v := range v1Aliases {

--- a/lfs/pointer_test.go
+++ b/lfs/pointer_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"io"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -58,6 +59,18 @@ func assertLine(t *testing.T, r *bufio.Reader, expected string) {
 	actual, err := r.ReadString('\n')
 	assert.Equal(t, nil, err)
 	assert.Equal(t, expected, actual)
+}
+
+func TestDecodeTinyFile(t *testing.T) {
+	ex := "this is not a git-lfs file!"
+	p, err := DecodePointer(bytes.NewBufferString(ex))
+	if p != nil {
+		t.Errorf("pointer was decoded: %v", p)
+	}
+
+	if !IsNotAPointerError(err) {
+		t.Errorf("error is not a NotAPointerError: %s: '%v'", reflect.TypeOf(err), err)
+	}
 }
 
 func TestDecode(t *testing.T) {

--- a/test/test-pull.sh
+++ b/test/test-pull.sh
@@ -69,7 +69,6 @@ begin_test "pull"
   git lfs pull
   [ "a" = "$(cat a.dat)" ]
 
-
   # Test include / exclude filters supplied in gitconfig
   rm -rf .git/lfs/objects
   git config "lfs.fetchinclude" "a*"
@@ -91,8 +90,6 @@ begin_test "pull"
   rm -rf .git/lfs/objects
   git lfs pull --exclude="a*"
   refute_local_object "$contents_oid"
-
-
 )
 end_test
 

--- a/test/test-smudge.sh
+++ b/test/test-smudge.sh
@@ -44,7 +44,8 @@ begin_test "smudge with invalid pointer"
 
   cd repo
   [ "wat" = "$(echo "wat" | git lfs smudge)" ]
-  [ "not a git-lfs file" = "$(echo "wat" | git lfs smudge)" ]
+  [ "not a git-lfs file" = "$(echo "not a git-lfs file" | git lfs smudge)" ]
+  [ "version " = "$(echo "version " | git lfs smudge)" ]
 )
 end_test
 

--- a/test/test-smudge.sh
+++ b/test/test-smudge.sh
@@ -44,6 +44,7 @@ begin_test "smudge with invalid pointer"
 
   cd repo
   [ "wat" = "$(echo "wat" | git lfs smudge)" ]
+  [ "not a git-lfs file" = "$(echo "wat" | git lfs smudge)" ]
 )
 end_test
 


### PR DESCRIPTION
Git LFS uses a few properties to determine whether something is a valid LFS pointer or not. Right now, the criteria is:

1. Below the blob size threshold (1024 bytes)
2. Contains `git-lfs` in the content.

This causes problems for small test files like "this is a sample git-lfs file." So, it assumes anything that doesn't even start with `version` isn't even trying to be a Git LFS file.

/cc @rubyist: Did this by elevating the bad pointer key message to its own error type.