### PR TITLE
Support remote.name.pushurl correctly to fix #945

### DIFF
--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -16,7 +16,7 @@ var (
 func envCommand(cmd *cobra.Command, args []string) {
 	lfs.ShowConfigWarnings = true
 	config := lfs.Config
-	endpoint := config.Endpoint()
+	endpoint := config.Endpoint("download")
 
 	gitV, err := git.Config.Version()
 	if err != nil {
@@ -28,14 +28,14 @@ func envCommand(cmd *cobra.Command, args []string) {
 	Print("")
 
 	if len(endpoint.Url) > 0 {
-		Print("Endpoint=%s (auth=%s)", endpoint.Url, config.Access())
+		Print("Endpoint=%s (auth=%s)", endpoint.Url, config.EndpointAccess(endpoint))
 		if len(endpoint.SshUserAndHost) > 0 {
 			Print("  SSH=%s:%s", endpoint.SshUserAndHost, endpoint.SshPath)
 		}
 	}
 
 	for _, remote := range config.Remotes() {
-		remoteEndpoint := config.RemoteEndpoint(remote)
+		remoteEndpoint := config.RemoteEndpoint(remote, "download")
 		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, config.EndpointAccess(remoteEndpoint))
 		if len(remoteEndpoint.SshUserAndHost) > 0 {
 			Print("  SSH=%s:%s", remoteEndpoint.SshUserAndHost, remoteEndpoint.SshPath)

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -17,6 +17,11 @@ lfs option can be scoped inside the configuration for a remote.
   The url used to call the Git LFS remote API. Default blank (derive from clone
   URL).
 
+* `lfs.pushurl` / `<remote>.lfspushurl`
+
+  The url used to call the Git LFS remote API when pushing. Default blank (derive
+  from either LFS non-push urls or clone url).
+
 * `lfs.concurrenttransfers`
 
   The number of concurrent uploads/downloads. Default 3.

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -422,7 +422,7 @@ func doLegacyApiRequest(req *http.Request) (*http.Response, *ObjectResource, err
 	return res, obj, nil
 }
 
-// HttpRequestToOperation determines the operation type for a http.Request
+// getOperationForHttpRequest determines the operation type for a http.Request
 func getOperationForHttpRequest(req *http.Request) string {
 	operation := "download"
 	if req.Method == "POST" || req.Method == "PUT" {

--- a/lfs/credentials.go
+++ b/lfs/credentials.go
@@ -51,7 +51,8 @@ func getCredsForAPI(req *http.Request) (Creds, error) {
 }
 
 func getCredURLForAPI(req *http.Request) (*url.URL, error) {
-	apiUrl, err := Config.ObjectUrl("")
+	operation := getOperationForHttpRequest(req)
+	apiUrl, err := url.Parse(Config.Endpoint(operation).Url)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +70,7 @@ func getCredURLForAPI(req *http.Request) (*url.URL, error) {
 
 	credsUrl := apiUrl
 	if len(Config.CurrentRemote) > 0 {
-		if u, ok := Config.GitConfig("remote." + Config.CurrentRemote + ".url"); ok {
+		if u := Config.GitRemoteUrl(Config.CurrentRemote, operation == "upload"); u != "" {
 			gitRemoteUrl, err := url.Parse(u)
 			if err != nil {
 				return nil, err
@@ -90,7 +91,7 @@ func getCredURLForAPI(req *http.Request) (*url.URL, error) {
 }
 
 func skipCredsCheck(req *http.Request) bool {
-	if Config.NtlmAccess() {
+	if Config.NtlmAccess(getOperationForHttpRequest(req)) {
 		return false
 	}
 

--- a/lfs/ssh_test.go
+++ b/lfs/ssh_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSSHGetExeAndArgsSsh(t *testing.T) {
-	endpoint := Config.Endpoint()
+	endpoint := Config.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	oldGITSSH := Config.Getenv("GIT_SSH")
 	Config.Setenv("GIT_SSH", "")
@@ -20,7 +20,7 @@ func TestSSHGetExeAndArgsSsh(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsSshCustomPort(t *testing.T) {
-	endpoint := Config.Endpoint()
+	endpoint := Config.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
 	oldGITSSH := Config.Getenv("GIT_SSH")
@@ -33,7 +33,7 @@ func TestSSHGetExeAndArgsSshCustomPort(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsPlink(t *testing.T) {
-	endpoint := Config.Endpoint()
+	endpoint := Config.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	oldGITSSH := Config.Getenv("GIT_SSH")
 	// this will run on non-Windows platforms too but no biggie
@@ -47,7 +47,7 @@ func TestSSHGetExeAndArgsPlink(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsPlinkCustomPort(t *testing.T) {
-	endpoint := Config.Endpoint()
+	endpoint := Config.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
 	oldGITSSH := Config.Getenv("GIT_SSH")
@@ -62,7 +62,7 @@ func TestSSHGetExeAndArgsPlinkCustomPort(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsTortoisePlink(t *testing.T) {
-	endpoint := Config.Endpoint()
+	endpoint := Config.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	oldGITSSH := Config.Getenv("GIT_SSH")
 	// this will run on non-Windows platforms too but no biggie
@@ -76,7 +76,7 @@ func TestSSHGetExeAndArgsTortoisePlink(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsTortoisePlinkCustomPort(t *testing.T) {
-	endpoint := Config.Endpoint()
+	endpoint := Config.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
 	oldGITSSH := Config.Getenv("GIT_SSH")


### PR DESCRIPTION
Fixes #945 

Right now git-lfs ignores the use of 'remote.[name].pushurl' in asymmetrical pull/push situations (within a single remote). This PR changes the way Endpoints are built so that the operation ("download" or "upload") is taken into account and the pushurl is used as a basis instead of the url when pushing. This avoids git-lfs behaving inconsistently with Git itself & the resulting confusion.

Also add support for 'remote.[name].lfspushurl' and global 'lfs.pushurl' so that push versions of urls are supported everywhere you might configure them.

This also affects the Access flags which are stored & looked up alongside the correct url based on whether you're pulling or pushing, in case the 2 urls have different auth mechanisms.