### PR TITLE
Fix fallthrough when git-lfs-authenticate returns an error

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -648,6 +648,7 @@ func newApiRequest(method, oid string) (*http.Request, error) {
 		tracerx.Printf("ssh: attempted with %s.  Error: %s",
 			endpoint.SshUserAndHost, err.Error(),
 		)
+		return nil, err
 	}
 
 	if len(res.Href) > 0 {
@@ -691,6 +692,7 @@ func newBatchApiRequest(operation string) (*http.Request, error) {
 		tracerx.Printf("ssh: %s attempted with %s.  Error: %s",
 			operation, endpoint.SshUserAndHost, err.Error(),
 		)
+		return nil, err
 	}
 
 	if len(res.Href) > 0 {


### PR DESCRIPTION
If using an SSH URL and git-lfs-authenticate returns an error, without this change the error is just reported to the trace but execution continues.

A common result is a completely made up LFS URL being returned which then 404's, which ends up setting lfs.batch=false. If the server doesn't implement the non-batch interface, this config then breaks LFS even after the SSH issue is resolved & has to be manually removed, which is quite confusing for the user.