### PR TITLE
NTLM: cloneable body

### DIFF
--- a/lfs/ntlm_test.go
+++ b/lfs/ntlm_test.go
@@ -132,7 +132,7 @@ func TestCloneBigBody(t *testing.T) {
 }
 
 func assertCloneableBody(t *testing.T, cloneable *cloneableBody, expectedBody, expectedBuffer string) {
-	buffer := string(cloneable.b)
+	buffer := string(cloneable.bytes)
 	if buffer != expectedBuffer {
 		t.Errorf("Expected buffer %q, got %q", expectedBody, buffer)
 	}


### PR DESCRIPTION
This is a proposal to merge into #820. It's complicated enough that I think it could use its own review.

Instead of buffering the entire request body into an in-memory byte buffer, this uses an internal `cloneableBody` type that only buffers up to 1MB. Any overflow is then written to a local temp file. This type can also clone itself without reading the body again. It simply creates a new struct with the same 1MB byte buffer, and re-opens the temp file.

Also, assuming all file handles are properly closed, a `cloneableBody` buffer will only delete the tempfile when the last one is closed. 