### PR TITLE
Docker and rpm updates

### DIFF
--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -7,7 +7,7 @@
 #
 # Special Environmet Variables
 #  REPO_HOSTNAME - Override the hostname for all the repos generated/tested
-#  DOCKER_AUTOBUILD - Default 1. If set to 0, it will not build docker images 
+#  DOCKER_AUTOPULL - Default 1. If set to 0, it will not build docker images 
 #                before running
 #  AUTO_REMOVE - Default 1. If set to 0, it will not automatically delete the
 #                docker instance when done. This can be useful for a post mortem
@@ -63,10 +63,11 @@ mkdir -p "${PACKAGE_DIR}"
 for DOCKER_FILE in "${IMAGES[@]}"; do
   split_image_name "${DOCKER_FILE}" #set IMAGE_NAME and IMAGE_INFO
 
-  #Auto build docker unless DOCKER_AUTOBUILD=0
-  #if [[ ${DOCKER_AUTOBUILD-1} != 0 ]]; then
-  #  ${CUR_DIR}/build_dockers.bsh ${DOCKER_FILE}
-  #fi
+  #Auto pull docker unless DOCKER_AUTOPULL=0
+  if [[ ${DOCKER_AUTOPULL-1} != 0 ]]; then
+    $SUDO docker pull andyneff/build_git-lfs:${IMAGE_NAME}
+    #${CUR_DIR}/build_dockers.bsh ${DOCKER_FILE}
+  fi
 
   #It CAN'T be empty () with set -u... So I put some defaults in here
   OTHER_OPTIONS=("-it")

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -40,8 +40,12 @@ mkdir -p -m 755 ${RPM_BUILD_ROOT}/usr/share/man/man1
 install -D man/*.1 ${RPM_BUILD_ROOT}/usr/share/man/man1
 
 %check
-GOPATH=`pwd` ./script/test
-GOPATH=`pwd` ./script/integration
+export GOPATH=`pwd`
+export GIT_LFS_TEST_DIR=`pwd`/test_dir
+mkdir -p $GIT_LFS_TEST_DIR
+
+./script/test
+./script/integration
 
 %clean
 rm -rf %{buildroot}

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -41,11 +41,12 @@ install -D man/*.1 ${RPM_BUILD_ROOT}/usr/share/man/man1
 
 %check
 export GOPATH=`pwd`
-export GIT_LFS_TEST_DIR=`pwd`/test_dir
-mkdir -p $GIT_LFS_TEST_DIR
+export GIT_LFS_TEST_DIR=$(mktemp -d)
 
 ./script/test
 ./script/integration
+
+rmdir ${GIT_LFS_TEST_DIR}
 
 %clean
 rm -rf %{buildroot}
@@ -57,6 +58,9 @@ rm -rf %{buildroot}
 /usr/share/man/man1/*.1.gz
 
 %changelog
+* Sat Oct 31 2015 Andrew Neff <andyneff@users.noreply.github.com> - 1.0.3-1
+- Added GIT_LFS_TEST_DIR to prevent future test race condition
+
 * Sun Aug 2 2015 Andrew Neff <andyneff@users.noreply.github.com> - 0.5.4-1
 - Added tests back in
 

--- a/rpm/build_rpms.bsh
+++ b/rpm/build_rpms.bsh
@@ -35,15 +35,9 @@ RPMBUILD=(rpmbuild --define "_topdir ${CURDIR}" --define "dist ${RPM_DIST}")
 if [[ ${NODEPS:-0} != 0 ]]; then
   RPMBUILD=("${RPMBUILD[@]}" --nodeps)
 fi
-LOG=${CURDIR}/build.log
+
 SUDO=${SUDO=`if which sudo > /dev/null 2>&1; then echo sudo; fi`}
 export PATH=${PATH}:/usr/local/bin
-
-exec 6>&1
-exec 7>&2
-
-exec > $LOG
-exec 2>> $LOG
 
 set -vx
 

--- a/rpm/build_rpms.bsh
+++ b/rpm/build_rpms.bsh
@@ -41,7 +41,7 @@ export PATH=${PATH}:/usr/local/bin
 
 set -vx
 
-echo "Downloading/checking for some essentials..." >&6
+echo "Downloading/checking for some essentials..."
 if which git > /dev/null 2>&1; then
   GIT_VERSION=($(git --version))
   IFS_OLD=${IFS}
@@ -81,7 +81,7 @@ if ( [[ ${GIT_VERSION[0]} == 1 ]] && [[ ${GIT_VERSION[1]} < 8 ]] ) || [[ ${GIT_V
 fi
 
 if ! which go; then
-  echo "Installing go... one way or another" >&6
+  echo "Installing go... one way or another"
   if [[ ${VERSION_ID[0]} == 5 ]]; then
     $SUDO yum install -y curl.x86_64 glibc gcc
     ${CURDIR}/golang_patch.bsh
@@ -108,7 +108,7 @@ fi
 
 if [[ ${RUBY_VERSION[0]} < 2 ]]; then
   if [[ ${VERSION_ID[0]} < 7 ]]; then
-    echo "Downloading ruby..." >&6
+    echo "Downloading ruby..."
 
     if ! rpm -q epel-release; then
       $SUDO yum install -y epel-release #Optional part of centos
@@ -118,9 +118,9 @@ if [[ ${RUBY_VERSION[0]} < 2 ]]; then
     pushd ${CURDIR}/SOURCES
       curl -L -O http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.gz
     popd
-    echo "Building ruby..." >&6
+    echo "Building ruby..."
     "${RPMBUILD[@]}" -ba ${CURDIR}/SPECS/ruby.spec
-    echo "Installing ruby..." >&6
+    echo "Installing ruby..."
     $SUDO yum install -y --nogpgcheck ${CURDIR}/RPMS/x86_64/ruby*.rpm
   else
     $SUDO yum install -y ruby ruby-devel
@@ -128,7 +128,7 @@ if [[ ${RUBY_VERSION[0]} < 2 ]]; then
 fi
 
 if ! which ronn; then
-  echo "Downloading some ruby gems..." >&6
+  echo "Downloading some ruby gems..."
   pushd ${CURDIR}/SOURCES
     curl -L -O https://rubygems.org/downloads/rdiscount-2.1.8.gem
     curl -L -O https://rubygems.org/downloads/hpricot-0.8.6.gem
@@ -136,13 +136,13 @@ if ! which ronn; then
     curl -L -O https://rubygems.org/downloads/ronn-0.7.3.gem
   popd
 
-  echo "Building ruby gems..." >&6
+  echo "Building ruby gems..."
   "${RPMBUILD[@]}" -ba ${CURDIR}/SPECS/rubygem-rdiscount.spec
   "${RPMBUILD[@]}" -ba ${CURDIR}/SPECS/rubygem-mustache.spec
   "${RPMBUILD[@]}" -ba ${CURDIR}/SPECS/rubygem-hpricot.spec
   "${RPMBUILD[@]}" -ba ${CURDIR}/SPECS/rubygem-ronn.spec
 
-  echo "Installing ruby gems..." >&6
+  echo "Installing ruby gems..."
   $SUDO yum install -y --nogpgcheck $(ls ${CURDIR}/RPMS/noarch/rubygem-*.rpm ${CURDIR}/RPMS/x86_64/rubygem-*.rpm | grep -v debuginfo)
 fi
 
@@ -159,7 +159,7 @@ pushd ${CURDIR}/..
 popd
 
 #Prep the SOURCES dir for git-lfs
-echo "Zipping up current checkout of git-lfs..." >&6
+echo "Zipping up current checkout of git-lfs..."
   
 rm -rvf ${CURDIR}/tmptar
 mkdir -p ${CURDIR}/tmptar/git-lfs-${LFS_VERSION}
@@ -181,9 +181,9 @@ rm -rvf ${CURDIR}/tmptar
 touch ${CURDIR}/SOURCES/RPM-GPG-KEY-GITLFS
 
 
-echo "Build git-lfs rpm..." >&6
+echo "Build git-lfs rpm..."
 
 #--no-deps added for now so you can compile without offical rpms installed
 "${RPMBUILD[@]}" --nodeps -ba ${CURDIR}/SPECS/git-lfs.spec
 
-echo "All Done!" >&6
+echo "All Done!"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -7,7 +7,7 @@ if [ -z "$GOPATH" ] && uname -s | grep -vq "_NT-"; then
   export GOPATH="$(pwd)"
   mkdir -p src/github.com/github
   [ -h src/github.com/github/git-lfs ] ||
-    ln -sf "$GOPATH" src/github.com/github/git-lfs
+    ln -s "$GOPATH" src/github.com/github/git-lfs
 fi
 
 script/fmt

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -7,7 +7,7 @@ if [ -z "$GOPATH" ] && uname -s | grep -vq "_NT-"; then
   export GOPATH="$(pwd)"
   mkdir -p src/github.com/github
   [ -h src/github.com/github/git-lfs ] ||
-    ln -s "$GOPATH" src/github.com/github/git-lfs
+    ln -sf "$GOPATH" src/github.com/github/git-lfs
 fi
 
 script/fmt


### PR DESCRIPTION
- `run_dockers.bsh` can now auto pull the latest docker images
- More verbose (and un cut) output of 64 bit rpm builds build. No more redirect to `build.log`
- RPMs use GIT_LFS_TEST_DIR in %check