### PR TITLE
Fix resolve of git dirs finding a parent non-bare repo if wd is a bare repo

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -338,5 +339,33 @@ func GetCommitSummary(commit string) (*CommitSummary, error) {
 		msg := fmt.Sprintf("Unexpected output from git show: %v", string(out))
 		return nil, errors.New(msg)
 	}
+
+}
+
+func RootDir() (string, error) {
+	cmd := execCommand("git", "rev-parse", "--show-toplevel")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("Failed to call git rev-parse --show-toplevel: %v %v", err, string(out))
+	}
+
+	path := strings.TrimSpace(string(out))
+	if len(path) > 0 {
+		return filepath.Abs(path)
+	}
+	return "", nil
+
+}
+func GitDir() (string, error) {
+	cmd := execCommand("git", "rev-parse", "--git-dir")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("Failed to call git rev-parse --git-dir: %v %v", err, string(out))
+	}
+	path := strings.TrimSpace(string(out))
+	if len(path) > 0 {
+		return filepath.Abs(path)
+	}
+	return "", nil
 
 }

--- a/test/test-env.sh
+++ b/test/test-env.sh
@@ -323,21 +323,6 @@ git config filter.lfs.clean = \"\"
   actual5=$(GIT_DIR=$gitDir GIT_WORK_TREE=a/b git lfs env)
   [ "$expected5" = "$actual5" ]
 
-  expected6=$(printf "%s\n%s\n
-LocalWorkingDir=$TRASHDIR/$reponame/a/b
-LocalGitDir=$TRASHDIR/$reponame/.git
-LocalGitStorageDir=$TRASHDIR/$reponame/.git
-LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
-TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
-ConcurrentTransfers=3
-BatchTransfer=true
-$(GIT_WORK_TREE=a/b env | grep "^GIT")
-git config filter.lfs.smudge = \"\"
-git config filter.lfs.clean = \"\"
-" "$(git lfs version)" "$(git version)")
-  actual6=$(GIT_WORK_TREE=a/b git lfs env)
-  [ "$expected6" = "$actual6" ]
-
   cd $TRASHDIR/$reponame/a/b
   expected7=$(printf "%s\n%s\n
 LocalWorkingDir=$TRASHDIR/$reponame/a/b
@@ -367,5 +352,30 @@ $(GIT_WORK_TREE=$workTree env | grep "^GIT")
 " "$(git lfs version)" "$(git version)" "$envInitConfig")
   actual8=$(GIT_WORK_TREE=$workTree git lfs env)
   [ "$expected8" = "$actual8" ]
+)
+end_test
+
+
+begin_test "env with bare repo"
+(
+  set -e
+  reponame="env-with-bare-repo"
+  git init --bare $reponame
+  cd $reponame
+
+  expected=$(printf "%s\n%s\n
+LocalWorkingDir=
+LocalGitDir=$TRASHDIR/$reponame
+LocalGitStorageDir=$TRASHDIR/$reponame
+LocalMediaDir=$TRASHDIR/$reponame/lfs/objects
+TempDir=$TRASHDIR/$reponame/lfs/tmp
+ConcurrentTransfers=3
+BatchTransfer=true
+$(env | grep "^GIT")
+%s
+" "$(git lfs version)" "$(git version)" "$envInitConfig")
+  actual=$(git lfs env)
+  [ "$expected" = "$actual" ]
+
 )
 end_test


### PR DESCRIPTION
This causes tests to fail if GIT_LFS_TEST_DIR is not set, since the bare repo tests actually cascade up to the git-lfs repo itself and start modifying config files in there. Might potentially affect other cases where a bare repo is inside a non-bare repo.

Resolution is to use `git rev-parse` to locate all dirs instead of manually recursing. Could potentially remove manual processing of GIT_DIR and GIT_WORK_TREE in future but have left as belt & braces for now.

Had to remove test for using relative GIT_WORK_TREE with no GIT_DIR, git rev-parse always fails in that case so it appears it's not supported by git even though man git-config claims it is.