### PR TITLE
Remove 'config clash' warning, this can be misleading

### DIFF
--- a/lfs/config.go
+++ b/lfs/config.go
@@ -389,7 +389,6 @@ func (c *Configuration) readGitConfigFromFiles(filenames []string, filenameIndex
 
 func (c *Configuration) readGitConfig(output string, uniqRemotes map[string]bool, onlySafe bool) {
 	lines := strings.Split(output, "\n")
-	uniqKeys := make(map[string]string)
 
 	for _, line := range lines {
 		pieces := strings.SplitN(line, "=", 2)
@@ -400,14 +399,6 @@ func (c *Configuration) readGitConfig(output string, uniqRemotes map[string]bool
 		allowed := !onlySafe
 		key := strings.ToLower(pieces[0])
 		value := pieces[1]
-
-		if origKey, ok := uniqKeys[key]; ok && c.gitConfig[key] != value {
-			fmt.Fprintf(os.Stderr, "WARNING: These git config values clash:\n")
-			fmt.Fprintf(os.Stderr, "  git config %q = %q\n", origKey, c.gitConfig[key])
-			fmt.Fprintf(os.Stderr, "  git config %q = %q\n", pieces[0], value)
-		} else {
-			uniqKeys[key] = pieces[0]
-		}
 
 		keyParts := strings.Split(key, ".")
 		if len(keyParts) == 4 && keyParts[0] == "lfs" && keyParts[1] == "extension" {


### PR DESCRIPTION
I'm not sure what problem this was originally solving but it causes false-positives in SourceTree and some scripts that I run. 

Common perfectly valid cases where this can happen include using the '-c' option to git on any setting that's already specified in the gitconfig. It's normal to want to override settings like this sometimes and the warnings look scary when everything is fine.

If there's a more specific way to solve the original problem please let me know.