### PR TITLE
Improved default remote behaviour & validation for fetch/pull

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -30,10 +30,12 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		// Remote is first arg
 		lfs.Config.CurrentRemote = args[0]
 	} else {
-		trackedRemote, err := git.RemoteForCurrentBranch()
-		if err == nil {
-			lfs.Config.CurrentRemote = trackedRemote
-		} // otherwise leave as default (origin)
+		// Actively find the default remote, don't just assume origin
+		defaultRemote, err := git.DefaultRemote()
+		if err != nil {
+			Panic(err, "No default remote")
+		}
+		lfs.Config.CurrentRemote = defaultRemote
 	}
 
 	if len(args) > 1 {

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -29,14 +29,14 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 	if len(args) > 0 {
 		// Remote is first arg
 		if err := git.ValidateRemote(args[0]); err != nil {
-			Panic(err, fmt.Sprintf("Invalid remote name '%v'", args[0]))
+			Exit("Invalid remote name %q", args[0])
 		}
 		lfs.Config.CurrentRemote = args[0]
 	} else {
 		// Actively find the default remote, don't just assume origin
 		defaultRemote, err := git.DefaultRemote()
 		if err != nil {
-			Panic(err, "No default remote")
+			Exit("No default remote")
 		}
 		lfs.Config.CurrentRemote = defaultRemote
 	}

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -30,7 +30,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		// Remote is first arg
 		lfs.Config.CurrentRemote = args[0]
 	} else {
-		trackedRemote, err := git.CurrentRemote()
+		trackedRemote, err := git.RemoteForCurrentBranch()
 		if err == nil {
 			lfs.Config.CurrentRemote = trackedRemote
 		} // otherwise leave as default (origin)

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -28,6 +28,9 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 
 	if len(args) > 0 {
 		// Remote is first arg
+		if err := git.ValidateRemote(args[0]); err != nil {
+			Panic(err, fmt.Sprintf("Invalid remote name '%v'", args[0]))
+		}
 		lfs.Config.CurrentRemote = args[0]
 	} else {
 		// Actively find the default remote, don't just assume origin

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -22,7 +22,7 @@ func pullCommand(cmd *cobra.Command, args []string) {
 		// Remote is first arg
 		lfs.Config.CurrentRemote = args[0]
 	} else {
-		trackedRemote, err := git.CurrentRemote()
+		trackedRemote, err := git.RemoteForCurrentBranch()
 		if err == nil {
 			lfs.Config.CurrentRemote = trackedRemote
 		} // otherwise leave as default (origin)

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
@@ -20,6 +22,9 @@ func pullCommand(cmd *cobra.Command, args []string) {
 
 	if len(args) > 0 {
 		// Remote is first arg
+		if err := git.ValidateRemote(args[0]); err != nil {
+			Panic(err, fmt.Sprintf("Invalid remote name '%v'", args[0]))
+		}
 		lfs.Config.CurrentRemote = args[0]
 	} else {
 		// Actively find the default remote, don't just assume origin

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -22,10 +22,12 @@ func pullCommand(cmd *cobra.Command, args []string) {
 		// Remote is first arg
 		lfs.Config.CurrentRemote = args[0]
 	} else {
-		trackedRemote, err := git.RemoteForCurrentBranch()
-		if err == nil {
-			lfs.Config.CurrentRemote = trackedRemote
-		} // otherwise leave as default (origin)
+		// Actively find the default remote, don't just assume origin
+		defaultRemote, err := git.DefaultRemote()
+		if err != nil {
+			Panic(err, "No default remote")
+		}
+		lfs.Config.CurrentRemote = defaultRemote
 	}
 
 	ref, err := git.CurrentRef()

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -57,12 +57,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 			Panic(err, "Could not scan for Git LFS objects")
 		}
 
-		remote, err := git.RemoteForCurrentBranch()
-		if err != nil {
-			Panic(err, "Could not get current remote branch")
-		}
-
-		Print("Git LFS objects to be pushed to %s:\n", remote)
+		Print("Git LFS objects to be pushed to %s:\n", remoteRef.Name)
 		for _, p := range pointers {
 			Print("\t%s (%s)", p.Name, humanizeBytes(p.Size))
 		}

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -57,7 +57,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 			Panic(err, "Could not scan for Git LFS objects")
 		}
 
-		remote, err := git.CurrentRemote()
+		remote, err := git.RemoteForCurrentBranch()
 		if err != nil {
 			Panic(err, "Could not get current remote branch")
 		}

--- a/git/git.go
+++ b/git/git.go
@@ -144,6 +144,21 @@ func RemoteList() ([]string, error) {
 	return ret, nil
 }
 
+// ValidateRemote checks that a named remote is valid for use
+// Mainly to check user-supplied remotes & fail more nicely
+func ValidateRemote(remote string) error {
+	remotes, err := RemoteList()
+	if err != nil {
+		return err
+	}
+	for _, r := range remotes {
+		if r == remote {
+			return nil
+		}
+	}
+	return errors.New("Invalid remote name")
+}
+
 // DefaultRemote returns the default remote based on:
 // 1. The currently tracked remote branch, if present
 // 2. "origin", if defined

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -56,11 +56,18 @@ func TestCurrentRefAndCurrentRemoteRef(t *testing.T) {
 	assert.Equal(t, &Ref{"master", RefTypeLocalBranch, outputs[2].Sha}, ref)
 	// Check remote
 	repo.AddRemote("origin")
-	test.RunGitCommand(t, true, "push", "-u", "origin", "master")
+	test.RunGitCommand(t, true, "push", "-u", "origin", "master:someremotebranch")
 	ref, err = CurrentRemoteRef()
 	assert.Equal(t, nil, err)
-	assert.Equal(t, &Ref{"origin/master", RefTypeRemoteBranch, outputs[2].Sha}, ref)
+	assert.Equal(t, &Ref{"origin/someremotebranch", RefTypeRemoteBranch, outputs[2].Sha}, ref)
 
+	refname, err := RemoteRefNameForCurrentBranch()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "origin/someremotebranch", refname)
+
+	remote, err := RemoteForCurrentBranch()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "origin", remote)
 }
 
 func TestRecentBranches(t *testing.T) {

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -462,5 +462,13 @@ begin_test "fetch with no origin remote"
   # and no origin, but only 1 remote, should pick the only one as default
   git lfs fetch
   assert_local_object "$contents_oid" 1
+
+  # delete again, now add a second remote, also non-origin
+  rm -rf .git/lfs
+  git remote add something2 "$GITSERVER/$reponame"
+  git lfs fetch 2>&1 | grep "No default remote"
+  refute_local_object "$contents_oid"
+
+
 )
 end_test

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -404,3 +404,63 @@ begin_test "fetch: outside git repository"
   grep "Not in a git repository" fetch.log
 )
 end_test
+
+begin_test "fetch with no origin remote"
+(
+  set -e
+
+  reponame="fetch-no-remote"
+  setup_remote_repo "$reponame"
+
+  clone_repo "$reponame" no-remote-clone
+
+  clone_repo "$reponame" no-remote-repo
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \*.dat" track.log
+
+  contents="a"
+  contents_oid=$(calc_oid "$contents")
+
+  printf "$contents" > a.dat
+  git add a.dat
+  git add .gitattributes
+  git commit -m "add a.dat" 2>&1 | tee commit.log
+  grep "master (root-commit)" commit.log
+  grep "2 files changed" commit.log
+  grep "create mode 100644 a.dat" commit.log
+  grep "create mode 100644 .gitattributes" commit.log
+
+  [ "a" = "$(cat a.dat)" ]
+
+  assert_local_object "$contents_oid" 1
+
+  refute_server_object "$reponame" "$contents_oid"
+
+  git push origin master 2>&1 | tee push.log
+  grep "(1 of 1 files)" push.log
+  grep "master -> master" push.log
+
+
+  # change to the clone's working directory
+  cd ../no-remote-clone
+
+  # pull commits & lfs
+  git pull 2>&1 | grep "Downloading a.dat (1 B)"
+  assert_local_object "$contents_oid" 1
+
+  # now checkout detached HEAD so we're not tracking anything on remote
+  git checkout --detach
+
+  # delete lfs
+  rm -rf .git/lfs
+
+  # rename remote from 'origin' to 'something'
+  git remote rename origin something
+
+  # fetch should still pick this remote as in the case of no tracked remote,
+  # and no origin, but only 1 remote, should pick the only one as default
+  git lfs fetch
+  assert_local_object "$contents_oid" 1
+)
+end_test


### PR DESCRIPTION
This fixes #660 and also improves a few other areas:
* Default remote is now either the tracked remote, or "origin" or any other *single* remote defined. If all of these fail there's a better error message now.
* User-supplied remotes are now validated to avoid ambiguous fail cases
* General tidy up to make it clearer what each of these git package functions are intended to do