### PR TITLE
Make fetch return error code when 1+ downloads failed

### DIFF
--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -227,7 +227,7 @@ func (q *TransferQueue) batchApiRoutine() {
 
 		for _, o := range objects {
 			if o.Error != nil {
-				q.errorc <- Error(o.Error)
+				q.errorc <- Errorf(o.Error, "[%v] %v", o.Oid, o.Error.Message)
 				q.meter.Skip(o.Size)
 				q.wait.Done()
 				continue

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -130,6 +130,20 @@ begin_test "fetch"
   git lfs fetch --include="c*,d*" --exclude="a*,b*" origin master newbranch
   refute_local_object "$contents_oid"
   refute_local_object "$b_oid"
+
+  # test fail case error code
+  rm -rf .git/lfs/objects
+  delete_server_object "$reponame" "$b_oid"
+  refute_server_object "$reponame" "$b_oid"
+  # should return non-zero, but should also download all the other valid files too
+  set +e
+  git lfs fetch origin master newbranch
+  fetch_exit=$?
+  set -e
+  [ "$fetch_exit" != "0" ]
+  assert_local_object "$contents_oid" 1
+  refute_local_object "$b_oid"
+
 )
 end_test
 

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -62,6 +62,22 @@ refute_server_object() {
   grep "404 Not Found" http.log
 }
 
+# Delete an object on the lfs server. HTTP log is
+# written to http.log. JSON output is written to http.json.
+#
+#   $ delete_server_object "reponame" "oid"
+delete_server_object() {
+  local reponame="$1"
+  local oid="$2"
+  curl -v "$GITSERVER/$reponame.git/info/lfs/delete/$oid" \
+    -u "user:pass" \
+    -o http.json \
+    -H "Accept: application/vnd.git-lfs+json" 2>&1 |
+    tee http.log
+
+  grep "200 OK" http.log
+}
+
 # check that the object does exist in the git lfs server. HTTP log is written
 # to http.log. JSON output is written to http.json.
 assert_server_object() {


### PR DESCRIPTION
Raised as part of #731 

Includes some changes to the test git server which actually wasn't strictly complying with the 1.0 API spec. Also includes a couple of tweaks to make errors from transfer queue identifiable to the oid that caused them.

Added a 'delete' method to the git test server just for testing purposes, to create a failing condition.