### PR TITLE
Add git version dependency to 

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,12 +2,12 @@ Source: git-lfs
 Section: vcs
 Priority: optional
 Maintainer: Stephen Gelman <gelman@getbraintree.com>
-Build-Depends: debhelper (>= 9), dh-golang, golang-go:native (>= 1.3.0), git (>= 1.8.0), ruby-ronn
+Build-Depends: debhelper (>= 9), dh-golang, golang-go:native (>= 1.3.0), git (>= 1.8.2), ruby-ronn
 Standards-Version: 3.9.6
 
 Package: git-lfs
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, git
+Depends: ${shlibs:Depends}, ${misc:Depends}, git (>= 1.8.2)
 Built-Using: ${misc:Built-Using}
 Description: Git Large File Support
  An open source Git extension for versioning large files


### PR DESCRIPTION
Since git-lfs requires git >= 1.8.2 this ensures that people don't accidentally install it with older versions of git