### PR TITLE
rewrite test runner in go to reduce output race conditions

### DIFF
--- a/script/fmt
+++ b/script/fmt
@@ -6,7 +6,7 @@ hash goimports 2>/dev/null && {
 }
 
 # don't run gofmt in these directories
-ignored=(/bin/ /docs/ /log/ /man/ /tmp/ /vendor/)
+ignored=(/bin/ /docs/ /log/ /man/ /tmp/ /vendor/ /rpm/ /docker/ /debian/)
 for i in */ ; do
   if [[ ! ${ignored[*]} =~ "/$i" ]]; then
     $formatter -w -l "$@" "${i%?}"

--- a/script/integration
+++ b/script/integration
@@ -5,7 +5,6 @@ set -e
 
 SHUTDOWN_LFS=no
 SHOW_LOGS=yes
-TESTS=( "$@" )
 
 atexit() {
   res=${1:-$?}
@@ -47,15 +46,4 @@ parallel=${GIT_LFS_TEST_MAXPROCS:-4}
 echo "Running this maxprocs=$parallel"
 echo
 
-if [ ${#TESTS[@]} -eq 0 ]
-then
-  testfiles=(test/test-*.sh)
-else
-  for ((i=0; i<${#TESTS[@]}; i++)); do
-    testfiles[i]=test/test-${TESTS[i]}.sh
-  done
-fi
-
-for file in "${testfiles[@]}"; do
-  echo "0$(cat .$(basename $file).time 2>/dev/null || true) $file"
-done | sort -rnk1 | awk '{ print $2 }' | xargs -I % -P $parallel -n 1 /bin/bash % --batch
+GIT_LFS_TEST_MAXPROCS=$parallel GIT_LFS_TEST_DIR="$GIT_LFS_TEST_DIR" SHUTDOWN_LFS="no" go run script/*.go -cmd integration "$@"

--- a/script/integration.go
+++ b/script/integration.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	showlogs    = false
+	erroring    = false
 	maxprocs    = 4
 	testPattern = regexp.MustCompile(`test/test-([a-z\-]+)\.sh`)
 )
@@ -46,10 +46,18 @@ func mainIntegration() {
 	wg.Wait()
 	close(output)
 	printOutput(output)
+
+	if erroring {
+		os.Exit(1)
+	}
 }
 
 func runTest(output chan string, test string) {
-	out, _ := exec.Command("/bin/bash", test).CombinedOutput()
+	out, err := exec.Command("/bin/bash", test).CombinedOutput()
+	if err != nil {
+		erroring = true
+	}
+
 	output <- strings.TrimSpace(string(out))
 }
 

--- a/script/integration.go
+++ b/script/integration.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+var (
+	showlogs    = false
+	maxprocs    = 4
+	testPattern = regexp.MustCompile(`test/test-([a-z\-]+)\.sh`)
+)
+
+func mainIntegration() {
+	if maxprocs < 1 {
+		maxprocs = 1
+	}
+
+	files := testFiles()
+
+	if len(files) == 0 {
+		fmt.Println("no tests to run")
+		os.Exit(1)
+	}
+
+	var wg sync.WaitGroup
+	tests := make(chan string, len(files))
+	output := make(chan string, len(files))
+
+	for _, file := range files {
+		tests <- file
+	}
+
+	go printOutput(output)
+	for i := 0; i < maxprocs; i++ {
+		wg.Add(1)
+		go worker(tests, output, &wg)
+	}
+
+	close(tests)
+	wg.Wait()
+	close(output)
+	printOutput(output)
+}
+
+func runTest(output chan string, test string) {
+	out, _ := exec.Command("/bin/bash", test).CombinedOutput()
+	output <- strings.TrimSpace(string(out))
+}
+
+func printOutput(output <-chan string) {
+	for {
+		select {
+		case out, ok := <-output:
+			if !ok {
+				return
+			}
+
+			fmt.Println(out)
+		}
+	}
+}
+
+func worker(tests <-chan string, output chan string, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case testname, ok := <-tests:
+			if !ok {
+				return
+			}
+			runTest(output, testname)
+		}
+	}
+}
+
+func testFiles() []string {
+	if len(os.Args) < 4 {
+		return allTestFiles()
+	}
+
+	fileMap := make(map[string]bool)
+	for _, file := range allTestFiles() {
+		fileMap[file] = true
+	}
+
+	files := make([]string, 0, len(os.Args)-3)
+	for _, arg := range os.Args {
+		fullname := "test/test-" + arg + ".sh"
+		if fileMap[fullname] {
+			files = append(files, fullname)
+		}
+	}
+
+	return files
+}
+
+func allTestFiles() []string {
+	files := make([]string, 0, 100)
+	filepath.Walk("test", func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !testPattern.MatchString(path) {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	return files
+}

--- a/script/script.go
+++ b/script/script.go
@@ -19,6 +19,8 @@ func main() {
 		mainBuild()
 	case "release":
 		mainRelease()
+	case "integration":
+		mainIntegration()
 	default:
 		log.Fatalln("Unknown command:", *SubCommand)
 	}

--- a/test/test-init.sh
+++ b/test/test-init.sh
@@ -6,13 +6,16 @@ begin_test "init again"
 (
   set -e
 
-  [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
-  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
+  smudge="$(git config filter.lfs.smudge)"
+  clean="$(git config filter.lfs.clean)"
+
+  printf "$smudge" | grep "git-lfs smudge"
+  printf "$clean" | grep "git-lfs clean"
 
   git lfs init
 
-  [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
-  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
+  [ "$smudge" = "$(git config filter.lfs.smudge)" ]
+  [ "$clean" = "$(git config filter.lfs.clean)" ]
 )
 end_test
 
@@ -34,12 +37,12 @@ begin_test "init with old settings"
   grep -E "(clean|smudge) attribute should be" init.log
   [ `grep -c "(MISSING)" init.log` = "0" ]
 
-  [ "git lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
-  [ "git lfs clean %f" = "$(git config filter.lfs.clean)" ]
+  [ "git lfs smudge %f" = "$(git config --global filter.lfs.smudge)" ]
+  [ "git lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
 
   git lfs init --force
-  [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
-  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
+  [ "git-lfs smudge %f" = "$(git config --global filter.lfs.smudge)" ]
+  [ "git-lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
 )
 end_test
 
@@ -85,7 +88,7 @@ Git LFS initialized."
 Git LFS initialized." = "$(git lfs init --force)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
-  [ -n "$LFS_DOCKER" ] && exit 0
+  has_test_dir || exit 0
 
   echo "test with bare repository"
   cd ..
@@ -127,16 +130,16 @@ begin_test "init --skip-smudge"
   set -e
 
   git lfs init
-  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
-  [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
+  [ "git-lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
+  [ "git-lfs smudge %f" = "$(git config --global filter.lfs.smudge)" ]
 
   git lfs init --skip-smudge
-  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
-  [ "git-lfs smudge --skip %f" = "$(git config filter.lfs.smudge)" ]
+  [ "git-lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
+  [ "git-lfs smudge --skip %f" = "$(git config --global filter.lfs.smudge)" ]
 
   git lfs init --force
-  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
-  [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
+  [ "git-lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
+  [ "git-lfs smudge %f" = "$(git config --global filter.lfs.smudge)" ]
 )
 end_test
 
@@ -169,7 +172,7 @@ begin_test "init --local outside repository"
 
   set +e
 
-  [ -n "$LFS_DOCKER" ] && exit 0
+  has_test_dir || exit 0
 
   git lfs init --local 2> err.log
   res=$?

--- a/test/test-uninit.sh
+++ b/test/test-uninit.sh
@@ -6,8 +6,11 @@ begin_test "uninit outside repository"
 (
   set -e
 
-  [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
-  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
+  smudge="$(git config filter.lfs.smudge)"
+  clean="$(git config filter.lfs.clean)"
+
+  printf "$smudge" | grep "git-lfs smudge"
+  printf "$clean" | grep "git-lfs clean"
 
   # uninit multiple times to trigger https://github.com/github/git-lfs/issues/529
   git lfs uninit
@@ -15,8 +18,8 @@ begin_test "uninit outside repository"
   git lfs uninit | tee uninit.log
   grep "configuration has been removed" uninit.log
 
-  [ "" = "$(git config filter.lfs.smudge)" ]
-  [ "" = "$(git config filter.lfs.clean)" ]
+  [ "" = "$(git config --global filter.lfs.smudge)" ]
+  [ "" = "$(git config --global filter.lfs.clean)" ]
 
   cat $HOME/.gitconfig
   [ "$(grep 'filter "lfs"' $HOME/.gitconfig -c)" = "0" ]

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -68,7 +68,7 @@ Run \`git lfs update --force\` to overwrite this hook."
   [ "Updated pre-push hook." = "$(git lfs update --force)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
-  [ -n "$LFS_DOCKER" ] && exit 0
+  has_test_dir || exit 0
 
   echo "test with bare repository"
   cd ..

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -227,6 +227,7 @@ setup() {
   echo
   echo "HOME: $HOME"
   echo "TMP: $TMPDIR"
+  echo "CREDS: $CREDSDIR"
   echo "lfstest-gitserver:"
   echo "  LFSTEST_URL=$LFS_URL_FILE"
   echo "  LFSTEST_DIR=$REMOTEDIR"
@@ -408,7 +409,7 @@ escape_path() {
 # As native_path but escape all backslash characters to "\\"
 native_path_escaped() {
   local unescaped=$(native_path "$1")
-  escape_path "$unescaped"    
+  escape_path "$unescaped"
 }
 
 # Compare 2 lists which are newline-delimited in a string, ignoring ordering and blank lines

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -426,8 +426,14 @@ contains_same_elements() {
   exit $res
 }
 
-
 is_stdin_attached() {
   test -t0
   echo $?
+}
+
+has_test_dir() {
+  if [ -z "$GIT_LFS_TEST_DIR" ]; then
+    echo "No GIT_LFS_TEST_DIR. Skipping..."
+    exit 0
+  fi
 }

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -75,7 +75,7 @@ begin_test () {
     err="$TRASHDIR/err"
     trace="$TRASHDIR/trace"
 
-    exec 1>"$out" 2>"$err" 
+    exec 1>"$out" 2>"$err"
 
     # enabling GIT_TRACE can cause Windows git to stall, esp with fd 5
     # other fd numbers like 8/9 don't stall but still don't work, so disable


### PR DESCRIPTION
Replace 3 highly compact shell lines in `script/integration` with 100 lines of go code. It uses goroutines to manage the concurrency, and a channel to ensure output is dumped to stdout without race conditions.

/cc @andyneff @rubyist @sinbad 