### PR TITLE
Fix clone fail when fetch is excluded globally (#759)

### DIFF
--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -75,8 +75,11 @@ func smudgeCommand(cmd *cobra.Command, args []string) {
 
 	if err != nil {
 		ptr.Encode(os.Stdout)
-		LoggedError(err, "Error accessing media: %s (%s)", filename, ptr.Oid)
-		os.Exit(2)
+		// Download declined error is ok to skip if we weren't requesting download
+		if !(lfs.IsDownloadDeclinedError(err) && !download) {
+			LoggedError(err, "Error accessing media: %s (%s)", filename, ptr.Oid)
+			os.Exit(2)
+		}
 	}
 }
 


### PR DESCRIPTION
Smudge command should return 0 if download was optional and didn't occur