### PR TITLE
Debian build script shouldn't depend on a specific version of Ruby

### DIFF
--- a/script/debian-build
+++ b/script/debian-build
@@ -35,12 +35,8 @@ install -D bin/git-lfs /usr/local/bin
 git lfs install
 
 apt-get -y install build-essential groff man
-if grep -q Debian /etc/issue; then
-  apt-get install -y ruby ruby-dev
-elif grep -q Ubuntu /etc/issue; then
-  apt-get -y install ruby2.2 ruby2.2-dev
-  rm /usr/bin/ruby && sudo ln -s /usr/bin/ruby2.2 /usr/bin/ruby
-  rm -fr /usr/bin/gem && sudo ln -s /usr/bin/gem2.2 /usr/bin/gem
+if grep -q 'Debian\|Ubuntu' /etc/issue; then
+  apt-get -y install ruby ruby-dev
 else
   {
     echo "unknown Debian release"

--- a/script/debian-build
+++ b/script/debian-build
@@ -38,9 +38,9 @@ apt-get -y install build-essential groff man
 if grep -q Debian /etc/issue; then
   apt-get install -y ruby ruby-dev
 elif grep -q Ubuntu /etc/issue; then
-  apt-get -y install ruby2.0 ruby2.0-dev
-  rm /usr/bin/ruby && sudo ln -s /usr/bin/ruby2.0 /usr/bin/ruby
-  rm -fr /usr/bin/gem && sudo ln -s /usr/bin/gem2.0 /usr/bin/gem
+  apt-get -y install ruby2.2 ruby2.2-dev
+  rm /usr/bin/ruby && sudo ln -s /usr/bin/ruby2.2 /usr/bin/ruby
+  rm -fr /usr/bin/gem && sudo ln -s /usr/bin/gem2.2 /usr/bin/gem
 else
   {
     echo "unknown Debian release"


### PR DESCRIPTION
Ubuntu repositories no longer offer the Ruby2.0 package, thus breaking the script