### PR TITLE
Fix not setting global attribute when needed to b/c of local state

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -224,6 +224,12 @@ func (c *gitConfig) Find(val string) string {
 }
 
 // Find returns the git config value for the key
+func (c *gitConfig) FindGlobal(val string) string {
+	output, _ := simpleExec("git", "config", "--global", val)
+	return output
+}
+
+// Find returns the git config value for the key
 func (c *gitConfig) FindLocal(val string) string {
 	output, _ := simpleExec("git", "config", "--local", val)
 	return output

--- a/lfs/attribute.go
+++ b/lfs/attribute.go
@@ -67,7 +67,7 @@ func (a *Attribute) set(key, value string, opt InstallOptions) error {
 	if opt.Local {
 		currentValue = git.Config.FindLocal(key)
 	} else {
-		currentValue = git.Config.Find(key)
+		currentValue = git.Config.FindGlobal(key)
 	}
 
 	if opt.Force || shouldReset(currentValue) {


### PR DESCRIPTION
Attribute checks whether it thinks the setting is already in the desired state before setting, but for global options was using plain `Find()` which uses `git config` without any flags, which makes it pull in local state too. It should have been using the `--global` flag to get the current value just like it does when setting it. 

Before this fix it could incorrectly assume the global setting is there already and skip setting it, even though when you move out of that folder the setting disappears. This was causing some random failures on Windows tests. Separated from the rest of the Windows test fixing work because it's actually a general bug.