### PR TITLE
Rename "Init" command to "install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ preferences.
 * [Binary packages are available][rel] for Windows, Mac, Linux, and FreeBSD.
 * You can build it with Go 1.5+. See the [Contributing Guide](./CONTRIBUTING.md) for instructions.
 
-Once installed, you can run `git lfs init` to setup the global Git hooks
+Once installed, you can run `git lfs install` to setup the global Git hooks
 necessary for Git LFS to work. You can get help on specific commands directly:
 
 ```bash

--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -7,7 +7,7 @@ import (
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
 )
 
-// TODO: Remove for Git LFS v2.0
+// TODO: Remove for Git LFS v2.0 https://github.com/github/git-lfs/issues/839
 
 var (
 	initCmd = &cobra.Command{

--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -7,6 +7,8 @@ import (
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
 )
 
+// TODO: Remove for Git LFS v2.0
+
 var (
 	initCmd = &cobra.Command{
 		Use: "init",

--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
-	"github.com/github/git-lfs/lfs"
+	"fmt"
+	"os"
+
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
 )
 
@@ -15,44 +17,22 @@ var (
 		Use: "hooks",
 		Run: initHooksCommand,
 	}
-
-	forceInit      = false
-	localInit      = false
-	skipSmudgeInit = false
 )
 
 func initCommand(cmd *cobra.Command, args []string) {
-	if localInit {
-		requireInRepo()
-	}
-
-	opt := lfs.InstallOptions{Force: forceInit, Local: localInit}
-	if skipSmudgeInit {
-		// assume the user is changing their smudge mode, so enable force implicitly
-		opt.Force = true
-	}
-
-	if err := lfs.InstallFilters(opt, skipSmudgeInit); err != nil {
-		Error(err.Error())
-		Exit("Run `git lfs init --force` to reset git config.")
-	}
-
-	if localInit || lfs.InRepo() {
-		initHooksCommand(cmd, args)
-	}
-
-	Print("Git LFS initialized.")
+	fmt.Fprintf(os.Stderr, "WARNING: 'git lfs init' is deprecated. Use 'git lfs install' now.\n")
+	installCommand(cmd, args)
 }
 
 func initHooksCommand(cmd *cobra.Command, args []string) {
-	updateForce = forceInit
-	updateCommand(cmd, args)
+	fmt.Fprintf(os.Stderr, "WARNING: 'git lfs init' is deprecated. Use 'git lfs install' now.\n")
+	installHooksCommand(cmd, args)
 }
 
 func init() {
-	initCmd.Flags().BoolVarP(&forceInit, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
-	initCmd.Flags().BoolVarP(&localInit, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
-	initCmd.Flags().BoolVarP(&skipSmudgeInit, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
+	initCmd.Flags().BoolVarP(&forceInstall, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
+	initCmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
+	initCmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
 	initCmd.AddCommand(initHooksCmd)
 	RootCmd.AddCommand(initCmd)
 }

--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"github.com/github/git-lfs/lfs"
+	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
+)
+
+var (
+	installCmd = &cobra.Command{
+		Use: "install",
+		Run: installCommand,
+	}
+
+	installHooksCmd = &cobra.Command{
+		Use: "hooks",
+		Run: installHooksCommand,
+	}
+
+	forceInstall      = false
+	localInstall      = false
+	skipSmudgeInstall = false
+)
+
+func installCommand(cmd *cobra.Command, args []string) {
+	if localInstall {
+		requireInRepo()
+	}
+
+	opt := lfs.InstallOptions{Force: forceInstall, Local: localInstall}
+	if skipSmudgeInstall {
+		// assume the user is changing their smudge mode, so enable force implicitly
+		opt.Force = true
+	}
+
+	if err := lfs.InstallFilters(opt, skipSmudgeInstall); err != nil {
+		Error(err.Error())
+		Exit("Run `git lfs install --force` to reset git config.")
+	}
+
+	if localInstall || lfs.InRepo() {
+		installHooksCommand(cmd, args)
+	}
+
+	Print("Git LFS initialized.")
+}
+
+func installHooksCommand(cmd *cobra.Command, args []string) {
+	updateForce = forceInstall
+	updateCommand(cmd, args)
+}
+
+func init() {
+	installCmd.Flags().BoolVarP(&forceInstall, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
+	installCmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
+	installCmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
+	installCmd.AddCommand(installHooksCmd)
+	RootCmd.AddCommand(installCmd)
+}

--- a/commands/command_uninit.go
+++ b/commands/command_uninit.go
@@ -7,7 +7,7 @@ import (
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
 )
 
-// TODO: Remove for Git LFS v2.0
+// TODO: Remove for Git LFS v2.0 https://github.com/github/git-lfs/issues/839
 
 var (
 	// uninitCmd removes any configuration and hooks set by Git LFS.

--- a/commands/command_uninit.go
+++ b/commands/command_uninit.go
@@ -7,6 +7,8 @@ import (
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
 )
 
+// TODO: Remove for Git LFS v2.0
+
 var (
 	// uninitCmd removes any configuration and hooks set by Git LFS.
 	uninitCmd = &cobra.Command{

--- a/commands/command_uninit.go
+++ b/commands/command_uninit.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
-	"github.com/github/git-lfs/lfs"
+	"fmt"
+	"os"
+
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
 )
 
@@ -20,23 +22,13 @@ var (
 )
 
 func uninitCommand(cmd *cobra.Command, args []string) {
-	if err := lfs.UninstallFilters(); err != nil {
-		Error(err.Error())
-	}
-
-	Print("Global Git LFS configuration has been removed.")
-
-	if lfs.InRepo() {
-		uninitHooksCommand(cmd, args)
-	}
+	fmt.Fprintf(os.Stderr, "WARNING: 'git lfs uninit' is deprecated. Use 'git lfs uninstall' now.\n")
+	uninstallCommand(cmd, args)
 }
 
 func uninitHooksCommand(cmd *cobra.Command, args []string) {
-	if err := lfs.UninstallHooks(); err != nil {
-		Error(err.Error())
-	}
-
-	Print("Hooks for this repository have been removed.")
+	fmt.Fprintf(os.Stderr, "WARNING: 'git lfs uninit' is deprecated. Use 'git lfs uninstall' now.\n")
+	uninstallHooksCommand(cmd, args)
 }
 
 func init() {

--- a/commands/command_uninstall.go
+++ b/commands/command_uninstall.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"github.com/github/git-lfs/lfs"
+	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
+)
+
+var (
+	// uninstallCmd removes any configuration and hooks set by Git LFS.
+	uninstallCmd = &cobra.Command{
+		Use: "uninstall",
+		Run: uninstallCommand,
+	}
+
+	// uninstallHooksCmd removes any hooks created by Git LFS.
+	uninstallHooksCmd = &cobra.Command{
+		Use: "hooks",
+		Run: uninstallHooksCommand,
+	}
+)
+
+func uninstallCommand(cmd *cobra.Command, args []string) {
+	if err := lfs.UninstallFilters(); err != nil {
+		Error(err.Error())
+	}
+
+	Print("Global Git LFS configuration has been removed.")
+
+	if lfs.InRepo() {
+		uninstallHooksCommand(cmd, args)
+	}
+}
+
+func uninstallHooksCommand(cmd *cobra.Command, args []string) {
+	if err := lfs.UninstallHooks(); err != nil {
+		Error(err.Error())
+	}
+
+	Print("Hooks for this repository have been removed.")
+}
+
+func init() {
+	uninstallCmd.AddCommand(uninstallHooksCmd)
+	RootCmd.AddCommand(uninstallCmd)
+}

--- a/docs/man/git-lfs-clean.1.ronn
+++ b/docs/man/git-lfs-clean.1.ronn
@@ -15,6 +15,6 @@ Git attributes.
 
 ## SEE ALSO
 
-git-lfs-init(1), git-lfs-push(1), gitattributes(5).
+git-lfs-install(1), git-lfs-push(1), gitattributes(5).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -111,6 +111,6 @@ lfs option can be scoped inside the configuration for a remote.
 
 ## SEE ALSO
 
-git-config(1), git-lfs-init(1), gitattributes(5).
+git-config(1), git-lfs-install(1), gitattributes(5).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-init.1.ronn
+++ b/docs/man/git-lfs-init.1.ronn
@@ -1,4 +1,4 @@
-git-lfs-init(1) -- Ensure Git LFS is configured properly
+git-lfs-init(1) -- Install Git LFS configuration.
 ========================================================
 
 ## SYNOPSIS
@@ -7,30 +7,10 @@ git-lfs-init(1) -- Ensure Git LFS is configured properly
 
 ## DESCRIPTION
 
-Perform the following actions to ensure that Git LFS is setup properly:
-
-* Set up the clean and smudge filters under the name "lfs" in the global Git
-  config.
-* Install a pre-push hook to run git-lfs-pre-push(1) for the current repository,
-  if run from inside one.
-
-## OPTIONS
-
-Without any options, `git lfs init` will only setup the "lfs" smudge and clean
-filters if they are not already set.
-
-* `--force`:
-    Sets the "lfs" smudge and clean filters, overwriting existing values.
-* `--local`:
-    Sets the "lfs" smudge and clean filters in the local repository's git
-    config, instead of the global git config.
-* `--skip-smudge`:
-    Skips automatic downloading of objects on clone or pull. This requires a
-    manual "git lfs pull" every time a new commit is checked out on your
-    repository.
+This command is deprecated. Run "git lfs install" instead.
 
 ## SEE ALSO
 
-git-lfs-uninit(1).
+git-lfs-init(1), git-lfs-uninit(1).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-init.1.ronn
+++ b/docs/man/git-lfs-init.1.ronn
@@ -11,6 +11,6 @@ This command is deprecated. Run "git lfs install" instead.
 
 ## SEE ALSO
 
-git-lfs-init(1), git-lfs-uninit(1).
+git-lfs-install(1), git-lfs-uninstall(1).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-install.1.ronn
+++ b/docs/man/git-lfs-install.1.ronn
@@ -31,6 +31,6 @@ filters if they are not already set.
 
 ## SEE ALSO
 
-git-lfs-uninit(1).
+git-lfs-uninstall(1).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-install.1.ronn
+++ b/docs/man/git-lfs-install.1.ronn
@@ -1,0 +1,36 @@
+git-lfs-install(1) -- Install Git LFS configuration.
+========================================================
+
+## SYNOPSIS
+
+`git lfs install` [options]
+
+## DESCRIPTION
+
+Perform the following actions to ensure that Git LFS is setup properly:
+
+* Set up the clean and smudge filters under the name "lfs" in the global Git
+  config.
+* Install a pre-push hook to run git-lfs-pre-push(1) for the current repository,
+  if run from inside one.
+
+## OPTIONS
+
+Without any options, `git lfs install` will only setup the "lfs" smudge and clean
+filters if they are not already set.
+
+* `--force`:
+    Sets the "lfs" smudge and clean filters, overwriting existing values.
+* `--local`:
+    Sets the "lfs" smudge and clean filters in the local repository's git
+    config, instead of the global git config.
+* `--skip-smudge`:
+    Skips automatic downloading of objects on clone or pull. This requires a
+    manual "git lfs pull" every time a new commit is checked out on your
+    repository.
+
+## SEE ALSO
+
+git-lfs-uninit(1).
+
+Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-smudge.1.ronn
+++ b/docs/man/git-lfs-smudge.1.ronn
@@ -31,6 +31,6 @@ standard output.
 
 ## SEE ALSO
 
-git-lfs-init(1), gitattributes(5).
+git-lfs-install(1), gitattributes(5).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-track.1.ronn
+++ b/docs/man/git-lfs-track.1.ronn
@@ -23,6 +23,6 @@ the currently-tracked paths.
 
 ## SEE ALSO
 
-git-lfs-untrack(1), git-lfs-init(1), gitattributes(5).
+git-lfs-untrack(1), git-lfs-install(1), gitattributes(5).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-uninit.1.ronn
+++ b/docs/man/git-lfs-uninit.1.ronn
@@ -1,19 +1,16 @@
 git-lfs-uninit(1) -- Remove Git LFS configuration
-=================================================
+========================================================
 
 ## SYNOPSIS
 
-`git lfs uninit`
+`git lfs uninit` [options]
 
 ## DESCRIPTION
 
-Perform the following actions to remove the Git LFS configuration:
-
-* Remove the "lfs" clean and smudge filters from the global Git config.
-* Uninstall the Git LFS pre-push hook if run from inside a Git repository.
+This command is deprecated. Run "git lfs uninstall" instead.
 
 ## SEE ALSO
 
-git-lfs-init(1).
+git-lfs-install(1), git-lfs-uninstall(1).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-uninstall.1.ronn
+++ b/docs/man/git-lfs-uninstall.1.ronn
@@ -1,0 +1,19 @@
+git-lfs-uninstall(1) -- Remove Git LFS configuration
+=================================================
+
+## SYNOPSIS
+
+`git lfs uninstall`
+
+## DESCRIPTION
+
+Perform the following actions to remove the Git LFS configuration:
+
+* Remove the "lfs" clean and smudge filters from the global Git config.
+* Uninstall the Git LFS pre-push hook if run from inside a Git repository.
+
+## SEE ALSO
+
+git-lfs-install(1).
+
+Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-untrack.1.ronn
+++ b/docs/man/git-lfs-untrack.1.ronn
@@ -18,6 +18,6 @@ can be a glob pattern or a file path.
 
 ## SEE ALSO
 
-git-lfs-track(1), git-lfs-init(1), gitattributes(5).
+git-lfs-track(1), git-lfs-install(1), gitattributes(5).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs.1.ronn
+++ b/docs/man/git-lfs.1.ronn
@@ -37,8 +37,8 @@ commands and low level ("plumbing") commands.
     Download git LFS files from a remote
 * git-lfs-fsck(1):
     Check GIT LFS files for consistency.
-* git-lfs-init(1):
-    Ensure Git LFS is configured properly.
+* git-lfs-install(1):
+    Install Git LFS configuration.
 * git-lfs-logs(1):
     Show errors from the git-lfs command.
 * git-lfs-ls-files(1):

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -153,7 +153,7 @@ a credential cache helper to save passwords for future users.
 ## Intercepting Git
 
 Git LFS uses the `clean` and `smudge` filters to decide which files use it.  The
-global filters can be set up with `git lfs init`:
+global filters can be set up with `git lfs install`:
 
 ```
 $ git lfs init
@@ -201,5 +201,3 @@ $ cat .gitattributes
 ```
 
 Use the `git lfs track` command to view and add to `.gitattributes`.
-
-

--- a/script/install.sh.example
+++ b/script/install.sh.example
@@ -17,4 +17,4 @@ for g in git*; do
 done
 
 PATH+=:$prefix/bin
-git lfs init
+git lfs install

--- a/script/nsis/installer.nsi
+++ b/script/nsis/installer.nsi
@@ -39,7 +39,7 @@ FunctionEnd
 
 Function .onInstSuccess
   IfSilent +2
-    MessageBox MB_OK "Open Git Bash and run 'git lfs init' to get started."
+    MessageBox MB_OK "Open Git Bash and run 'git lfs install' to get started."
 FunctionEnd
 
 Page license

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -2,7 +2,7 @@
 
 . "test/testlib.sh"
 
-begin_test "init again"
+begin_test "install again"
 (
   set -e
 
@@ -12,14 +12,14 @@ begin_test "init again"
   printf "$smudge" | grep "git-lfs smudge"
   printf "$clean" | grep "git-lfs clean"
 
-  git lfs init
+  git lfs install
 
   [ "$smudge" = "$(git config filter.lfs.smudge)" ]
   [ "$clean" = "$(git config filter.lfs.clean)" ]
 )
 end_test
 
-begin_test "init with old settings"
+begin_test "install with old settings"
 (
   set -e
 
@@ -27,31 +27,31 @@ begin_test "init with old settings"
   git config --global filter.lfs.clean "git lfs clean %f"
 
   set +e
-  git lfs init 2> init.log
+  git lfs install 2> install.log
   res=$?
   set -e
 
   [ "$res" = 2 ]
 
-  cat init.log
-  grep -E "(clean|smudge) attribute should be" init.log
-  [ `grep -c "(MISSING)" init.log` = "0" ]
+  cat install.log
+  grep -E "(clean|smudge) attribute should be" install.log
+  [ `grep -c "(MISSING)" install.log` = "0" ]
 
   [ "git lfs smudge %f" = "$(git config --global filter.lfs.smudge)" ]
   [ "git lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
 
-  git lfs init --force
+  git lfs install --force
   [ "git-lfs smudge %f" = "$(git config --global filter.lfs.smudge)" ]
   [ "git-lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
 )
 end_test
 
-begin_test "init updates repo hooks"
+begin_test "install updates repo hooks"
 (
   set -e
 
-  mkdir init-repo-hooks
-  cd init-repo-hooks
+  mkdir install-repo-hooks
+  cd install-repo-hooks
   git init
 
   pre_push_hook="#!/bin/sh
@@ -59,7 +59,7 @@ command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configu
 git lfs pre-push \"\$@\""
 
   [ "Updated pre-push hook.
-Git LFS initialized." = "$(git lfs init)" ]
+Git LFS initialized." = "$(git lfs install)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook
@@ -67,7 +67,7 @@ Git LFS initialized." = "$(git lfs init)" ]
   echo "#!/bin/sh
 git lfs push --stdin \$*" > .git/hooks/pre-push
   [ "Updated pre-push hook.
-Git LFS initialized." = "$(git lfs init)" ]
+Git LFS initialized." = "$(git lfs install)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # don't replace unexpected hook
@@ -80,28 +80,28 @@ Git LFS initialized."
 
   echo "test" > .git/hooks/pre-push
   [ "test" = "$(cat .git/hooks/pre-push)" ]
-  [ "$expected" = "$(git lfs init 2>&1)" ]
+  [ "$expected" = "$(git lfs install 2>&1)" ]
   [ "test" = "$(cat .git/hooks/pre-push)" ]
 
   # force replace unexpected hook
   [ "Updated pre-push hook.
-Git LFS initialized." = "$(git lfs init --force)" ]
+Git LFS initialized." = "$(git lfs install --force)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   has_test_dir || exit 0
 
   echo "test with bare repository"
   cd ..
-  git clone --mirror init-repo-hooks bare-init-repo-hooks
-  cd bare-init-repo-hooks
+  git clone --mirror install-repo-hooks bare-install-repo-hooks
+  cd bare-install-repo-hooks
   git lfs env
-  git lfs init
+  git lfs install
   ls -al hooks
   [ "$pre_push_hook" = "$(cat hooks/pre-push)" ]
 )
 end_test
 
-begin_test "init outside repository directory"
+begin_test "install outside repository directory"
 (
   set -e
   if [ -d "hooks" ]; then
@@ -110,7 +110,7 @@ begin_test "init outside repository directory"
     exit 1
   fi
 
-  git lfs init 2>&1 > check.log
+  git lfs install 2>&1 > check.log
 
   if [ -d "hooks" ]; then
     ls -al
@@ -120,41 +120,41 @@ begin_test "init outside repository directory"
 
   cat check.log
 
-  # doesn't print this because being in a git repo is not necessary for init
+  # doesn't print this because being in a git repo is not necessary for install
   [ "$(grep -c "Not in a git repository" check.log)" = "0" ]
 )
 end_test
 
-begin_test "init --skip-smudge"
+begin_test "install --skip-smudge"
 (
   set -e
 
-  git lfs init
+  git lfs install
   [ "git-lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
   [ "git-lfs smudge %f" = "$(git config --global filter.lfs.smudge)" ]
 
-  git lfs init --skip-smudge
+  git lfs install --skip-smudge
   [ "git-lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
   [ "git-lfs smudge --skip %f" = "$(git config --global filter.lfs.smudge)" ]
 
-  git lfs init --force
+  git lfs install --force
   [ "git-lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
   [ "git-lfs smudge %f" = "$(git config --global filter.lfs.smudge)" ]
 )
 end_test
 
-begin_test "init --local"
+begin_test "install --local"
 (
   set -e
 
-  # old values that should be ignored by `init --local`
+  # old values that should be ignored by `install --local`
   git config --global filter.lfs.smudge "git lfs smudge %f"
   git config --global filter.lfs.clean "git lfs clean %f"
 
-  mkdir init-local-repo
-  cd init-local-repo
+  mkdir install-local-repo
+  cd install-local-repo
   git init
-  git lfs init --local
+  git lfs install --local
 
   [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
   [ "git-lfs clean %f" = "$(git config --local filter.lfs.clean)" ]
@@ -162,11 +162,11 @@ begin_test "init --local"
 )
 end_test
 
-begin_test "init --local outside repository"
+begin_test "install --local outside repository"
 (
   # If run inside the git-lfs source dir this will update its .git/config & cause issues
   if [ "$GIT_LFS_TEST_DIR" == "" ]; then
-    echo "Skipping init --local because GIT_LFS_TEST_DIR is not set"
+    echo "Skipping install --local because GIT_LFS_TEST_DIR is not set"
     exit 0
   fi
 
@@ -174,7 +174,7 @@ begin_test "init --local outside repository"
 
   has_test_dir || exit 0
 
-  git lfs init --local 2> err.log
+  git lfs install --local 2> err.log
   res=$?
 
   [ "Not in a git repository." = "$(cat err.log)" ]

--- a/test/test-uninstall.sh
+++ b/test/test-uninstall.sh
@@ -2,7 +2,7 @@
 
 . "test/testlib.sh"
 
-begin_test "uninit outside repository"
+begin_test "uninstall outside repository"
 (
   set -e
 
@@ -12,11 +12,11 @@ begin_test "uninit outside repository"
   printf "$smudge" | grep "git-lfs smudge"
   printf "$clean" | grep "git-lfs clean"
 
-  # uninit multiple times to trigger https://github.com/github/git-lfs/issues/529
-  git lfs uninit
+  # uninstall multiple times to trigger https://github.com/github/git-lfs/issues/529
+  git lfs uninstall
   git lfs init
-  git lfs uninit | tee uninit.log
-  grep "configuration has been removed" uninit.log
+  git lfs uninstall | tee uninstall.log
+  grep "configuration has been removed" uninstall.log
 
   [ "" = "$(git config --global filter.lfs.smudge)" ]
   [ "" = "$(git config --global filter.lfs.clean)" ]
@@ -26,7 +26,7 @@ begin_test "uninit outside repository"
 )
 end_test
 
-begin_test "uninit inside repository with default pre-push hook"
+begin_test "uninstall inside repository with default pre-push hook"
 (
   set -e
 
@@ -42,7 +42,7 @@ begin_test "uninit inside repository with default pre-push hook"
   [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
   [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
 
-  git lfs uninit
+  git lfs uninstall
 
   [ -f .git/hooks/pre-push ] && {
     echo "expected .git/hooks/pre-push to be deleted"
@@ -53,7 +53,7 @@ begin_test "uninit inside repository with default pre-push hook"
 )
 end_test
 
-begin_test "uninit inside repository without git lfs pre-push hook"
+begin_test "uninstall inside repository without git lfs pre-push hook"
 (
   set -e
 
@@ -71,7 +71,7 @@ begin_test "uninit inside repository without git lfs pre-push hook"
   [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
   [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
 
-  git lfs uninit
+  git lfs uninstall
 
   [ -f .git/hooks/pre-push ]
   [ "" = "$(git config filter.lfs.smudge)" ]
@@ -79,7 +79,7 @@ begin_test "uninit inside repository without git lfs pre-push hook"
 )
 end_test
 
-begin_test "uninit hooks inside repository"
+begin_test "uninstall hooks inside repository"
 (
   set -e
 
@@ -95,7 +95,7 @@ begin_test "uninit hooks inside repository"
   [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
   [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
 
-  git lfs uninit hooks
+  git lfs uninstall hooks
 
   [ -f .git/hooks/pre-push ] && {
     echo "expected .git/hooks/pre-push to be deleted"


### PR DESCRIPTION
This renames both `git lfs init` and `git lfs uninit` to `git lfs install` and `git lfs uninstall`.  The old commands will be available until Git LFS v2.0.

Fixes #781