### PR TITLE
lfs complain not a git directory

### DIFF
--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -22,7 +22,13 @@ var (
 )
 
 func initCommand(cmd *cobra.Command, args []string) {
-	requireInRepo()
+	if localInit {
+		requireInRepo()
+	}
+
+	if lfs.LocalGitDir == "" {
+		Print("Not a git repository.")
+	}
 
 	opt := lfs.InstallOptions{Force: forceInit, Local: localInit}
 	if skipSmudgeInit {

--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -22,9 +22,7 @@ var (
 )
 
 func initCommand(cmd *cobra.Command, args []string) {
-	if localInit {
-		requireInRepo()
-	}
+	requireInRepo()
 
 	opt := lfs.InstallOptions{Force: forceInit, Local: localInit}
 	if skipSmudgeInit {


### PR DESCRIPTION
For fixed issue #717 and I have an question.
Why we provide flag `local`and `force` in source code but in [help page](https://github.com/github/git-lfs/blob/master/docs/man/git-lfs-init.1.ronn) not found how to use it?