### PR TITLE
Display the specific error in the case of a 403

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -216,6 +216,8 @@ func Batch(objects []*objectResource, operation string) ([]*objectResource, erro
 		case 404, 410:
 			tracerx.Printf("api: batch not implemented: %d", res.StatusCode)
 			return nil, newNotImplementedError(nil)
+		case 403:
+			return nil, Error(err)
 		}
 
 		tracerx.Printf("api error: %s", err)

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -216,11 +216,10 @@ func Batch(objects []*objectResource, operation string) ([]*objectResource, erro
 		case 404, 410:
 			tracerx.Printf("api: batch not implemented: %d", res.StatusCode)
 			return nil, newNotImplementedError(nil)
-		case 403:
-			return nil, Error(err)
 		}
 
 		tracerx.Printf("api error: %s", err)
+		return nil, Error(err)
 	}
 	LogTransfer("lfs.api.batch", res)
 

--- a/test/test-batch-error-handling.sh
+++ b/test/test-batch-error-handling.sh
@@ -50,7 +50,7 @@ begin_test "batch error handling"
 
   # This pushes to the remote repository set up at the top of the test.
   git push origin master 2>&1 | tee push.log
-  grep "Invalid status for POST" push.log
+  grep "Unable to parse HTTP response" push.log
 )
 end_test
 


### PR DESCRIPTION
A status of 403 against the API would be masked with a generic message. This displays a more specific message - either one returned in the API json, or a default message about authentication.