### PR TITLE
whitelist the valid keys from .gitconfig

### DIFF
--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "default config"
+(
+  set -e
+  reponame="default-config"
+  mkdir $reponame
+  cd $reponame
+  git init
+  git remote add origin "$GITSERVER/$reponame"
+  git lfs env | tee env.log
+  grep "Endpoint=$GITSERVER/$reponame.git/info/lfs (auth=none)" env.log
+
+  git config --file=.gitconfig lfs.url http://gitconfig-file
+  git lfs env | tee env.log
+  grep "Endpoint=http://gitconfig-file (auth=none)" env.log
+
+  git config lfs.url http://local-gitconfig
+  git lfs env | tee env.log
+  grep "Endpoint=http://local-gitconfig (auth=none)" env.log
+)
+end_test
+
+begin_test "extension config"
+(
+  set -e
+
+  git config --global lfs.extension.env-test.clean "env-test-clean"
+  git config --global lfs.extension.env-test.smudge "env-test-smudge"
+  git config --global lfs.extension.env-test.priority 0
+
+  reponame="extension-config"
+  mkdir $reponame
+  cd $reponame
+  git init
+
+  expected0="Extension: env-test
+    clean = env-test-clean
+    smudge = env-test-smudge
+    priority = 0"
+
+  [ "$expected0" = "$(git lfs ext)" ]
+
+  # any git config takes precedence over .gitconfig
+  git config --global --unset lfs.extension.env-test.priority
+
+  git config --file=.gitconfig lfs.extension.env-test.clean "file-env-test-clean"
+  git config --file=.gitconfig lfs.extension.env-test.smudge "file-env-test-smudge"
+  git config --file=.gitconfig lfs.extension.env-test.priority 1
+  cat .gitconfig
+  expected1="Extension: env-test
+    clean = env-test-clean
+    smudge = env-test-smudge
+    priority = 1"
+
+  [ "$expected1" = "$(GIT_TRACE=5 git lfs ext)" ]
+
+  git config lfs.extension.env-test.clean "local-env-test-clean"
+  git config lfs.extension.env-test.smudge "local-env-test-smudge"
+  git config lfs.extension.env-test.priority 2
+  expected2="Extension: env-test
+    clean = local-env-test-clean
+    smudge = local-env-test-smudge
+    priority = 2"
+
+  [ "$expected2" = "$(git lfs ext)" ]
+)
+end_test

--- a/test/test-env.sh
+++ b/test/test-env.sh
@@ -244,7 +244,7 @@ begin_test "env with .gitconfig"
   echo '[remote "origin"]
 	lfsurl = http://foobar:8080/
 [lfs]
-     batch = true
+     batch = false
 	concurrenttransfers = 5
 ' > .gitconfig
 
@@ -255,7 +255,7 @@ LocalGitDir=$TRASHDIR/$reponame/.git
 LocalGitStorageDir=$TRASHDIR/$reponame/.git
 LocalMediaDir=$TRASHDIR/$reponame/.git/lfs/objects
 TempDir=$TRASHDIR/$reponame/.git/lfs/tmp
-ConcurrentTransfers=5
+ConcurrentTransfers=3
 BatchTransfer=true
 $(env | grep "^GIT")
 %s


### PR DESCRIPTION
This whitelists the valid keys that are read from `.gitconfig`. Git LFS can't make Git read options from `.gitconfig` by default, but it should be explicit about what it allows.

* `lfs.url`
* `remote.{name}.lfsurl`
* `lfs.extension.{name}.priority`

The `.gitconfig` file is designed for common settings for all users cloning.  IMO the other settings should be set by a user's standard git config.