### PR TITLE
Use LoggedError instead of Panic if update-index fails in checkout

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -225,7 +225,8 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 	if cmd != nil && updateIdxStdin != nil {
 		updateIdxStdin.Close()
 		if err := cmd.Wait(); err != nil {
-			Panic(err, "Error updating the git index")
+			outp, _ := cmd.CombinedOutput()
+			LoggedError(err, "Error updating the git index\n%v", string(outp))
 		}
 	}
 }


### PR DESCRIPTION
Also report stderr/out since error object is often something useless like "exit status 128".
To help with #725. 