### PR TITLE
teach 'git lfs smudge' to send the expected size to the LFS api

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -108,12 +108,15 @@ func (e *ClientError) Error() string {
 // Download will attempt to download the object with the given oid. The batched
 // API will be used, but if the server does not implement the batch operations
 // it will fall back to the legacy API.
-func Download(oid string) (io.ReadCloser, int64, error) {
+func Download(oid string, size int64) (io.ReadCloser, int64, error) {
 	if !Config.BatchTransfer() {
 		return DownloadLegacy(oid)
 	}
 
-	objects := []*objectResource{&objectResource{Oid: oid}}
+	objects := []*objectResource{
+		&objectResource{Oid: oid, Size: size},
+	}
+
 	objs, err := Batch(objects, "download")
 	if err != nil {
 		if IsNotImplementedError(err) {

--- a/lfs/download_test.go
+++ b/lfs/download_test.go
@@ -87,7 +87,7 @@ func TestSuccessfulDownload(t *testing.T) {
 	Config.SetConfig("lfs.batch", "false")
 	Config.SetConfig("lfs.url", server.URL+"/media")
 
-	reader, size, err := Download("oid")
+	reader, size, err := Download("oid", 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -219,7 +219,7 @@ func TestSuccessfulDownloadWithRedirects(t *testing.T) {
 	Config.SetConfig("lfs.url", server.URL+"/redirect")
 
 	for _, redirect := range redirectCodes {
-		reader, size, err := Download("oid")
+		reader, size, err := Download("oid", 0)
 		if err != nil {
 			t.Fatalf("unexpected error for %d status: %s", redirect, err)
 		}
@@ -324,7 +324,7 @@ func TestSuccessfulDownloadWithAuthorization(t *testing.T) {
 	defer Config.ResetConfig()
 	Config.SetConfig("lfs.batch", "false")
 	Config.SetConfig("lfs.url", server.URL+"/media")
-	reader, size, err := Download("oid")
+	reader, size, err := Download("oid", 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -425,7 +425,7 @@ func TestSuccessfulDownloadFromSeparateHost(t *testing.T) {
 	defer Config.ResetConfig()
 	Config.SetConfig("lfs.batch", "false")
 	Config.SetConfig("lfs.url", server.URL+"/media")
-	reader, size, err := Download("oid")
+	reader, size, err := Download("oid", 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -559,7 +559,7 @@ func TestSuccessfulDownloadFromSeparateRedirectedHost(t *testing.T) {
 	Config.SetConfig("lfs.url", server.URL+"/media")
 
 	for _, redirect := range redirectCodes {
-		reader, size, err := Download("oid")
+		reader, size, err := Download("oid", 0)
 		if err != nil {
 			t.Fatalf("unexpected error for %d status: %s", redirect, err)
 		}
@@ -595,7 +595,7 @@ func TestDownloadAPIError(t *testing.T) {
 	defer Config.ResetConfig()
 	Config.SetConfig("lfs.batch", "false")
 	Config.SetConfig("lfs.url", server.URL+"/media")
-	_, _, err := Download("oid")
+	_, _, err := Download("oid", 0)
 	if err == nil {
 		t.Fatal("no error?")
 	}
@@ -664,7 +664,7 @@ func TestDownloadStorageError(t *testing.T) {
 	defer Config.ResetConfig()
 	Config.SetConfig("lfs.batch", "false")
 	Config.SetConfig("lfs.url", server.URL+"/media")
-	_, _, err := Download("oid")
+	_, _, err := Download("oid", 0)
 	if err == nil {
 		t.Fatal("no error?")
 	}

--- a/lfs/pointer_smudge.go
+++ b/lfs/pointer_smudge.go
@@ -119,7 +119,7 @@ func downloadObject(ptr *Pointer, obj *objectResource, mediafile string, cb Copy
 
 func downloadFile(writer io.Writer, ptr *Pointer, workingfile, mediafile string, cb CopyCallback) error {
 	fmt.Fprintf(os.Stderr, "Downloading %s (%s)\n", workingfile, pb.FormatBytes(ptr.Size))
-	reader, size, err := Download(filepath.Base(mediafile))
+	reader, size, err := Download(filepath.Base(mediafile), ptr.Size)
 	if reader != nil {
 		defer reader.Close()
 	}


### PR DESCRIPTION
This fixes a devious bug that affects strict LFS API servers that verify the size of objects before it lets you download them. 

The update is hopefully temporary, until we refactor the API client as described in https://github.com/github/git-lfs/issues/779.

You can see this at play with `GIT_CURL_VERBOSE`:

```bash
# manually triggering the smudge command
$ git cat-file -p 1bca198451cc7404e257e5abe60a8478bf28d4cf | GIT_CURL_VERBOSE=1 git lfs smudge
Downloading ... (73.53 KB)
> POST /github/git-lfs-test.git/info/lfs/objects/batch HTTP/1.1
> Accept: application/vnd.git-lfs+json; charset=utf-8
> Authorization: Basic abcdef
> Content-Type: application/vnd.git-lfs+json; charset=utf-8
> User-Agent: git-lfs/1.0.1 (GitHub; darwin amd64; go 1.5.1; git a999185)
>
{"objects":[{"oid":"e1732d149d262963996ca77a47a5d3c51c85c6e97187afad370a8bef2828b6b7","size":0}],"operation":"download"}
```

Here it is with the fix:

```bash
$ git cat-file -p 1bca198451cc7404e257e5abe60a8478bf28d4cf | GIT_CURL_VERBOSE=1 ~p/git-lfs/bin/git-lfs smudge
Downloading ... (73.53 KB)
> POST /github/git-lfs-test.git/info/lfs/objects/batch HTTP/1.1
> Accept: application/vnd.git-lfs+json; charset=utf-8
> Authorization: Basic abcdef
> Content-Type: application/vnd.git-lfs+json; charset=utf-8
> User-Agent: git-lfs/1.0.1 (GitHub; darwin amd64; go 1.5.1; git 25bbe79)
>
{"objects":[{"oid":"e1732d149d262963996ca77a47a5d3c51c85c6e97187afad370a8bef2828b6b7","size":75291}],"operation":"download"}
```