### PR TITLE
Fix loading config file (.lfsconfig or .gitconfig) when git lfs repository is used as submodule

### DIFF
--- a/lfs/config.go
+++ b/lfs/config.go
@@ -339,6 +339,14 @@ func (c *Configuration) loadGitConfig() bool {
 		// TODO: remove .gitconfig support for Git LFS v2.0 https://github.com/github/git-lfs/issues/839
 		filepath.Join(LocalWorkingDir, ".gitconfig"),
 	}
+
+	gitRootDir, _ := git.RootDir()
+	if gitRootDir != "" {
+		configFiles = append(configFiles, filepath.Join(gitRootDir, ".lfsconfig"),
+			// TODO: remove .gitconfig support for Git LFS v2.0 https://github.com/github/git-lfs/issues/839
+			filepath.Join(gitRootDir, ".gitconfig"))
+	}
+
 	c.readGitConfigFromFiles(configFiles, 0, uniqRemotes)
 
 	listOutput, err := git.Config.List()


### PR DESCRIPTION
If git lfs repository is used as submodule then git lfs can't find configure file (.lfsconfig or .gitconfig), because git lfs looks for the configure file in the directory <root_repository>/.git/modules (GIT_WORK_TREE) and the configure file is located in directory <root_repository>/<submodule_path>.