### PR TITLE
Fix submodule lfsconfig

### DIFF
--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -179,22 +179,15 @@ func processGitDirVar(gitDir, workTree string) (string, string, error) {
 }
 
 func processWorkTreeVar(gitDir, workTree string) (string, string, error) {
-	// See `core.worktree` in `man git-config`:
-	// “The value [of core.worktree, GIT_WORK_TREE, or --work-tree] can be an absolute path
-	// or relative to the path to the .git directory, which is either specified
-	// by --git-dir or GIT_DIR, or automatically discovered.”
-
-	if filepath.IsAbs(workTree) {
-		return workTree, gitDir, nil
+	absWorkTree, err := filepath.Abs(workTree)
+	if err != nil {
+		return workTree, gitDir, err
 	}
 
-	base := filepath.Dir(filepath.Clean(gitDir))
-	absWorkTree := filepath.Join(base, workTree)
 	return absWorkTree, gitDir, nil
 }
 
 func resolveGitDirFromCurrentDir() (string, string, error) {
-
 	// Get root of the git working dir
 	gitDir, err := git.GitDir()
 	if err != nil {

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -99,7 +99,7 @@ func InRepo() bool {
 
 func ResolveDirs() {
 	var err error
-	LocalWorkingDir, LocalGitDir, err = resolveGitDir()
+	LocalGitDir, LocalWorkingDir, err = git.GitAndRootDirs()
 	if err == nil {
 		LocalGitStorageDir = resolveGitStorageDir(LocalGitDir)
 		LocalMediaDir = filepath.Join(LocalGitStorageDir, "lfs", "objects")
@@ -117,11 +117,16 @@ func ResolveDirs() {
 		if err := os.MkdirAll(LocalObjectTempDir, tempDirPerms); err != nil {
 			panic(fmt.Errorf("Error trying to create temp directory in '%s': %s", TempDir, err))
 		}
+	} else {
+		errMsg := err.Error()
+		tracerx.Printf("Error running 'git rev-parse': %s", errMsg)
+		if !strings.Contains(errMsg, "Not a git repository") {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", errMsg)
+		}
 	}
 }
 
 func init() {
-
 	tracerx.DefaultKey = "GIT"
 	tracerx.Prefix = "trace git-lfs: "
 
@@ -138,84 +143,6 @@ func init() {
 		strings.Replace(runtime.Version(), "go", "", 1),
 		gitCommit,
 	)
-}
-
-func resolveGitDir() (string, string, error) {
-	gitDir := Config.Getenv("GIT_DIR")
-	workTree := Config.Getenv("GIT_WORK_TREE")
-
-	if gitDir != "" {
-		return processGitDirVar(gitDir, workTree)
-	}
-
-	workTreeR, gitDirR, err := resolveGitDirFromCurrentDir()
-	if err != nil {
-		return "", "", err
-	}
-
-	if workTree != "" {
-		return processWorkTreeVar(gitDirR, workTree)
-	}
-
-	return workTreeR, gitDirR, nil
-}
-
-func processGitDirVar(gitDir, workTree string) (string, string, error) {
-	if workTree != "" {
-		return processWorkTreeVar(gitDir, workTree)
-	}
-
-	// See `core.worktree` in `man git-config`:
-	// “If --git-dir or GIT_DIR is specified but none of --work-tree, GIT_WORK_TREE and
-	// core.worktree is specified, the current working directory is regarded as the top
-	// level of your working tree.”
-
-	wd, err := os.Getwd()
-	if err != nil {
-		return "", "", err
-	}
-
-	return wd, gitDir, nil
-}
-
-func processWorkTreeVar(gitDir, workTree string) (string, string, error) {
-	absWorkTree, err := filepath.Abs(workTree)
-	if err != nil {
-		return workTree, gitDir, err
-	}
-
-	return absWorkTree, gitDir, nil
-}
-
-func resolveGitDirFromCurrentDir() (string, string, error) {
-	// Get root of the git working dir
-	gitDir, err := git.GitDir()
-	if err != nil {
-		return "", "", err
-	}
-
-	// Allow this to fail, will do so if GIT_DIR isn't set but GIT_WORK_TREE is rel
-	// Dealt with by parent
-	rootDir, _ := git.RootDir()
-
-	return rootDir, gitDir, nil
-}
-
-func resolveDotGitFile(file string) (string, string, error) {
-	// The local working directory is the directory the `.git` file is located in.
-	wd := filepath.Dir(file)
-
-	// The `.git` file tells us where the submodules `.git` directory is.
-	gitDir, err := processDotGitFile(file)
-	if err != nil {
-		return "", "", err
-	}
-
-	return wd, gitDir, nil
-}
-
-func processDotGitFile(file string) (string, error) {
-	return processGitRedirectFile(file, gitPtrPrefix)
 }
 
 func processGitRedirectFile(file, prefix string) (string, error) {

--- a/test/test-commit-delete-push.sh
+++ b/test/test-commit-delete-push.sh
@@ -33,12 +33,12 @@ begin_test "commit, delete, then push"
   git rm deleted.dat
   git commit -m "did not need deleted.dat after all"
 
-  GIT_TRACE=1 git lfs push origin master --dry-run 2>&1 | tee dryrun.log
+  git lfs push origin master --dry-run 2>&1 | tee dryrun.log
   grep "push ee31ef227442936872744b50d3297385c08b40ffc7baeaf34a39e6d81d6cd9ee => deleted.dat" dryrun.log
   grep "push 3428719b7688c78a0cc8ba4b9e80b4e464c815fbccfd4b20695a15ffcefc22af => added.dat" dryrun.log
 
   git log
-  GIT_TRACE=1 git push origin master 2>&1 > push.log || {
+  git push origin master 2>&1 > push.log || {
     cat push.log
     git lfs logs last
     exit 1

--- a/test/test-submodule-lfsconfig.sh
+++ b/test/test-submodule-lfsconfig.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+lfsname="submodule-config-test-lfs"
+reponame="submodule-config-test-repo"
+submodname="submodule-config-test-submodule"
+
+begin_test "submodule env with .lfsconfig"
+(
+  set -e
+
+  # setup dummy repo with lfs store
+  # no git data will be pushed, just lfs objects
+  setup_remote_repo "$lfsname"
+  echo $GITSERVER/$lfsname.git/info/lfs
+
+  # setup submodule
+  setup_remote_repo "$submodname"
+  clone_repo "$submodname" submod
+  mkdir dir
+  git config -f .lfsconfig lfs.url "$GITSERVER/$lfsname.git/info/lfs"
+  git lfs track "*.dat"
+  submodcontent="submodule lfs file"
+  submodoid=$(calc_oid "$submodcontent")
+  printf "$submodcontent" > dir/test.dat
+  git add .lfsconfig .gitattributes dir
+  git commit -m "create submodule"
+  git push origin master
+
+  assert_server_object "$lfsname" "$submodoid"
+
+  # setup repo with submodule
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" repo
+  git config -f .lfsconfig lfs.url "$GITSERVER/$lfsname.git/info/lfs"
+  git submodule add "$GITSERVER/$submodname" sub
+  git submodule update
+  git lfs track "*.dat"
+  mkdir dir
+  repocontent="repository lfs file"
+  repooid=$(calc_oid "$repocontent")
+  printf "$repocontent" > dir/test.dat
+  git add .gitattributes .lfsconfig .gitmodules dir sub
+  git commit -m "create repo"
+  git push origin master
+
+  assert_server_object "$lfsname" "$repooid"
+
+  echo "repo"
+  git lfs env | tee env.log
+  grep "Endpoint=$GITSERVER/$lfsname.git/info/lfs (auth=basic)$" env.log
+
+  cd sub
+  echo "./sub"
+  git lfs env | tee env.log
+  grep "Endpoint=$GITSERVER/$lfsname.git/info/lfs (auth=basic)$" env.log
+
+  cd dir
+  echo "./sub/dir"
+  git lfs env | tee env.log
+  grep "Endpoint=$GITSERVER/$lfsname.git/info/lfs (auth=basic)$" env.log
+)
+end_test
+
+begin_test "submodule update --init --remote with .lfsconfig"
+(
+  set -e
+  clone_repo "$reponame" clone
+  grep "$repocontent" dir/test.dat
+
+  git submodule update --init --remote
+
+  grep "$submodcontent" sub/dir/test.dat
+)
+end_test

--- a/test/test-submodule.sh
+++ b/test/test-submodule.sh
@@ -26,6 +26,7 @@ begin_test "submodule local git dir"
   git push origin master
 
   grep "sub module" sub/dir/README || {
+    echo "submodule not setup correctly?"
     cat sub/dir/README
     exit 1
   }


### PR DESCRIPTION
This is another approach to fixing #922.

While #927 fixes the bug, I'm not completey happy with it. Calling `git.RootDir()` in `loadGitConfig()` adds another os exec that's run on _every_ lfs command. This is in addition to when it's run inside `resolveGitDir()` if the `GIT_DIR` is specified. I'd like to fix the behavior without running `git.RootDir()` again.

The problem: `git submodule update --init --remote` runs `git lfs smudge` commands with the following env:

```
GIT_DIR=/path/to/repo/.git/modules/sub
GIT_WORK_TREE=.
```

When run with the above ENV vars, `LocalWorkingDirectory` is `/path/to/repo/.git/modules`, which is wrong. It should be `/path/to/repo/sub`, where `sub` is the path for the submodule. Here's the [code](https://github.com/github/git-lfs/blob/84e9e66c9156564180c9621491865b985f3c838d/lfs/lfs.go#L187-L193):

```go
func processWorkTreeVar(gitDir, workTree string) (string, string, error) {
	// See `core.worktree` in `man git-config`:
	// “The value [of core.worktree, GIT_WORK_TREE, or --work-tree] can be an absolute path
	// or relative to the path to the .git directory, which is either specified
	// by --git-dir or GIT_DIR, or automatically discovered.”

	if filepath.IsAbs(workTree) {
		return workTree, gitDir, nil
	}

	base := filepath.Dir(filepath.Clean(gitDir))
	absWorkTree := filepath.Join(base, workTree)
	return absWorkTree, gitDir, nil
}
```

If we treat `GIT_WORK_TREE=.` relative to the process' current working directory, it works just fine.  It seems like the comments (which are taken directly from the git docs) are wrong in this case. I can pass both `--git-dir` and `--work-tree` to get the status of my local git-lfs repo, from a totally different directory:

```cli
~/test $ git --git-dir=/Users/rick/p/git-lfs/.git --work-tree="/Users/rick/p/git-lfs" status -sb
## rikdev-fix-submodule-lfsconfig...origin/rikdev-fix-submodule-lfsconfig
 M lfs/config.go
 M lfs/lfs.go
 M test/test-submodule-lfsconfig.sh
```

If I try relative to the `.git` directory, it doesn't work.

```
~/test $ git --git-dir=/Users/rick/p/git-lfs/.git --work-tree=".." status -sb
## rikdev-fix-submodule-lfsconfig...origin/rikdev-fix-submodule-lfsconfig
 D ../.gitattributes
```

If I try relative to the current working directory, while in the git-lfs directory, it works:

```cli
~p/git-lfs git:(rikdev-fix-submodule-lfsconfig) $ git --git-dir=/Users/rick/p/git-lfs/.git --work-tree="." status -sb
## rikdev-fix-submodule-lfsconfig...origin/rikdev-fix-submodule-lfsconfig
 M lfs/config.go
 M lfs/lfs.go
 M test/test-submodule-lfsconfig.sh
```

@sinbad @rikdev: Thoughts?  