### PR TITLE
use .lfsconfig (with fallback to .gitconfig)

### DIFF
--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -14,6 +14,7 @@ var (
 )
 
 func envCommand(cmd *cobra.Command, args []string) {
+	lfs.ShowConfigWarnings = true
 	config := lfs.Config
 	endpoint := config.Endpoint()
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -128,8 +128,10 @@ of rules that Git LFS uses to determine a repository's Git LFS server:
 Git LFS runs two `git config` commands to build up the list of values that it
 uses:
 
-1. `git config -l -f .gitconfig` - This file is checked into the repository and
-can set defaults for every user that clones the repository.
+1. `git config -l -f .lfsconfig` - This file is checked into the repository and
+can set defaults for every user that clones the repository. Note: Git LFS used
+".gitconfig" instead of ".lfsconfig" until Git LFS v1.1. Git LFS will continue
+to read ".gitconfig" if ".lfsconfig" does not exist until Git LFS v2.0.
 2. `git config -l` - A user's local git configuration can override any settings
 from `.gitconfig`.
 
@@ -201,5 +203,3 @@ $ cat .gitattributes
 ```
 
 Use the `git lfs track` command to view and add to `.gitattributes`.
-
-

--- a/git/git.go
+++ b/git/git.go
@@ -280,9 +280,6 @@ func (c *gitConfig) List() (string, error) {
 
 // ListFromFile lists all of the git config values in the given config file
 func (c *gitConfig) ListFromFile(f string) (string, error) {
-	if _, err := os.Stat(f); os.IsNotExist(err) {
-		return "", nil
-	}
 	return simpleExec("git", "config", "-l", "-f", f)
 }
 

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -360,6 +360,12 @@ func (c *Configuration) readGitConfigFromFiles(filenames []string, filenameIndex
 	filename := filenames[filenameIndex]
 	_, err := os.Stat(filename)
 	if err == nil {
+		if filenameIndex > 0 && ShowConfigWarnings {
+			expected := ".lfsconfig"
+			fmt.Fprintf(os.Stderr, "WARNING: Reading LFS config from %q, not %q. Rename to %q before Git LFS v2.0 to remove this warning.\n",
+				filepath.Base(filename), expected, expected)
+		}
+
 		fileOutput, err := git.Config.ListFromFile(filename)
 		if err != nil {
 			panic(fmt.Errorf("Error listing git config from %s: %s", filename, err))
@@ -371,11 +377,6 @@ func (c *Configuration) readGitConfigFromFiles(filenames []string, filenameIndex
 	if os.IsNotExist(err) {
 		newIndex := filenameIndex + 1
 		if len(filenames) > newIndex {
-			if ShowConfigWarnings {
-				expected := ".lfsconfig"
-				fmt.Fprintf(os.Stderr, "WARNING: Reading LFS config from %q, not %q. Rename to %q before Git LFS v2.0 to remove this warning.\n",
-					filepath.Base(filenames[newIndex]), expected, expected)
-			}
 			c.readGitConfigFromFiles(filenames, newIndex, uniqRemotes)
 		}
 		return

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -331,6 +331,8 @@ func (c *Configuration) loadGitConfig() bool {
 
 	configFiles := []string{
 		filepath.Join(LocalWorkingDir, ".lfsconfig"),
+
+		// TODO: remove .gitconfig support for Git LFS v2.0
 		filepath.Join(LocalWorkingDir, ".gitconfig"),
 	}
 	c.readGitConfigFromFiles(configFiles, 0, uniqRemotes)
@@ -368,6 +370,9 @@ func (c *Configuration) readGitConfigFromFiles(filenames []string, filenameIndex
 	if os.IsNotExist(err) {
 		newIndex := filenameIndex + 1
 		if len(filenames) > newIndex {
+			expected := ".lfsconfig"
+			fmt.Fprintf(os.Stderr, "WARNING: Reading LFS config from %q, not %q. Rename to %q before Git LFS v2.0 to remove this warning.\n",
+				filepath.Base(filenames[newIndex]), expected, expected)
 			c.readGitConfigFromFiles(filenames, newIndex, uniqRemotes)
 		}
 		return

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -386,6 +386,8 @@ func (c *Configuration) readGitConfigFromFiles(filenames []string, filenameIndex
 
 func (c *Configuration) readGitConfig(output string, uniqRemotes map[string]bool, onlySafe bool) {
 	lines := strings.Split(output, "\n")
+	uniqKeys := make(map[string]string)
+
 	for _, line := range lines {
 		pieces := strings.SplitN(line, "=", 2)
 		if len(pieces) < 2 {
@@ -395,6 +397,12 @@ func (c *Configuration) readGitConfig(output string, uniqRemotes map[string]bool
 		allowed := !onlySafe
 		key := strings.ToLower(pieces[0])
 		value := pieces[1]
+
+		if origKey, ok := uniqKeys[key]; ok {
+			fmt.Fprintf(os.Stderr, "WARNING: The %q value clashes with the existing %q value.\n", pieces[0], origKey)
+		} else {
+			uniqKeys[key] = pieces[0]
+		}
 
 		keyParts := strings.Split(key, ".")
 		if len(keyParts) == 4 && keyParts[0] == "lfs" && keyParts[1] == "extension" {

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -333,7 +333,7 @@ func (c *Configuration) loadGitConfig() bool {
 	configFiles := []string{
 		filepath.Join(LocalWorkingDir, ".lfsconfig"),
 
-		// TODO: remove .gitconfig support for Git LFS v2.0
+		// TODO: remove .gitconfig support for Git LFS v2.0 https://github.com/github/git-lfs/issues/839
 		filepath.Join(LocalWorkingDir, ".gitconfig"),
 	}
 	c.readGitConfigFromFiles(configFiles, 0, uniqRemotes)

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -398,8 +398,10 @@ func (c *Configuration) readGitConfig(output string, uniqRemotes map[string]bool
 		key := strings.ToLower(pieces[0])
 		value := pieces[1]
 
-		if origKey, ok := uniqKeys[key]; ok {
-			fmt.Fprintf(os.Stderr, "WARNING: The %q value clashes with the existing %q value.\n", pieces[0], origKey)
+		if origKey, ok := uniqKeys[key]; ok && c.gitConfig[key] != value {
+			fmt.Fprintf(os.Stderr, "WARNING: These git config values clash:\n")
+			fmt.Fprintf(os.Stderr, "  git config %q = %q\n", origKey, c.gitConfig[key])
+			fmt.Fprintf(os.Stderr, "  git config %q = %q\n", pieces[0], value)
 		} else {
 			uniqKeys[key] = pieces[0]
 		}

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -16,8 +16,9 @@ import (
 )
 
 var (
-	Config        = NewConfig()
-	defaultRemote = "origin"
+	Config             = NewConfig()
+	defaultRemote      = "origin"
+	ShowConfigWarnings = false
 )
 
 // FetchPruneConfig collects together the config options that control fetching and pruning
@@ -370,9 +371,11 @@ func (c *Configuration) readGitConfigFromFiles(filenames []string, filenameIndex
 	if os.IsNotExist(err) {
 		newIndex := filenameIndex + 1
 		if len(filenames) > newIndex {
-			expected := ".lfsconfig"
-			fmt.Fprintf(os.Stderr, "WARNING: Reading LFS config from %q, not %q. Rename to %q before Git LFS v2.0 to remove this warning.\n",
-				filepath.Base(filenames[newIndex]), expected, expected)
+			if ShowConfigWarnings {
+				expected := ".lfsconfig"
+				fmt.Fprintf(os.Stderr, "WARNING: Reading LFS config from %q, not %q. Rename to %q before Git LFS v2.0 to remove this warning.\n",
+					filepath.Base(filenames[newIndex]), expected, expected)
+			}
 			c.readGitConfigFromFiles(filenames, newIndex, uniqRemotes)
 		}
 		return

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -13,13 +13,14 @@ begin_test "default config"
   git lfs env | tee env.log
   grep "Endpoint=$GITSERVER/$reponame.git/info/lfs (auth=none)" env.log
 
-  git config --file=.gitconfig lfs.url http://gitconfig-file
+  git config --file=.gitconfig lfs.url http://gitconfig-file-ignored
+  git config --file=.lfsconfig lfs.url http://lfsconfig-file
   git lfs env | tee env.log
-  grep "Endpoint=http://gitconfig-file (auth=none)" env.log
+  grep "Endpoint=http://lfsconfig-file (auth=none)" env.log
 
-  git config lfs.url http://local-gitconfig
+  git config lfs.url http://local-lfsconfig
   git lfs env | tee env.log
-  grep "Endpoint=http://local-gitconfig (auth=none)" env.log
+  grep "Endpoint=http://local-lfsconfig (auth=none)" env.log
 )
 end_test
 
@@ -32,6 +33,73 @@ begin_test "extension config"
   git config --global lfs.extension.env-test.priority 0
 
   reponame="extension-config"
+  mkdir $reponame
+  cd $reponame
+  git init
+
+  expected0="Extension: env-test
+    clean = env-test-clean
+    smudge = env-test-smudge
+    priority = 0"
+
+  [ "$expected0" = "$(git lfs ext)" ]
+
+  # any git config takes precedence over .lfsconfig
+  git config --global --unset lfs.extension.env-test.priority
+
+  git config --file=.lfsconfig lfs.extension.env-test.clean "file-env-test-clean"
+  git config --file=.lfsconfig lfs.extension.env-test.smudge "file-env-test-smudge"
+  git config --file=.lfsconfig lfs.extension.env-test.priority 1
+  cat .lfsconfig
+  expected1="Extension: env-test
+    clean = env-test-clean
+    smudge = env-test-smudge
+    priority = 1"
+
+  [ "$expected1" = "$(GIT_TRACE=5 git lfs ext)" ]
+
+  git config lfs.extension.env-test.clean "local-env-test-clean"
+  git config lfs.extension.env-test.smudge "local-env-test-smudge"
+  git config lfs.extension.env-test.priority 2
+  expected2="Extension: env-test
+    clean = local-env-test-clean
+    smudge = local-env-test-smudge
+    priority = 2"
+
+  [ "$expected2" = "$(git lfs ext)" ]
+)
+end_test
+
+begin_test "default config (with gitconfig)"
+(
+  set -e
+  reponame="default-config-with-gitconfig"
+  mkdir $reponame
+  cd $reponame
+  git init
+  git remote add origin "$GITSERVER/$reponame"
+  git lfs env | tee env.log
+  grep "Endpoint=$GITSERVER/$reponame.git/info/lfs (auth=none)" env.log
+
+  git config --file=.gitconfig lfs.url http://gitconfig-file
+  git lfs env | tee env.log
+  grep "Endpoint=http://gitconfig-file (auth=none)" env.log
+
+  git config lfs.url http://local-gitconfig
+  git lfs env | tee env.log
+  grep "Endpoint=http://local-gitconfig (auth=none)" env.log
+)
+end_test
+
+begin_test "extension config (with gitconfig)"
+(
+  set -e
+
+  git config --global lfs.extension.env-test.clean "env-test-clean"
+  git config --global lfs.extension.env-test.smudge "env-test-smudge"
+  git config --global lfs.extension.env-test.priority 0
+
+  reponame="extension-config-with-gitconfig"
   mkdir $reponame
   cd $reponame
   git init


### PR DESCRIPTION
This changes Git LFS to read committed lfs config settings from `.lfsconfig` instead of `.gitconfig`. This makes it more clear what settings should go in that file. It does continue to check for `.gitconfig` but only IF `.lfsconfig` does not exist. This is meant as a way for projects to gradually rename this file on their own. By Git LFS v2.0, we'll remove support completely.

This also makes a few other changes:

* `ListFromFile()` doesn't run `os.Stat` anymore. The new `readGitConfigFromFiles()` function minimizes `os.Stat` calls.
* The config order was tweaked slightly, reducing the number of `git config` calls. No need to call `git config --list` AND `git config --file .git/config --list`. Now it only calls `git config --file .lfsconfig --list` and `git config --list`.

Fixes #780