### PR TITLE
"smudge with skip" test would fail if GIT_LFS_TEST_DIR was not set

### DIFF
--- a/test/test-smudge.sh
+++ b/test/test-smudge.sh
@@ -98,7 +98,7 @@ begin_test "smudge with skip"
 
   echo "test clone with env"
   export GIT_LFS_SKIP_SMUDGE=1
-  env | grep LFS
+  env | grep LFS_SKIP
   clone_repo "$reponame" "skip-clone-env"
   [ "$pointer" = "$(cat a.dat)" ]
   [ "0" = "$(grep -c "Downloading a.dat" clone.log)" ]
@@ -108,7 +108,7 @@ begin_test "smudge with skip"
 
   echo "test clone without env"
   unset GIT_LFS_SKIP_SMUDGE
-  env | grep LFS
+  [ "$(env | grep LFS_SKIP)" == "" ]
   clone_repo "$reponame" "no-skip"
   [ "smudge a" = "$(cat a.dat)" ]
   [ "1" = "$(grep -c "Downloading a.dat" clone.log)" ]


### PR DESCRIPTION
It was erroneously succeeding when that was set because the test was incorrect, should have been checking the env did NOT include GIT_LFS_SKIP_SMUDGE after unsetting. However any LFS env setting would false-positive and therefore work in Travis.