### PR TITLE
Fix windows integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,17 @@
 * Improved default remote behaviour & validation for fetch/pull #713 (@sinbad)
 * Make fetch return error code when 1+ downloads failed #734 (@sinbad)
 * Improve lfs.InRepo() detection in `init`/`update` #756 (@technoweenie)
-* whitelist the valid keys read from .gitconfig #760 (@technoweenie)
 * Teach smudge to use the batch api #711 (@rubyist)
 * Fix not setting global attribute when needed to b/c of local state #765 (@sinbad)
 * Fix clone fail when fetch is excluded globally #770 (@sinbad)
 * Fix for partial downloads problem #763 (@technoweenie)
 * Get integration tests passing on Windows #771 (@sinbad)
+
+### Security
+
+* Whitelist the valid keys read from .gitconfig #760 (@technoweenie)
+
+This prevents unsafe git configuration values from being used by Git LFS.
 
 ## v1.0 (1 October, 2015)
 

--- a/script/integration.go
+++ b/script/integration.go
@@ -11,12 +11,17 @@ import (
 )
 
 var (
+	debugging   = false
 	erroring    = false
 	maxprocs    = 4
 	testPattern = regexp.MustCompile(`test/test-([a-z\-]+)\.sh$`)
 )
 
 func mainIntegration() {
+	if len(os.Getenv("DEBUG")) > 0 {
+		debugging = true
+	}
+
 	if maxprocs < 1 {
 		maxprocs = 1
 	}
@@ -111,8 +116,15 @@ func testFiles() []string {
 func allTestFiles() []string {
 	files := make([]string, 0, 100)
 	filepath.Walk("test", func(path string, info os.FileInfo, err error) error {
+		if debugging {
+			fmt.Println("FOUND:", path)
+		}
 		if err != nil || info.IsDir() || !testPattern.MatchString(path) {
 			return nil
+		}
+
+		if debugging {
+			fmt.Println("MATCHING:", path)
 		}
 		files = append(files, path)
 		return nil

--- a/script/integration.go
+++ b/script/integration.go
@@ -14,7 +14,7 @@ var (
 	debugging   = false
 	erroring    = false
 	maxprocs    = 4
-	testPattern = regexp.MustCompile(`test/test-([a-z\-]+)\.sh$`)
+	testPattern = regexp.MustCompile(`test[/\\]test-([a-z\-]+)\.sh$`)
 )
 
 func mainIntegration() {

--- a/script/integration.go
+++ b/script/integration.go
@@ -11,6 +11,7 @@ import (
 )
 
 var (
+	bashPath    string
 	debugging   = false
 	erroring    = false
 	maxprocs    = 4
@@ -21,6 +22,8 @@ func mainIntegration() {
 	if len(os.Getenv("DEBUG")) > 0 {
 		debugging = true
 	}
+
+	setBash()
 
 	if maxprocs < 1 {
 		maxprocs = 1
@@ -58,7 +61,7 @@ func mainIntegration() {
 }
 
 func runTest(output chan string, test string) {
-	out, err := exec.Command("/bin/bash", test).CombinedOutput()
+	out, err := exec.Command(bashPath, test).CombinedOutput()
 	if err != nil {
 		erroring = true
 	}
@@ -130,4 +133,17 @@ func allTestFiles() []string {
 		return nil
 	})
 	return files
+}
+
+func setBash() {
+	out, err := exec.Command("which", "bash").Output()
+	if err != nil {
+		fmt.Println("Unable to find bash:", err)
+		os.Exit(1)
+	}
+
+	bashPath = strings.TrimSpace(string(out))
+	if debugging {
+		fmt.Println("Using", bashPath)
+	}
 }

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -6,6 +6,8 @@ packagecloud_token = ENV["PACKAGECLOUD_TOKEN"] || begin
   exit 1
 end
 
+require "json"
+
 begin
   require "packagecloud"
 rescue LoadError

--- a/test/test-happy-path.sh
+++ b/test/test-happy-path.sh
@@ -4,41 +4,6 @@
 
 . "test/testlib.sh"
 
-begin_test "clears local temp objects"
-(
-  set -e
-
-  mkdir repo-temp-objects
-  cd repo-temp-objects
-  git init
-
-  # abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01
-  mkdir -p .git/lfs/objects/go/od
-  mkdir -p .git/lfs/tmp/objects
-
-  touch .git/lfs/objects/go/od/goodabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx
-  touch .git/lfs/tmp/objects/goodabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx-rand123
-  touch .git/lfs/tmp/objects/goodabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx-rand456
-  touch .git/lfs/tmp/objects/badabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxy-rand123
-  touch .git/lfs/tmp/objects/badabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxy-rand456
-
-  GIT_TRACE=5 git lfs env
-
-  # object file exists
-  [ -e ".git/lfs/objects/go/od/goodabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx" ]
-
-  # newer tmp files exist
-  [ -e ".git/lfs/tmp/objects/badabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxy-rand123" ]
-  [ -e ".git/lfs/tmp/objects/badabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxy-rand456" ]
-
-  # existing tmp files were cleaned up
-  [ ! -e ".git/lfs/tmp/objects/goodabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx-rand123" ]
-  [ ! -e ".git/lfs/tmp/objects/goodabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx-rand456" ]
-)
-end_test
-
-exit 0
-
 begin_test "happy path"
 (
   set -e
@@ -96,5 +61,38 @@ begin_test "happy path"
   [ "a" = "$(cat a.dat)" ]
 
   assert_pointer "master" "a.dat" "$contents_oid" 1
+)
+end_test
+
+begin_test "clears local temp objects"
+(
+  set -e
+
+  mkdir repo-temp-objects
+  cd repo-temp-objects
+  git init
+
+  # abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01
+  mkdir -p .git/lfs/objects/go/od
+  mkdir -p .git/lfs/tmp/objects
+
+  touch .git/lfs/objects/go/od/goodabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx
+  touch .git/lfs/tmp/objects/goodabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx-rand123
+  touch .git/lfs/tmp/objects/goodabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx-rand456
+  touch .git/lfs/tmp/objects/badabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxy-rand123
+  touch .git/lfs/tmp/objects/badabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxy-rand456
+
+  GIT_TRACE=5 git lfs env
+
+  # object file exists
+  [ -e ".git/lfs/objects/go/od/goodabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx" ]
+
+  # newer tmp files exist
+  [ -e ".git/lfs/tmp/objects/badabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxy-rand123" ]
+  [ -e ".git/lfs/tmp/objects/badabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxy-rand456" ]
+
+  # existing tmp files were cleaned up
+  [ ! -e ".git/lfs/tmp/objects/goodabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx-rand123" ]
+  [ ! -e ".git/lfs/tmp/objects/goodabcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx-rand456" ]
 )
 end_test


### PR DESCRIPTION
`script/integration.go` doesn't work on Windows. This fixes the easy bugs:

* file patterns didn't use back slashes
* use `which` to find the correct bash path

It still shows no output for each test though.