### PR TITLE
Add server API test tool

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -40,12 +40,12 @@ var (
 	}
 )
 
-type objectError struct {
+type ObjectError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
 }
 
-func (e *objectError) Error() string {
+func (e *ObjectError) Error() string {
 	return fmt.Sprintf("[%d] %s", e.Code, e.Message)
 }
 
@@ -54,7 +54,7 @@ type ObjectResource struct {
 	Size    int64                    `json:"size"`
 	Actions map[string]*linkRelation `json:"actions,omitempty"`
 	Links   map[string]*linkRelation `json:"_links,omitempty"`
-	Error   *objectError             `json:"error,omitempty"`
+	Error   *ObjectError             `json:"error,omitempty"`
 }
 
 func (o *ObjectResource) NewRequest(relation, method string) (*http.Request, error) {

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -60,6 +60,7 @@ type Configuration struct {
 	fetchIncludePaths []string
 	fetchExcludePaths []string
 	fetchPruneConfig  *FetchPruneConfig
+	manualEndpoint    *Endpoint
 }
 
 func NewConfig() *Configuration {
@@ -109,7 +110,16 @@ func (c *Configuration) GetenvBool(key string, def bool) bool {
 	return b
 }
 
+// Manually set an Endpoint to use instead of deriving from Git config
+func (c *Configuration) SetManualEndpoint(e Endpoint) {
+	c.manualEndpoint = &e
+}
+
 func (c *Configuration) Endpoint() Endpoint {
+	if c.manualEndpoint != nil {
+		return *c.manualEndpoint
+	}
+
 	if url, ok := c.GitConfig("lfs.url"); ok {
 		return NewEndpoint(url)
 	}

--- a/test/git-lfs-test-server-api/.gitignore
+++ b/test/git-lfs-test-server-api/.gitignore
@@ -1,0 +1,1 @@
+git-lfs-test-server-api*

--- a/test/git-lfs-test-server-api/README.md
+++ b/test/git-lfs-test-server-api/README.md
@@ -34,7 +34,7 @@ git-lfs-test-server-api [--url=<apiurl> | --clone=<cloneurl>]
 |------|-------|
 |`--url=<apiurl>`|URL of the server API to call. This must point directly at the API root and not the clone URL, and must be HTTP[S]. You must supply either this argument or the `--clone` argument|
 |`--clone=<cloneurl>`|The clone URL from which to derive the API URL. If it is HTTP[S], the test will try to find the API at `<cloneurl>/info/lfs`; if it is an SSH URL, then the test will call git-lfs-authenticate on the server to derive the API (with auth token if needed) just like the git-lfs client does. You must supply either this argument or the `--url` argument|
-|`<oid-exists-file> <oid-missing-file>`|Optional input files for data-driven mode (both must be supplied if this is used); each must be a file with one oid per line. The first must be a list of oids that exist on the server, the second must bea list of oids known not to exist. If supplied, the tests will not call the content server or modify any data. If omitted, the test will generate its own list of oids and will modify the server (and expects that the server is empty of oids at the start)|
+|`<oid-exists-file> <oid-missing-file>`|Optional input files for data-driven mode (both must be supplied if this is used); each must be a file with `<oid> <size_in_bytes>` per line. The first file must be a list of oids that exist on the server, the second must be a list of oids known not to exist. If supplied, the tests will not call the content server or modify any data. If omitted, the test will generate its own list of oids and will modify the server (and expects that the server is empty of oids at the start)|
 
 ## Authentication
 

--- a/test/git-lfs-test-server-api/README.md
+++ b/test/git-lfs-test-server-api/README.md
@@ -28,6 +28,7 @@ production system.
 ```
 git-lfs-test-server-api [--url=<apiurl> | --clone=<cloneurl>] 
                         [<oid-exists-file> <oid-missing-file>]
+                        [--save=<fileprefix>]
 ```
 
 |Argument|Purpose|
@@ -35,7 +36,7 @@ git-lfs-test-server-api [--url=<apiurl> | --clone=<cloneurl>]
 |`--url=<apiurl>`|URL of the server API to call. This must point directly at the API root and not the clone URL, and must be HTTP[S]. You must supply either this argument or the `--clone` argument|
 |`--clone=<cloneurl>`|The clone URL from which to derive the API URL. If it is HTTP[S], the test will try to find the API at `<cloneurl>/info/lfs`; if it is an SSH URL, then the test will call git-lfs-authenticate on the server to derive the API (with auth token if needed) just like the git-lfs client does. You must supply either this argument or the `--url` argument|
 |`<oid-exists-file> <oid-missing-file>`|Optional input files for data-driven mode (both must be supplied if this is used); each must be a file with `<oid> <size_in_bytes>` per line. The first file must be a list of oids that exist on the server, the second must be a list of oids known not to exist. If supplied, the tests will not call the content server or modify any data. If omitted, the test will generate its own list of oids and will modify the server (and expects that the server is empty of oids at the start)|
-
+|`--save=<fileprefix>`|If specified and no input files were provided, saves generated test data in the files `<fileprefix>_exists` and `<fileprefix>_missing`. These can be used as parameters to subsequent runs if required, if the server content remains unchanged between runs.|
 ## Authentication
 
 Authentication will behave just like the git-lfs client, so for HTTP[S] URLs the

--- a/test/git-lfs-test-server-api/README.md
+++ b/test/git-lfs-test-server-api/README.md
@@ -1,0 +1,45 @@
+# Git LFS Server API compliance test utility
+
+This package exists to provide automated testing of server API implementations, 
+to ensure that they conform to the behaviour expected by the client. You can
+run this utility against any server that implements the Git LFS API. 
+
+## Automatic or data-driven testing
+
+This utility is primarily intended to test the API implementation, but in order
+to correctly test the responses, the tests have to know what objects exist on
+the server already and which don't. 
+
+In 'automatic' mode, the tests require that both the API and the content server
+it links to via upload and download links are both available & free to use. 
+The content server must be empty at the start of the tests, and the tests will
+upload some data as part of the tests. Therefore obviously this cannot be a
+production system.
+
+Alternatively, in 'data-driven' mode, the tests must be provided with a list of 
+object IDs that already exist on the server (minimum 10), and a list of other
+object IDs that are known to not exist. The test will use these IDs to 
+construct its data sets, will only call the API (not the content server), and
+thus will not update any data - meaning you can in theory run this against a 
+production system. 
+
+## Calling the test tool
+
+```
+git-lfs-test-server-api [--url=<apiurl> | --clone=<cloneurl>] 
+                        [<oid-exists-file> <oid-missing-file>]
+```
+
+|Argument|Purpose|
+|------|-------|
+|`--url=<apiurl>`|URL of the server API to call. This must point directly at the API root and not the clone URL, and must be HTTP[S]. You must supply either this argument or the `--clone` argument|
+|`--clone=<cloneurl>`|The clone URL from which to derive the API URL. If it is HTTP[S], the test will try to find the API at `<cloneurl>/info/lfs`; if it is an SSH URL, then the test will call git-lfs-authenticate on the server to derive the API (with auth token if needed) just like the git-lfs client does. You must supply either this argument or the `--url` argument|
+|`<oid-exists-file> <oid-missing-file>`|Optional input files for data-driven mode (both must be supplied if this is used); each must be a file with one oid per line. The first must be a list of oids that exist on the server, the second must bea list of oids known not to exist. If supplied, the tests will not call the content server or modify any data. If omitted, the test will generate its own list of oids and will modify the server (and expects that the server is empty of oids at the start)|
+
+## Authentication
+
+Authentication will behave just like the git-lfs client, so for HTTP[S] URLs the
+git credential helper system will be used to obtain logins, and for SSH URLs,
+keys can be used to automate login. Otherwise you will receive prompts on the
+command line.
+

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -243,6 +243,32 @@ func callBatchApi(op string, objs []TestObject) ([]*lfs.ObjectResource, error) {
 	return lfs.Batch(apiobjs, op)
 }
 
+// Combine 2 slices into one by "randomly" interleaving
+// Not actually random, same sequence each time so repeatable
+func interleaveTestData(slice1, slice2 []TestObject) []TestObject {
+	// Predictable sequence, mixin existing & missing semi-randomly
+	rand.Seed(21)
+	count := len(slice1) + len(slice2)
+	ret := make([]TestObject, 0, count)
+	slice1Idx := 0
+	slice2Idx := 0
+	for left := count; left > 0; {
+		for i := rand.Intn(3) + 1; slice1Idx < len(slice1) && i > 0; i-- {
+			obj := slice1[slice1Idx]
+			ret = append(ret, obj)
+			slice1Idx++
+			left--
+		}
+		for i := rand.Intn(3) + 1; slice2Idx < len(slice2) && i > 0; i-- {
+			obj := slice2[slice2Idx]
+			ret = append(ret, obj)
+			slice2Idx++
+			left--
+		}
+	}
+	return ret
+}
+
 func init() {
 	RootCmd.Flags().StringVarP(&apiUrl, "url", "u", "", "URL of the API (must supply this or --clone)")
 	RootCmd.Flags().StringVarP(&cloneUrl, "clone", "c", "", "Clone URL from which to find API (must supply this or --url)")

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+
+	"github.com/github/git-lfs/lfs"
+	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
+)
+
+type ServerTest struct {
+	Name string
+	F    func(endp lfs.Endpoint, oidsExist, oidsMissing []string) error
+}
+
+var (
+	RootCmd = &cobra.Command{
+		Use:   "git-lfs-test-server-api [--url=<apiurl> | --clone=<cloneurl>] [<oid-exists-file> <oid-missing-file>]",
+		Short: "Test a Git LFS API server for compliance",
+		Run:   testServerApi,
+	}
+	apiUrl   string
+	cloneUrl string
+
+	tests []ServerTest
+)
+
+func main() {
+	RootCmd.Execute()
+}
+
+func testServerApi(cmd *cobra.Command, args []string) {
+
+	if (len(apiUrl) == 0 && len(cloneUrl) == 0) ||
+		(len(apiUrl) != 0 && len(cloneUrl) != 0) {
+		exit("Must supply either --url or --clone (and not both)")
+	}
+
+	if len(args) != 0 && len(args) != 2 {
+		exit("Must supply either no file arguments or both the exists AND missing file")
+	}
+
+	var endp lfs.Endpoint
+	if len(cloneUrl) > 0 {
+		endp = lfs.NewEndpointFromCloneURL(cloneUrl)
+	} else {
+		endp = lfs.NewEndpoint(apiUrl)
+	}
+
+	var oidsExist, oidsMissing []string
+	if len(args) >= 2 {
+		fmt.Printf("Reading test data from files (no server content changes)\n")
+		oidsExist = readTestOids(args[0])
+		oidsMissing = readTestOids(args[1])
+	} else {
+		fmt.Printf("Creating test data (will modify server contents)\n")
+		oidsExist, oidsMissing = constructTestOids()
+		// Run a 'test' which is really just a setup task, but because it has to
+		// use the same APIs it's a test in its own right too
+		err := runTest(ServerTest{"Set up test data", setupTestData}, endp, oidsExist, oidsMissing)
+		if err != nil {
+			exit("Failed to set up test data, aborting")
+		}
+	}
+
+	runTests(endp, oidsExist, oidsMissing)
+}
+
+func readTestOids(filename string) []string {
+	f, err := os.OpenFile(filename, os.O_RDONLY, 0644)
+	if err != nil {
+		exit("Error opening file %s", filename)
+	}
+	defer f.Close()
+
+	var ret []string
+	rdr := bufio.NewReader(f)
+	line, err := rdr.ReadString('\n')
+	for err == nil {
+		ret = append(ret, strings.TrimSpace(line))
+		line, err = rdr.ReadString('\n')
+	}
+
+	return ret
+}
+
+func constructTestOids() (oidsExist, oidsMissing []string) {
+	const oidCount = 50
+	oidsExist = make([]string, 0, oidCount)
+	oidsMissing = make([]string, 0, oidCount)
+
+	// Generate SHAs, not random so repeatable
+	rand.Seed(int64(oidCount))
+	runningSha := sha256.New()
+	for i := 0; i < oidCount; i++ {
+		runningSha.Write([]byte{byte(rand.Intn(256))})
+		oid := hex.EncodeToString(runningSha.Sum(nil))
+		oidsExist = append(oidsExist, oid)
+
+		runningSha.Write([]byte{byte(rand.Intn(256))})
+		oid = hex.EncodeToString(runningSha.Sum(nil))
+		oidsMissing = append(oidsMissing, oid)
+	}
+	return
+}
+
+func runTests(endp lfs.Endpoint, oidsExist, oidsMissing []string) {
+
+	fmt.Printf("Running %d tests...\n", len(tests))
+	for _, t := range tests {
+		runTest(t, endp, oidsExist, oidsMissing)
+	}
+
+}
+
+func runTest(t ServerTest, endp lfs.Endpoint, oidsExist, oidsMissing []string) error {
+	const linelen = 70
+	line := t.Name
+	if len(line) > linelen {
+		line = line[:linelen]
+	} else if len(line) < linelen {
+		line = fmt.Sprintf("%s%s", line, strings.Repeat(" ", linelen-len(line)))
+	}
+	fmt.Printf("%s...\r", line)
+
+	err := t.F(endp, oidsExist, oidsMissing)
+	if err != nil {
+		fmt.Printf("%s FAILED\n", line)
+		fmt.Println(err.Error())
+	} else {
+		fmt.Printf("%s OK\n", line)
+	}
+	return err
+}
+
+func setupTestData(endp lfs.Endpoint, oidsExist, oidsMissing []string) error {
+	// TODO
+	return nil
+}
+
+// Exit prints a formatted message and exits.
+func exit(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format, args...)
+	os.Exit(2)
+}
+
+func init() {
+	RootCmd.Flags().StringVarP(&apiUrl, "url", "u", "", "URL of the API (must supply this or --clone)")
+	RootCmd.Flags().StringVarP(&cloneUrl, "clone", "c", "", "Clone URL from which to find API (must supply this or --url)")
+}

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -71,6 +71,7 @@ func testServerApi(cmd *cobra.Command, args []string) {
 		oidsExist = readTestOids(args[0])
 		oidsMissing = readTestOids(args[1])
 	} else {
+		fmt.Printf("Creating test data (will upload to server)\n")
 		var err error
 		oidsExist, oidsMissing, err = buildTestData()
 		if err != nil {

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -204,6 +204,10 @@ func exit(format string, args ...interface{}) {
 	os.Exit(2)
 }
 
+func addTest(name string, f func(oidsExist, oidsMissing []TestObject) error) {
+	tests = append(tests, ServerTest{Name: name, F: f})
+}
+
 func init() {
 	RootCmd.Flags().StringVarP(&apiUrl, "url", "u", "", "URL of the API (must supply this or --clone)")
 	RootCmd.Flags().StringVarP(&cloneUrl, "clone", "c", "", "Clone URL from which to find API (must supply this or --url)")

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -92,7 +92,11 @@ func testServerApi(cmd *cobra.Command, args []string) {
 
 	}
 
-	runTests(oidsExist, oidsMissing)
+	ok := runTests(oidsExist, oidsMissing)
+	if !ok {
+		exit("One or more tests failed, see above")
+	}
+	fmt.Println("All tests passed")
 }
 
 func readTestOids(filename string) []TestObject {
@@ -195,13 +199,17 @@ func saveTestOids(filename string, objs []TestObject) {
 
 }
 
-func runTests(oidsExist, oidsMissing []TestObject) {
+func runTests(oidsExist, oidsMissing []TestObject) bool {
 
+	ok := true
 	fmt.Printf("Running %d tests...\n", len(tests))
 	for _, t := range tests {
-		runTest(t, oidsExist, oidsMissing)
+		err := runTest(t, oidsExist, oidsMissing)
+		if err != nil {
+			ok = false
+		}
 	}
-
+	return ok
 }
 
 func runTest(t ServerTest, oidsExist, oidsMissing []TestObject) error {

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -53,6 +53,9 @@ func testServerApi(cmd *cobra.Command, args []string) {
 		exit("Must supply either no file arguments or both the exists AND missing file")
 	}
 
+	// Force loading of config before we alter it
+	lfs.Config.AllGitConfig()
+
 	// Configure the endpoint manually
 	var endp lfs.Endpoint
 	if len(cloneUrl) > 0 {

--- a/test/git-lfs-test-server-api/testdownload.go
+++ b/test/git-lfs-test-server-api/testdownload.go
@@ -115,7 +115,7 @@ func downloadMixed(oidsExist, oidsMissing []TestObject) error {
 				errbuf.WriteString(fmt.Sprintf("Download link should not exist for %s, was %s\n", o.Oid, link))
 			}
 			if o.Error == nil {
-				errbuf.WriteString(fmt.Sprintf("Download should include an error for missing object %s, was %s\n", o.Oid))
+				errbuf.WriteString(fmt.Sprintf("Download should include an error for missing object %s", o.Oid))
 			} else if o.Error.Code != 404 {
 				errbuf.WriteString(fmt.Sprintf("Download error code for missing object %s should be 404, got %d\n", o.Oid, o.Error.Code))
 			}

--- a/test/git-lfs-test-server-api/testdownload.go
+++ b/test/git-lfs-test-server-api/testdownload.go
@@ -44,8 +44,8 @@ func downloadAllMissing(oidsExist, oidsMissing []TestObject) error {
 		return err
 	}
 
-	if len(retobjs) != len(oidsExist) {
-		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", len(oidsExist), len(retobjs))
+	if len(retobjs) != len(oidsMissing) {
+		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", len(oidsMissing), len(retobjs))
 	}
 
 	var errbuf bytes.Buffer

--- a/test/git-lfs-test-server-api/testdownload.go
+++ b/test/git-lfs-test-server-api/testdownload.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math/rand"
+
+	"github.com/github/git-lfs/lfs"
 )
 
 // "download" - all present
@@ -65,7 +68,74 @@ func downloadAllMissing(oidsExist, oidsMissing []TestObject) error {
 	return nil
 }
 
+// "download" - mixture
+func downloadMixed(oidsExist, oidsMissing []TestObject) error {
+
+	existSet := lfs.NewStringSetWithCapacity(len(oidsExist))
+	missingSet := lfs.NewStringSetWithCapacity(len(oidsMissing))
+
+	// Predictable sequence, mixin existing & missing semi-randomly
+	rand.Seed(21)
+	count := len(oidsExist) + len(oidsMissing)
+	calloids := make([]TestObject, 0, count)
+	existIdx := 0
+	missingIdx := 0
+	for left := count; left > 0; {
+		for i := rand.Intn(3) + 1; existIdx < len(oidsExist) && i > 0; i-- {
+			obj := oidsExist[existIdx]
+			existSet.Add(obj.Oid)
+			calloids = append(calloids, obj)
+			existIdx++
+			left--
+		}
+		for i := rand.Intn(3) + 1; missingIdx < len(oidsMissing) && i > 0; i-- {
+			obj := oidsMissing[missingIdx]
+			missingSet.Add(obj.Oid)
+			calloids = append(calloids, obj)
+			missingIdx++
+			left--
+		}
+	}
+
+	retobjs, err := callBatchApi("download", calloids)
+
+	if err != nil {
+		return err
+	}
+
+	if len(retobjs) != count {
+		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", count, len(retobjs))
+	}
+
+	var errbuf bytes.Buffer
+	for _, o := range retobjs {
+		link, ok := o.Rel("download")
+		if missingSet.Contains(o.Oid) {
+			if ok {
+				errbuf.WriteString(fmt.Sprintf("Download link should not exist for %s, was %s\n", o.Oid, link))
+			}
+			if o.Error == nil {
+				errbuf.WriteString(fmt.Sprintf("Download should include an error for missing object %s, was %s\n", o.Oid))
+			} else if o.Error.Code != 404 {
+				errbuf.WriteString(fmt.Sprintf("Download error code for missing object %s should be 404, got %d\n", o.Oid, o.Error.Code))
+			}
+		}
+		if existSet.Contains(o.Oid) && !ok {
+			errbuf.WriteString(fmt.Sprintf("Missing download link for %s\n", o.Oid))
+		}
+
+	}
+
+	if errbuf.Len() > 0 {
+		return errors.New(errbuf.String())
+	}
+
+	return nil
+
+}
+
 func init() {
 	addTest("Test download: all existing", downloadAllExist)
 	addTest("Test download: all missing", downloadAllMissing)
+	addTest("Test download: mixed", downloadMixed)
 }

--- a/test/git-lfs-test-server-api/testdownload.go
+++ b/test/git-lfs-test-server-api/testdownload.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+// "download" - all present
+func downloadAllExist(oidsExist, oidsMissing []TestObject) error {
+	retobjs, err := callBatchApi("download", oidsExist)
+
+	if err != nil {
+		return err
+	}
+
+	if len(retobjs) != len(oidsExist) {
+		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", len(oidsExist), len(retobjs))
+	}
+
+	var errbuf bytes.Buffer
+	for _, o := range retobjs {
+		_, ok := o.Rel("download")
+		if !ok {
+			errbuf.WriteString(fmt.Sprintf("Missing download link for %s\n", o.Oid))
+		}
+	}
+
+	if errbuf.Len() > 0 {
+		return errors.New(errbuf.String())
+	}
+
+	return nil
+}
+
+// "download" - all missing (test includes 404 error entry)
+func downloadAllMissing(oidsExist, oidsMissing []TestObject) error {
+	retobjs, err := callBatchApi("download", oidsMissing)
+
+	if err != nil {
+		return err
+	}
+
+	if len(retobjs) != len(oidsExist) {
+		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", len(oidsExist), len(retobjs))
+	}
+
+	var errbuf bytes.Buffer
+	for _, o := range retobjs {
+		link, ok := o.Rel("download")
+		if ok {
+			errbuf.WriteString(fmt.Sprintf("Download link should not exist for %s, was %s\n", o.Oid, link))
+		}
+		if o.Error == nil {
+			errbuf.WriteString(fmt.Sprintf("Download should include an error for missing object %s, was %s\n", o.Oid))
+		} else if o.Error.Code != 404 {
+			errbuf.WriteString(fmt.Sprintf("Download error code for missing object %s should be 404, got %d\n", o.Oid, o.Error.Code))
+		}
+	}
+
+	if errbuf.Len() > 0 {
+		return errors.New(errbuf.String())
+	}
+
+	return nil
+}
+
+func init() {
+	addTest("Test download: all existing", downloadAllExist)
+	addTest("Test download: all missing", downloadAllMissing)
+}

--- a/test/git-lfs-test-server-api/testupload.go
+++ b/test/git-lfs-test-server-api/testupload.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/github/git-lfs/lfs"
+)
+
+// "upload" - all missing
+func uploadAllMissing(oidsExist, oidsMissing []TestObject) error {
+	retobjs, err := callBatchApi("upload", oidsMissing)
+
+	if err != nil {
+		return err
+	}
+
+	if len(retobjs) != len(oidsMissing) {
+		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", len(oidsMissing), len(retobjs))
+	}
+
+	var errbuf bytes.Buffer
+	for _, o := range retobjs {
+		_, ok := o.Rel("upload")
+		if !ok {
+			errbuf.WriteString(fmt.Sprintf("Missing upload link for %s\n", o.Oid))
+		}
+		// verify link is optional so don't check
+	}
+
+	if errbuf.Len() > 0 {
+		return errors.New(errbuf.String())
+	}
+
+	return nil
+}
+
+// "upload" - all present
+func uploadAllExists(oidsExist, oidsMissing []TestObject) error {
+	retobjs, err := callBatchApi("upload", oidsExist)
+
+	if err != nil {
+		return err
+	}
+
+	if len(retobjs) != len(oidsExist) {
+		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", len(oidsExist), len(retobjs))
+	}
+
+	var errbuf bytes.Buffer
+	for _, o := range retobjs {
+		link, ok := o.Rel("upload")
+		if ok {
+			errbuf.WriteString(fmt.Sprintf("Upload link should not exist for %s, was %s\n", o.Oid, link))
+		}
+	}
+
+	if errbuf.Len() > 0 {
+		return errors.New(errbuf.String())
+	}
+
+	return nil
+}
+
+// "upload" - mix of missing & present
+func uploadMixed(oidsExist, oidsMissing []TestObject) error {
+
+	existSet := lfs.NewStringSetWithCapacity(len(oidsExist))
+	for _, o := range oidsExist {
+		existSet.Add(o.Oid)
+	}
+	missingSet := lfs.NewStringSetWithCapacity(len(oidsMissing))
+	for _, o := range oidsMissing {
+		missingSet.Add(o.Oid)
+	}
+
+	calloids := interleaveTestData(oidsExist, oidsMissing)
+	retobjs, err := callBatchApi("upload", calloids)
+
+	if err != nil {
+		return err
+	}
+
+	count := len(oidsExist) + len(oidsMissing)
+	if len(retobjs) != count {
+		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", count, len(retobjs))
+	}
+
+	var errbuf bytes.Buffer
+	for _, o := range retobjs {
+		link, ok := o.Rel("upload")
+		if existSet.Contains(o.Oid) {
+			if ok {
+				errbuf.WriteString(fmt.Sprintf("Upload link should not exist for %s, was %s\n", o.Oid, link))
+			}
+		}
+		if missingSet.Contains(o.Oid) && !ok {
+			errbuf.WriteString(fmt.Sprintf("Missing upload link for %s\n", o.Oid))
+		}
+
+	}
+
+	if errbuf.Len() > 0 {
+		return errors.New(errbuf.String())
+	}
+
+	return nil
+
+}
+
+func uploadEdgeCases(oidsExist, oidsMissing []TestObject) error {
+	errorCases := make([]TestObject, 0, 5)
+	errorCodeMap := make(map[string]int, 5)
+	errorReasonMap := make(map[string]string, 5)
+	validCases := make([]TestObject, 0, 1)
+	validReasonMap := make(map[string]string, 5)
+
+	// Invalid SHAs - code 422
+	// Too short
+	sha := "a345cde"
+	errorCases = append(errorCases, TestObject{Oid: sha, Size: 99})
+	errorCodeMap[sha] = 422
+	errorReasonMap[sha] = "SHA is too short"
+	// Too long
+	sha = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	errorCases = append(errorCases, TestObject{Oid: sha, Size: 99})
+	errorCodeMap[sha] = 422
+	errorReasonMap[sha] = "SHA is too long"
+	// Invalid characters -----!---------------------------------!
+	sha = "bf3e3e2af9366a3b704ax0c31de5afa64193ebabffde2091936ad2G7510bc03a"
+	errorCases = append(errorCases, TestObject{Oid: sha, Size: 99})
+	errorCodeMap[sha] = 422
+	errorReasonMap[sha] = "SHA contains invalid characters"
+
+	// Invalid size - code 422
+	sha = "e3bf3e2af9366a3b704af0c31de5afa64193ebabffde2091936ad237510bc03a"
+	errorCases = append(errorCases, TestObject{Oid: sha, Size: -1})
+	errorCodeMap[sha] = 422
+	errorReasonMap[sha] = "Negative size"
+	sha = "d2983e2af9366a3b704af0c31de5afa64193ebabffde2091936ad237510bc03a"
+	errorCases = append(errorCases, TestObject{Oid: sha, Size: -125})
+	errorCodeMap[sha] = 422
+	errorReasonMap[sha] = "Negative size"
+
+	// Zero size - should be allowed
+	sha = "159f6ac723b9023b704af0c31de5afa64193ebabffde2091936ad237510bc03a"
+	validCases = append(validCases, TestObject{Oid: sha, Size: 0})
+	validReasonMap[sha] = "Zero size should be allowed"
+
+	calloids := interleaveTestData(errorCases, validCases)
+	retobjs, err := callBatchApi("upload", calloids)
+
+	if err != nil {
+		return err
+	}
+
+	count := len(errorCases) + len(validCases)
+	if len(retobjs) != count {
+		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", count, len(retobjs))
+	}
+
+	var errbuf bytes.Buffer
+	for _, o := range retobjs {
+		link, ok := o.Rel("upload")
+		if code, iserror := errorCodeMap[o.Oid]; iserror {
+			reason, _ := errorReasonMap[o.Oid]
+			if ok {
+				errbuf.WriteString(fmt.Sprintf("Upload link should not exist for %s, was %s, reason %s\n", o.Oid, link, reason))
+			}
+			if o.Error == nil {
+				errbuf.WriteString(fmt.Sprintf("Upload should include an error for invalid object %s, reason %s", o.Oid, reason))
+			} else if o.Error.Code != code {
+				errbuf.WriteString(fmt.Sprintf("Upload error code for missing object %s should be %d, got %d, reason %s\n", o.Oid, code, o.Error.Code, reason))
+			}
+
+		}
+		if reason, reasonok := validReasonMap[o.Oid]; reasonok {
+			if !ok {
+				errbuf.WriteString(fmt.Sprintf("Missing upload link for %s, should be present because %s\n", o.Oid, reason))
+			}
+		}
+
+	}
+
+	if errbuf.Len() > 0 {
+		return errors.New(errbuf.String())
+	}
+
+	return nil
+
+}
+
+func init() {
+	addTest("Test upload: all missing", uploadAllMissing)
+	addTest("Test upload: all present", uploadAllExists)
+	addTest("Test upload: mixed", uploadMixed)
+	addTest("Test upload: edge cases", uploadEdgeCases)
+}

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -213,6 +213,8 @@ setup() {
     for go in test/cmd/*.go; do
       go build -o "$BINPATH/$(basename $go .go)" "$go"
     done
+    # Ensure API test util is built during tests to ensure it stays in sync
+    go build -o "$BINPATH/git-lfs-test-server-api" "test/git-lfs-test-server-api/main.go"
   fi
 
   LFSTEST_URL="$LFS_URL_FILE" LFSTEST_DIR="$REMOTEDIR" lfstest-gitserver > "$REMOTEDIR/gitserver.log" 2>&1 &


### PR DESCRIPTION
Created a tool called `git-lfs-test-server-api` which can be pointed at either an API URL or a clone URL and will run through a series of tests to ensure the responses are as expected. See the `Readme.md` for details of how to use it.

Currently only tests the API responses to upload/download and through inference correct authentication; HTTPS or SSH, works with both via `--clone=<url>`. Relies on the internal methods to test that content types etc are respected. In order to try to keep it simple to update in future, it just calls the `Batch()` method rather than trying to dig any deeper than that.

It can either generate its own test data (in which case it needs to be able to upload some initial state, although it doesn't push any commits, only LFS files), or it can be given lists of data to test with, in which case no server state is modified. In the latter case the content server is not hit at all, only the API.

I wrote this to provide a repeatable smoke test for API implementations, extensions for cases I haven't thought of are welcome, although as mentioned I didn't really want to go any lower than `Batch` to make it easier to keep in sync later.