### PR TITLE
Mixed use of real_paths and symlink paths

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -55,8 +55,7 @@ func trackCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	wd, _ := os.Getwd()
-	wd, _ = filepath.EvalSymlinks(wd)
+	wd, _ := lfs.Getwd()
 
 ArgsLoop:
 	for _, t := range args {
@@ -92,8 +91,7 @@ type mediaPath struct {
 
 func findPaths() []mediaPath {
 	paths := make([]mediaPath, 0)
-	wd, _ := os.Getwd()
-	wd, _ = filepath.EvalSymlinks(wd)
+	wd, _ := lfs.Getwd()
 
 	for _, path := range findAttributeFiles() {
 		attributes, err := os.Open(path)

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -56,6 +56,7 @@ func trackCommand(cmd *cobra.Command, args []string) {
 	}
 
 	wd, _ := os.Getwd()
+	wd, _ = filepath.EvalSymlinks(wd)
 
 ArgsLoop:
 	for _, t := range args {
@@ -92,6 +93,7 @@ type mediaPath struct {
 func findPaths() []mediaPath {
 	paths := make([]mediaPath, 0)
 	wd, _ := os.Getwd()
+	wd, _ = filepath.EvalSymlinks(wd)
 
 	for _, path := range findAttributeFiles() {
 		attributes, err := os.Open(path)

--- a/git/git.go
+++ b/git/git.go
@@ -459,8 +459,8 @@ func RootDir() (string, error) {
 		return filepath.Abs(path)
 	}
 	return "", nil
-
 }
+
 func GitDir() (string, error) {
 	cmd := execCommand("git", "rev-parse", "--git-dir")
 	out, err := cmd.Output()
@@ -469,7 +469,11 @@ func GitDir() (string, error) {
 	}
 	path := strings.TrimSpace(string(out))
 	if len(path) > 0 {
-		return filepath.Abs(path)
+		path, err = filepath.Abs(path)
+		if err == nil {
+			path, err = filepath.EvalSymlinks(path)
+		}
+		return path, err
 	}
 	return "", nil
 

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -170,7 +170,7 @@ func processGitDirVar(gitDir, workTree string) (string, string, error) {
 	// core.worktree is specified, the current working directory is regarded as the top
 	// level of your working tree.”
 
-	wd, err := os.Getwd()
+	wd, err := Getwd()
 	if err != nil {
 		return "", "", err
 	}

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -193,7 +193,7 @@ func GetPlatform() Platform {
 // but the user is in a subdir of their repo
 // Pass in a channel which you will fill with relative files & receive a channel which will get results
 func ConvertRepoFilesRelativeToCwd(repochan <-chan string) (<-chan string, error) {
-	wd, err := os.Getwd()
+	wd, err := Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("Unable to get working dir: %v", err)
 	}
@@ -232,7 +232,7 @@ func ConvertRepoFilesRelativeToCwd(repochan <-chan string) (<-chan string, error
 // to be rooted but the user is in a subdir of their repo & expects to use relative args
 // Pass in a channel which you will fill with relative files & receive a channel which will get results
 func ConvertCwdFilesRelativeToRepo(cwdchan <-chan string) (<-chan string, error) {
-	curdir, err := os.Getwd()
+	curdir, err := Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("Could not retrieve current directory: %v", err)
 	}
@@ -307,4 +307,13 @@ func FileExistsOfSize(path string, sz int64) bool {
 	}
 
 	return !fi.IsDir() && fi.Size() == sz
+}
+
+// Getwd return Current Working Directory with all symlink resolved.
+func Getwd() (string, error) {
+	path, err := os.Getwd()
+	if err == nil {
+		path, err = filepath.EvalSymlinks(path)
+	}
+	return path, err
 }


### PR DESCRIPTION
Some paths are real paths (all symlinks are resolved) like LocalWorkingDir and git.RootDir(),
which are from the command `git rev-parse --show-toplevel`. But others (like LocalGitDir and
may others from os.Getwd() are not.  This is why when `git lfs trace foo` on a symlink worktree,
will stop by:

    foo is outside repository

I found there is a similar PR #818 , maybe can be merged together. @sinbad 

