### PR TITLE
Export ObjectResource

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -49,7 +49,7 @@ func (e *objectError) Error() string {
 	return fmt.Sprintf("[%d] %s", e.Code, e.Message)
 }
 
-type objectResource struct {
+type ObjectResource struct {
 	Oid     string                   `json:"oid,omitempty"`
 	Size    int64                    `json:"size"`
 	Actions map[string]*linkRelation `json:"actions,omitempty"`
@@ -57,7 +57,7 @@ type objectResource struct {
 	Error   *objectError             `json:"error,omitempty"`
 }
 
-func (o *objectResource) NewRequest(relation, method string) (*http.Request, error) {
+func (o *ObjectResource) NewRequest(relation, method string) (*http.Request, error) {
 	rel, ok := o.Rel(relation)
 	if !ok {
 		return nil, errors.New("relation does not exist")
@@ -71,7 +71,7 @@ func (o *objectResource) NewRequest(relation, method string) (*http.Request, err
 	return req, nil
 }
 
-func (o *objectResource) Rel(name string) (*linkRelation, bool) {
+func (o *ObjectResource) Rel(name string) (*linkRelation, bool) {
 	var rel *linkRelation
 	var ok bool
 
@@ -114,8 +114,8 @@ func Download(oid string, size int64) (io.ReadCloser, int64, error) {
 		return DownloadLegacy(oid)
 	}
 
-	objects := []*objectResource{
-		&objectResource{Oid: oid, Size: size},
+	objects := []*ObjectResource{
+		&ObjectResource{Oid: oid, Size: size},
 	}
 
 	objs, err := Batch(objects, "download")
@@ -165,7 +165,7 @@ type byteCloser struct {
 	*bytes.Reader
 }
 
-func DownloadCheck(oid string) (*objectResource, error) {
+func DownloadCheck(oid string) (*ObjectResource, error) {
 	req, err := newApiRequest("GET", oid)
 	if err != nil {
 		return nil, Error(err)
@@ -185,7 +185,7 @@ func DownloadCheck(oid string) (*objectResource, error) {
 	return obj, nil
 }
 
-func DownloadObject(obj *objectResource) (io.ReadCloser, int64, error) {
+func DownloadObject(obj *ObjectResource) (io.ReadCloser, int64, error) {
 	req, err := obj.NewRequest("download", "GET")
 	if err != nil {
 		return nil, 0, Error(err)
@@ -204,7 +204,7 @@ func (b *byteCloser) Close() error {
 	return nil
 }
 
-func Batch(objects []*objectResource, operation string) ([]*objectResource, error) {
+func Batch(objects []*ObjectResource, operation string) ([]*ObjectResource, error) {
 	if len(objects) == 0 {
 		return nil, nil
 	}
@@ -263,7 +263,7 @@ func Batch(objects []*objectResource, operation string) ([]*objectResource, erro
 	return objs, nil
 }
 
-func UploadCheck(oidPath string) (*objectResource, error) {
+func UploadCheck(oidPath string) (*ObjectResource, error) {
 	oid := filepath.Base(oidPath)
 
 	stat, err := os.Stat(oidPath)
@@ -271,7 +271,7 @@ func UploadCheck(oidPath string) (*objectResource, error) {
 		return nil, Error(err)
 	}
 
-	reqObj := &objectResource{
+	reqObj := &ObjectResource{
 		Oid:  oid,
 		Size: stat.Size(),
 	}
@@ -318,7 +318,7 @@ func UploadCheck(oidPath string) (*objectResource, error) {
 	return obj, nil
 }
 
-func UploadObject(o *objectResource, cb CopyCallback) error {
+func UploadObject(o *ObjectResource, cb CopyCallback) error {
 	path, err := LocalMediaPath(o.Oid)
 	if err != nil {
 		return Error(err)
@@ -404,14 +404,14 @@ func UploadObject(o *objectResource, cb CopyCallback) error {
 }
 
 // doLegacyApiRequest runs the request to the LFS legacy API.
-func doLegacyApiRequest(req *http.Request) (*http.Response, *objectResource, error) {
+func doLegacyApiRequest(req *http.Request) (*http.Response, *ObjectResource, error) {
 	via := make([]*http.Request, 0, 4)
 	res, err := doApiRequestWithRedirects(req, via, true)
 	if err != nil {
 		return res, nil, err
 	}
 
-	obj := &objectResource{}
+	obj := &ObjectResource{}
 	err = decodeApiResponse(res, obj)
 
 	if err != nil {
@@ -426,7 +426,7 @@ func doLegacyApiRequest(req *http.Request) (*http.Response, *objectResource, err
 // 401, the repo will be marked as having private access and the request will be
 // re-run. When the repo is marked as having private access, credentials will
 // be retrieved.
-func doApiBatchRequest(req *http.Request) (*http.Response, []*objectResource, error) {
+func doApiBatchRequest(req *http.Request) (*http.Response, []*ObjectResource, error) {
 	res, err := doAPIRequest(req, Config.PrivateAccess())
 
 	if err != nil {
@@ -436,7 +436,7 @@ func doApiBatchRequest(req *http.Request) (*http.Response, []*objectResource, er
 		return res, nil, err
 	}
 
-	var objs map[string][]*objectResource
+	var objs map[string][]*ObjectResource
 	err = decodeApiResponse(res, &objs)
 
 	if err != nil {

--- a/lfs/download_queue.go
+++ b/lfs/download_queue.go
@@ -3,14 +3,14 @@ package lfs
 // The ability to check that a file can be downloaded
 type DownloadCheckable struct {
 	Pointer *WrappedPointer
-	object  *objectResource
+	object  *ObjectResource
 }
 
 func NewDownloadCheckable(p *WrappedPointer) *DownloadCheckable {
 	return &DownloadCheckable{Pointer: p}
 }
 
-func (d *DownloadCheckable) Check() (*objectResource, error) {
+func (d *DownloadCheckable) Check() (*ObjectResource, error) {
 	return DownloadCheck(d.Pointer.Oid)
 }
 
@@ -20,7 +20,7 @@ func (d *DownloadCheckable) Transfer(cb CopyCallback) error {
 	return nil
 }
 
-func (d *DownloadCheckable) Object() *objectResource {
+func (d *DownloadCheckable) Object() *ObjectResource {
 	return d.object
 }
 
@@ -36,7 +36,7 @@ func (d *DownloadCheckable) Name() string {
 	return d.Pointer.Name
 }
 
-func (d *DownloadCheckable) SetObject(o *objectResource) {
+func (d *DownloadCheckable) SetObject(o *ObjectResource) {
 	d.object = o
 }
 

--- a/lfs/download_test.go
+++ b/lfs/download_test.go
@@ -36,7 +36,7 @@ func TestSuccessfulDownload(t *testing.T) {
 			t.Error("Invalid Authorization")
 		}
 
-		obj := &objectResource{
+		obj := &ObjectResource{
 			Oid:  "oid",
 			Size: 4,
 			Actions: map[string]*linkRelation{
@@ -167,7 +167,7 @@ func TestSuccessfulDownloadWithRedirects(t *testing.T) {
 			t.Error("Invalid Authorization")
 		}
 
-		obj := &objectResource{
+		obj := &ObjectResource{
 			Oid:  "oid",
 			Size: 4,
 			Actions: map[string]*linkRelation{
@@ -267,7 +267,7 @@ func TestSuccessfulDownloadWithAuthorization(t *testing.T) {
 			t.Error("Invalid Authorization")
 		}
 
-		obj := &objectResource{
+		obj := &ObjectResource{
 			Oid:  "oid",
 			Size: 4,
 			Actions: map[string]*linkRelation{
@@ -375,7 +375,7 @@ func TestSuccessfulDownloadFromSeparateHost(t *testing.T) {
 			t.Error("Invalid Authorization")
 		}
 
-		obj := &objectResource{
+		obj := &ObjectResource{
 			Oid:  "oid",
 			Size: 4,
 			Actions: map[string]*linkRelation{
@@ -507,7 +507,7 @@ func TestSuccessfulDownloadFromSeparateRedirectedHost(t *testing.T) {
 			t.Error("Invalid Authorization")
 		}
 
-		obj := &objectResource{
+		obj := &ObjectResource{
 			Oid:  "oid",
 			Size: 4,
 			Actions: map[string]*linkRelation{
@@ -634,7 +634,7 @@ func TestDownloadStorageError(t *testing.T) {
 			t.Error("Invalid Authorization")
 		}
 
-		obj := &objectResource{
+		obj := &ObjectResource{
 			Oid:  "oid",
 			Size: 4,
 			Actions: map[string]*linkRelation{

--- a/lfs/pointer_smudge.go
+++ b/lfs/pointer_smudge.go
@@ -67,9 +67,9 @@ func PointerSmudge(writer io.Writer, ptr *Pointer, workingfile string, download 
 	return nil
 }
 
-// PointerSmudgeObject uses a Pointer and objectResource to download the object to the
+// PointerSmudgeObject uses a Pointer and ObjectResource to download the object to the
 // media directory. It does not write the file to the working directory.
-func PointerSmudgeObject(ptr *Pointer, obj *objectResource, cb CopyCallback) error {
+func PointerSmudgeObject(ptr *Pointer, obj *ObjectResource, cb CopyCallback) error {
 	mediafile, err := LocalMediaPath(obj.Oid)
 	if err != nil {
 		return err
@@ -96,7 +96,7 @@ func PointerSmudgeObject(ptr *Pointer, obj *objectResource, cb CopyCallback) err
 	return nil
 }
 
-func downloadObject(ptr *Pointer, obj *objectResource, mediafile string, cb CopyCallback) error {
+func downloadObject(ptr *Pointer, obj *ObjectResource, mediafile string, cb CopyCallback) error {
 	reader, size, err := DownloadObject(obj)
 	if reader != nil {
 		defer reader.Close()

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -13,13 +13,13 @@ const (
 )
 
 type Transferable interface {
-	Check() (*objectResource, error)
+	Check() (*ObjectResource, error)
 	Transfer(CopyCallback) error
-	Object() *objectResource
+	Object() *ObjectResource
 	Oid() string
 	Size() int64
 	Name() string
-	SetObject(*objectResource)
+	SetObject(*ObjectResource)
 }
 
 // TransferQueue provides a queue that will allow concurrent transfers.
@@ -197,9 +197,9 @@ func (q *TransferQueue) batchApiRoutine() {
 
 		tracerx.Printf("tq: sending batch of size %d", len(batch))
 
-		transfers := make([]*objectResource, 0, len(batch))
+		transfers := make([]*ObjectResource, 0, len(batch))
 		for _, t := range batch {
-			transfers = append(transfers, &objectResource{Oid: t.Oid(), Size: t.Size()})
+			transfers = append(transfers, &ObjectResource{Oid: t.Oid(), Size: t.Size()})
 		}
 
 		objects, err := Batch(transfers, q.transferKind)

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -12,7 +12,7 @@ type Uploadable struct {
 	OidPath  string
 	Filename string
 	size     int64
-	object   *objectResource
+	object   *ObjectResource
 }
 
 // NewUploadable builds the Uploadable from the given information.
@@ -37,7 +37,7 @@ func NewUploadable(oid, filename string) (*Uploadable, error) {
 	return &Uploadable{oid: oid, OidPath: localMediaPath, Filename: filename, size: fi.Size()}, nil
 }
 
-func (u *Uploadable) Check() (*objectResource, error) {
+func (u *Uploadable) Check() (*ObjectResource, error) {
 	return UploadCheck(u.OidPath)
 }
 
@@ -50,7 +50,7 @@ func (u *Uploadable) Transfer(cb CopyCallback) error {
 	return UploadObject(u.object, wcb)
 }
 
-func (u *Uploadable) Object() *objectResource {
+func (u *Uploadable) Object() *ObjectResource {
 	return u.object
 }
 
@@ -66,7 +66,7 @@ func (u *Uploadable) Name() string {
 	return u.Filename
 }
 
-func (u *Uploadable) SetObject(o *objectResource) {
+func (u *Uploadable) SetObject(o *ObjectResource) {
 	u.object = o
 }
 

--- a/lfs/upload_test.go
+++ b/lfs/upload_test.go
@@ -47,7 +47,7 @@ func TestExistingUpload(t *testing.T) {
 
 		buf := &bytes.Buffer{}
 		tee := io.TeeReader(r.Body, buf)
-		reqObj := &objectResource{}
+		reqObj := &ObjectResource{}
 		err := json.NewDecoder(tee).Decode(reqObj)
 		t.Logf("request header: %v", r.Header)
 		t.Logf("request body: %s", buf.String())
@@ -63,7 +63,7 @@ func TestExistingUpload(t *testing.T) {
 			t.Errorf("invalid size from request: %d", reqObj.Size)
 		}
 
-		obj := &objectResource{
+		obj := &ObjectResource{
 			Oid:  reqObj.Oid,
 			Size: reqObj.Size,
 			Actions: map[string]*linkRelation{
@@ -186,7 +186,7 @@ func TestUploadWithRedirect(t *testing.T) {
 
 		buf := &bytes.Buffer{}
 		tee := io.TeeReader(r.Body, buf)
-		reqObj := &objectResource{}
+		reqObj := &ObjectResource{}
 		err := json.NewDecoder(tee).Decode(reqObj)
 		t.Logf("request header: %v", r.Header)
 		t.Logf("request body: %s", buf.String())
@@ -202,7 +202,7 @@ func TestUploadWithRedirect(t *testing.T) {
 			t.Errorf("invalid size from request: %d", reqObj.Size)
 		}
 
-		obj := &objectResource{
+		obj := &ObjectResource{
 			Actions: map[string]*linkRelation{
 				"upload": &linkRelation{
 					Href:   server.URL + "/upload",
@@ -279,7 +279,7 @@ func TestSuccessfulUploadWithVerify(t *testing.T) {
 
 		buf := &bytes.Buffer{}
 		tee := io.TeeReader(r.Body, buf)
-		reqObj := &objectResource{}
+		reqObj := &ObjectResource{}
 		err := json.NewDecoder(tee).Decode(reqObj)
 		t.Logf("request header: %v", r.Header)
 		t.Logf("request body: %s", buf.String())
@@ -295,7 +295,7 @@ func TestSuccessfulUploadWithVerify(t *testing.T) {
 			t.Errorf("invalid size from request: %d", reqObj.Size)
 		}
 
-		obj := &objectResource{
+		obj := &ObjectResource{
 			Oid:  reqObj.Oid,
 			Size: reqObj.Size,
 			Actions: map[string]*linkRelation{
@@ -381,7 +381,7 @@ func TestSuccessfulUploadWithVerify(t *testing.T) {
 
 		buf := &bytes.Buffer{}
 		tee := io.TeeReader(r.Body, buf)
-		reqObj := &objectResource{}
+		reqObj := &ObjectResource{}
 		err := json.NewDecoder(tee).Decode(reqObj)
 		t.Logf("request header: %v", r.Header)
 		t.Logf("request body: %s", buf.String())
@@ -482,7 +482,7 @@ func TestSuccessfulUploadWithoutVerify(t *testing.T) {
 
 		buf := &bytes.Buffer{}
 		tee := io.TeeReader(r.Body, buf)
-		reqObj := &objectResource{}
+		reqObj := &ObjectResource{}
 		err := json.NewDecoder(tee).Decode(reqObj)
 		t.Logf("request header: %v", r.Header)
 		t.Logf("request body: %s", buf.String())
@@ -498,7 +498,7 @@ func TestSuccessfulUploadWithoutVerify(t *testing.T) {
 			t.Errorf("invalid size from request: %d", reqObj.Size)
 		}
 
-		obj := &objectResource{
+		obj := &ObjectResource{
 			Oid:  reqObj.Oid,
 			Size: reqObj.Size,
 			Actions: map[string]*linkRelation{
@@ -666,7 +666,7 @@ func TestUploadStorageError(t *testing.T) {
 
 		buf := &bytes.Buffer{}
 		tee := io.TeeReader(r.Body, buf)
-		reqObj := &objectResource{}
+		reqObj := &ObjectResource{}
 		err := json.NewDecoder(tee).Decode(reqObj)
 		t.Logf("request header: %v", r.Header)
 		t.Logf("request body: %s", buf.String())
@@ -682,7 +682,7 @@ func TestUploadStorageError(t *testing.T) {
 			t.Errorf("invalid size from request: %d", reqObj.Size)
 		}
 
-		obj := &objectResource{
+		obj := &ObjectResource{
 			Oid:  reqObj.Oid,
 			Size: reqObj.Size,
 			Actions: map[string]*linkRelation{
@@ -783,7 +783,7 @@ func TestUploadVerifyError(t *testing.T) {
 
 		buf := &bytes.Buffer{}
 		tee := io.TeeReader(r.Body, buf)
-		reqObj := &objectResource{}
+		reqObj := &ObjectResource{}
 		err := json.NewDecoder(tee).Decode(reqObj)
 		t.Logf("request header: %v", r.Header)
 		t.Logf("request body: %s", buf.String())
@@ -799,7 +799,7 @@ func TestUploadVerifyError(t *testing.T) {
 			t.Errorf("invalid size from request: %d", reqObj.Size)
 		}
 
-		obj := &objectResource{
+		obj := &ObjectResource{
 			Oid:  reqObj.Oid,
 			Size: reqObj.Size,
 			Actions: map[string]*linkRelation{


### PR DESCRIPTION
objectResource is returned by several public functions but isn't exported itself, so fix that. 

Context: I'm using calls to Batch() in my server API test tool which is outside the LFS package & need to see the results. I remember I also needed it when refactoring the API for my old SSH PR so I think it's likely to be useful generally.