### PR TITLE
Cred fixes

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -515,16 +515,6 @@ func doApiRequestWithRedirects(req *http.Request, via []*http.Request, useCreds 
 	var creds Creds
 	if useCreds {
 		c, err := getCredsForAPI(req)
-		if c == nil || len(c) < 1 {
-			errmsg := fmt.Sprintf("Git credentials for %s not found", req.URL)
-			if err != nil {
-				errmsg = errmsg + ":\n" + err.Error()
-			} else {
-				errmsg = errmsg + "."
-			}
-			return nil, errors.New(errmsg)
-		}
-
 		if err != nil {
 			return nil, err
 		}

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -515,6 +515,16 @@ func doApiRequestWithRedirects(req *http.Request, via []*http.Request, useCreds 
 	var creds Creds
 	if useCreds {
 		c, err := getCredsForAPI(req)
+		if c == nil || len(c) < 1 {
+			errmsg := fmt.Sprintf("Git credentials for %s not found", req.URL)
+			if err != nil {
+				errmsg = errmsg + ":\n" + err.Error()
+			} else {
+				errmsg = errmsg + "."
+			}
+			return nil, errors.New(errmsg)
+		}
+
 		if err != nil {
 			return nil, err
 		}

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -49,6 +49,7 @@ type Configuration struct {
 	ntlmSession           ntlm.ClientSession
 	envVars               map[string]string
 	isTracingHttp         bool
+	isDebuggingHttp       bool
 	isLoggingStats        bool
 
 	loading           sync.Mutex // guards initialization of gitConfig and remotes
@@ -67,6 +68,7 @@ func NewConfig() *Configuration {
 		envVars:       make(map[string]string),
 	}
 	c.isTracingHttp = c.GetenvBool("GIT_CURL_VERBOSE", false)
+	c.isDebuggingHttp = c.GetenvBool("LFS_DEBUG_HTTP", false)
 	c.isLoggingStats = c.GetenvBool("GIT_LOG_STATS", false)
 	return c
 }

--- a/lfs/credentials.go
+++ b/lfs/credentials.go
@@ -2,6 +2,7 @@ package lfs
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -109,9 +110,17 @@ func fillCredentials(req *http.Request, u *url.URL) (Creds, error) {
 	}
 
 	creds, err := execCreds(input, "fill")
+	if creds == nil || len(creds) < 1 {
+		errmsg := fmt.Sprintf("Git credentials for %s not found", u)
+		if err != nil {
+			errmsg = errmsg + ":\n" + err.Error()
+		} else {
+			errmsg = errmsg + "."
+		}
+		err = errors.New(errmsg)
+	}
 
-	if err != nil || creds == nil || len(creds) < 1 {
-		tracerx.Printf("No credentials for %s", u)
+	if err != nil {
 		return nil, err
 	}
 

--- a/lfs/credentials.go
+++ b/lfs/credentials.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"os/exec"
 	"strings"
+
+	"github.com/github/git-lfs/vendor/_nuts/github.com/rubyist/tracerx"
 )
 
 // getCreds gets the credentials for the given request's URL, and sets its
@@ -108,9 +110,13 @@ func fillCredentials(req *http.Request, u *url.URL) (Creds, error) {
 
 	creds, err := execCreds(input, "fill")
 
-	if creds != nil && err == nil {
-		setRequestAuth(req, creds["username"], creds["password"])
+	if err != nil || creds == nil || len(creds) < 1 {
+		tracerx.Printf("No credentials for %s", u)
+		return nil, err
 	}
+
+	tracerx.Printf("Filled credentials for %s", u)
+	setRequestAuth(req, creds["username"], creds["password"])
 
 	return creds, err
 }

--- a/lfs/credentials.go
+++ b/lfs/credentials.go
@@ -181,7 +181,7 @@ func execCredsCommand(input Creds, subCommand string) (Creds, error) {
 		// 'git credential' exits with 128 if the helper doesn't fill the username
 		// and password values.
 		if subCommand == "fill" && err.Error() == "exit status 128" {
-			return input, nil
+			return nil, nil
 		}
 	}
 
@@ -192,7 +192,7 @@ func execCredsCommand(input Creds, subCommand string) (Creds, error) {
 	creds := make(Creds)
 	for _, line := range strings.Split(output.String(), "\n") {
 		pieces := strings.SplitN(line, "=", 2)
-		if len(pieces) < 2 {
+		if len(pieces) < 2 || len(pieces[1]) < 1 {
 			continue
 		}
 		creds[pieces[0]] = pieces[1]

--- a/lfs/http.go
+++ b/lfs/http.go
@@ -158,7 +158,7 @@ func traceHttpRequest(req *http.Request) {
 		return
 	}
 
-	traceHttpDump(dump)
+	traceHttpDump(">", dump)
 }
 
 func traceHttpResponse(res *http.Response) {
@@ -183,18 +183,18 @@ func traceHttpResponse(res *http.Response) {
 		fmt.Fprintf(os.Stderr, "\n")
 	}
 
-	traceHttpDump(dump)
+	traceHttpDump("<", dump)
 }
 
-func traceHttpDump(dump []byte) {
+func traceHttpDump(direction string, dump []byte) {
 	scanner := bufio.NewScanner(bytes.NewBuffer(dump))
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix("authorization: basic", strings.ToLower(line)) {
-			fmt.Fprintf(os.Stderr, "< Authorization: Basic * * * * *\n")
+		if !Config.isDebuggingHttp && strings.HasPrefix(strings.ToLower(line), "authorization: basic") {
+			fmt.Fprintf(os.Stderr, "%s Authorization: Basic * * * * *\n", direction)
 		} else {
-			fmt.Fprintf(os.Stderr, "< %s\n", line)
+			fmt.Fprintf(os.Stderr, "%s %s\n", direction, line)
 		}
 	}
 }

--- a/test/test-credentials-no-prompt.sh
+++ b/test/test-credentials-no-prompt.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+# these tests rely on GIT_TERMINAL_PROMPT to test properly
+ensure_git_version_isnt $VERSION_LOWER "2.3.0"
+
+begin_test "attempt private access without credential helper"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" without-creds
+
+  git lfs track "*.dat"
+  echo "hi" > hi.dat
+  git add hi.dat
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  git config --unset credential.helper
+  git config --global --unset credential.helper
+
+  GIT_TERMINAL_PROMPT=0 git push origin master 2>&1 | tee push.log
+
+  grep "Git credentials for $GITSERVER/$reponame not found" push.log
+)
+end_test

--- a/test/test-credentials.sh
+++ b/test/test-credentials.sh
@@ -2,30 +2,6 @@
 
 . "test/testlib.sh"
 
-begin_test "attempt private access without credential helper"
-(
-  set -e
-
-  reponame="$(basename "$0" ".sh")"
-  setup_remote_repo "$reponame"
-  clone_repo "$reponame" without-creds
-
-  git lfs track "*.dat"
-  echo "hi" > hi.dat
-  git add hi.dat
-  git add .gitattributes
-  git commit -m "initial commit"
-
-  git config --unset credential.helper
-  git config --global --unset credential.helper
-
-  GIT_TERMINAL_PROMPT=0 git push origin master 2>&1 | tee push.log
-
-  grep "Git credentials for $GITSERVER/$reponame not found" push.log
-)
-end_test
-exit 0
-
 begin_test "credentials without useHttpPath, with bad path password"
 (
   set -e

--- a/test/test-credentials.sh
+++ b/test/test-credentials.sh
@@ -21,10 +21,10 @@ begin_test "attempt private access without credential helper"
 
   GIT_TERMINAL_PROMPT=0 git push origin master 2>&1 | tee push.log
 
-  repourl="$GITSERVER/$reponame.git/info/lfs/objects/batch"
-  grep "Git credentials for $repourl not found" push.log
+  grep "Git credentials for $GITSERVER/$reponame not found" push.log
 )
 end_test
+exit 0
 
 begin_test "credentials without useHttpPath, with bad path password"
 (


### PR DESCRIPTION
This prevents Git LFS from getting into an auth loop if no git credentials are found. It also adds a bit more tracing so we don't have to reach for `GIT_CURL_VERBOSE` as often. And when we do, its output is cleaned up a bit with extra linebreaks.