### PR TITLE
Make sure we don't accidentally run *.sh.orig (merge remnants) in test

### DIFF
--- a/script/integration.go
+++ b/script/integration.go
@@ -13,7 +13,7 @@ import (
 var (
 	erroring    = false
 	maxprocs    = 4
-	testPattern = regexp.MustCompile(`test/test-([a-z\-]+)\.sh`)
+	testPattern = regexp.MustCompile(`test/test-([a-z\-]+)\.sh$`)
 )
 
 func mainIntegration() {


### PR DESCRIPTION
I had a failure after #790 but it was because I had an old .orig file in my test dir from a previous rebase conflict.