### PR TITLE
Improve lfs.InRepo() detection in `init`/`update`

### DIFF
--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -37,7 +37,10 @@ func initCommand(cmd *cobra.Command, args []string) {
 		Exit("Run `git lfs init --force` to reset git config.")
 	}
 
-	initHooksCommand(cmd, args)
+	if localInit || lfs.InRepo() {
+		initHooksCommand(cmd, args)
+	}
+
 	Print("Git LFS initialized.")
 }
 

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -20,6 +20,8 @@ var (
 // updateCommand is used for updating parts of Git LFS that reside under
 // .git/lfs.
 func updateCommand(cmd *cobra.Command, args []string) {
+	requireInRepo()
+
 	if err := lfs.InstallHooks(updateForce); err != nil {
 		Error(err.Error())
 		Print("Run `git lfs update --force` to overwrite this hook.")

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -93,7 +93,7 @@ func Environ() []string {
 }
 
 func InRepo() bool {
-	return LocalWorkingDir != ""
+	return LocalGitDir != ""
 }
 
 func ResolveDirs() {

--- a/test/test-init.sh
+++ b/test/test-init.sh
@@ -98,6 +98,30 @@ Git LFS initialized." = "$(git lfs init --force)" ]
 )
 end_test
 
+begin_test "init outside repository directory"
+(
+  set -e
+  if [ -d "hooks" ]; then
+    ls -al
+    echo "hooks dir exists"
+    exit 1
+  fi
+
+  git lfs init 2>&1 > check.log
+
+  if [ -d "hooks" ]; then
+    ls -al
+    echo "hooks dir exists"
+    exit 1
+  fi
+
+  cat check.log
+
+  # doesn't print this because being in a git repo is not necessary for init
+  [ "$(grep -c "Not in a git repository" check.log)" = "0" ]
+)
+end_test
+
 begin_test "init --skip-smudge"
 (
   set -e

--- a/test/test-init.sh
+++ b/test/test-init.sh
@@ -85,8 +85,7 @@ Git LFS initialized."
 Git LFS initialized." = "$(git lfs init --force)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
-  # TODO: FIX FOR DOCKER TESTS
-  exit 0
+  [ -n "$LFS_DOCKER" ] && exit 0
 
   echo "test with bare repository"
   cd ..
@@ -140,8 +139,7 @@ begin_test "init --local outside repository"
 (
   set +e
 
-  # TODO: FIX FOR DOCKER TESTS
-  exit 0
+  [ -n "$LFS_DOCKER" ] && exit 0
 
   git lfs init --local 2> err.log
   res=$?

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -107,18 +107,33 @@ end_test
 
 begin_test "update: outside git repository"
 (
+  if [ -d "hooks" ]; then
+    ls -al
+    echo "hooks dir exists"
+    exit 1
+  fi
+
   set +e
   git lfs update 2>&1 > check.log
   res=$?
-  overwrite="$(grep "overwrite" check.log)"
-
   set -e
+
   if [ "$res" = "0" ]; then
-    echo "Passes because $GIT_LFS_TEST_DIR is unset."
-    exit 0
+    if [ -z "$GIT_LFS_TEST_DIR" ]; then
+      echo "Passes because $GIT_LFS_TEST_DIR is unset."
+      exit 0
+    fi
   fi
+
   [ "$res" = "128" ]
-  [ -z "$overwrite" ]
+
+  if [ -d "hooks" ]; then
+    ls -al
+    echo "hooks dir exists"
+    exit 1
+  fi
+
+  cat check.log
   grep "Not in a git repository" check.log
 )
 end_test

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -68,8 +68,7 @@ Run \`git lfs update --force\` to overwrite this hook."
   [ "Updated pre-push hook." = "$(git lfs update --force)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
-  # TODO: FIX FOR DOCKER TESTS
-  exit 0
+  [ -n "$LFS_DOCKER" ] && exit 0
 
   echo "test with bare repository"
   cd ..


### PR DESCRIPTION
Fixes #717 and supercedes #752.

1. Only skips the tests in docker IF `LFS_DOCKER` is set. This may change before we ship 1.0.1, but at least now I know ALL tests run locally and on Travis.
2. Changed `lfs.InRepo()` so it looks for an empty `LocalGitDir`, instead of `LocalWorkingDir`. Bare repositories have no working directory.
3. Updated the `update` and `init` tests to check that the hooks dir is not created.