### PR TITLE
convert git:// remotes to the lfs default

### DIFF
--- a/lfs/config.go
+++ b/lfs/config.go
@@ -512,7 +512,8 @@ func keyIsUnsafe(key string) bool {
 }
 
 var safeKeys = []string{
-	"lfs.url",
-	"lfs.fetchinclude",
 	"lfs.fetchexclude",
+	"lfs.fetchinclude",
+	"lfs.gitprotocol",
+	"lfs.url",
 }

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -112,7 +112,6 @@ func (c *Configuration) GetenvBool(key string, def bool) bool {
 // GitRemoteUrl returns the git clone/push url for a given remote (blank if not found)
 // the forpush argument is to cater for separate remote.name.pushurl settings
 func (c *Configuration) GitRemoteUrl(remote string, forpush bool) string {
-
 	if forpush {
 		if u, ok := c.GitConfig("remote." + remote + ".pushurl"); ok {
 			return u
@@ -128,15 +127,14 @@ func (c *Configuration) GitRemoteUrl(remote string, forpush bool) string {
 }
 
 func (c *Configuration) Endpoint(operation string) Endpoint {
-
 	if operation == "upload" {
 		if url, ok := c.GitConfig("lfs.pushurl"); ok {
-			return NewEndpoint(url)
+			return NewEndpointWithConfig(url, c)
 		}
 	}
 
 	if url, ok := c.GitConfig("lfs.url"); ok {
-		return NewEndpoint(url)
+		return NewEndpointWithConfig(url, c)
 	}
 
 	if len(c.CurrentRemote) > 0 && c.CurrentRemote != defaultRemote {
@@ -252,16 +250,16 @@ func (c *Configuration) RemoteEndpoint(remote, operation string) Endpoint {
 	// Support separate push URL if specified and pushing
 	if operation == "upload" {
 		if url, ok := c.GitConfig("remote." + remote + ".lfspushurl"); ok {
-			return NewEndpoint(url)
+			return NewEndpointWithConfig(url, c)
 		}
 	}
 	if url, ok := c.GitConfig("remote." + remote + ".lfsurl"); ok {
-		return NewEndpoint(url)
+		return NewEndpointWithConfig(url, c)
 	}
 
 	// finally fall back on git remote url (also supports pushurl)
 	if url := c.GitRemoteUrl(remote, operation == "upload"); url != "" {
-		return NewEndpointFromCloneURL(url)
+		return NewEndpointFromCloneURLWithConfig(url, c)
 	}
 
 	return Endpoint{}
@@ -270,6 +268,15 @@ func (c *Configuration) RemoteEndpoint(remote, operation string) Endpoint {
 func (c *Configuration) Remotes() []string {
 	c.loadGitConfig()
 	return c.remotes
+}
+
+// GitProtocol returns the protocol for the LFS API when converting from a
+// git:// remote url.
+func (c *Configuration) GitProtocol() string {
+	if value, ok := c.GitConfig("lfs.gitprotocol"); ok {
+		return value
+	}
+	return "https"
 }
 
 func (c *Configuration) Extensions() map[string]Extension {

--- a/lfs/config_test.go
+++ b/lfs/config_test.go
@@ -243,6 +243,32 @@ func TestBareHTTPEndpointAddsLfsSuffix(t *testing.T) {
 	assert.Equal(t, "", endpoint.SshPort)
 }
 
+func TestGitEndpointAddsLfsSuffix(t *testing.T) {
+	config := &Configuration{
+		gitConfig: map[string]string{"remote.origin.url": "git://example.com/foo/bar"},
+		remotes:   []string{},
+	}
+
+	endpoint := config.Endpoint("download")
+	assert.Equal(t, "https://example.com/foo/bar.git/info/lfs", endpoint.Url)
+	assert.Equal(t, "", endpoint.SshUserAndHost)
+	assert.Equal(t, "", endpoint.SshPath)
+	assert.Equal(t, "", endpoint.SshPort)
+}
+
+func TestBareGitEndpointAddsLfsSuffix(t *testing.T) {
+	config := &Configuration{
+		gitConfig: map[string]string{"remote.origin.url": "git://example.com/foo/bar.git"},
+		remotes:   []string{},
+	}
+
+	endpoint := config.Endpoint("download")
+	assert.Equal(t, "https://example.com/foo/bar.git/info/lfs", endpoint.Url)
+	assert.Equal(t, "", endpoint.SshUserAndHost)
+	assert.Equal(t, "", endpoint.SshPath)
+	assert.Equal(t, "", endpoint.SshPort)
+}
+
 func TestConcurrentTransfersSetValue(t *testing.T) {
 	config := &Configuration{
 		gitConfig: map[string]string{

--- a/lfs/config_test.go
+++ b/lfs/config_test.go
@@ -256,6 +256,22 @@ func TestGitEndpointAddsLfsSuffix(t *testing.T) {
 	assert.Equal(t, "", endpoint.SshPort)
 }
 
+func TestGitEndpointAddsLfsSuffixWithCustomProtocol(t *testing.T) {
+	config := &Configuration{
+		gitConfig: map[string]string{
+			"remote.origin.url": "git://example.com/foo/bar",
+			"lfs.gitprotocol":   "http",
+		},
+		remotes: []string{},
+	}
+
+	endpoint := config.Endpoint("download")
+	assert.Equal(t, "http://example.com/foo/bar.git/info/lfs", endpoint.Url)
+	assert.Equal(t, "", endpoint.SshUserAndHost)
+	assert.Equal(t, "", endpoint.SshPath)
+	assert.Equal(t, "", endpoint.SshPort)
+}
+
 func TestBareGitEndpointAddsLfsSuffix(t *testing.T) {
 	config := &Configuration{
 		gitConfig: map[string]string{"remote.origin.url": "git://example.com/foo/bar.git"},

--- a/lfs/endpoint.go
+++ b/lfs/endpoint.go
@@ -47,6 +47,8 @@ func NewEndpoint(rawurl string) Endpoint {
 		return endpointFromSshUrl(u)
 	case "http", "https":
 		return endpointFromHttpUrl(u)
+	case "git":
+		return endpointFromGitUrl(u)
 	case "":
 		return endpointFromBareSshUrl(u)
 	default:
@@ -123,6 +125,11 @@ func endpointFromSshUrl(u *url.URL) Endpoint {
 // Construct a new endpoint from a HTTP URL
 func endpointFromHttpUrl(u *url.URL) Endpoint {
 	// just pass this straight through
+	return Endpoint{Url: u.String()}
+}
+
+func endpointFromGitUrl(u *url.URL) Endpoint {
+	u.Scheme = "https"
 	return Endpoint{Url: u.String()}
 }
 

--- a/lfs/endpoint.go
+++ b/lfs/endpoint.go
@@ -21,7 +21,18 @@ type Endpoint struct {
 // NewEndpointFromCloneURL creates an Endpoint from a git clone URL by appending
 // "[.git]/info/lfs".
 func NewEndpointFromCloneURL(url string) Endpoint {
-	e := NewEndpoint(url)
+	return NewEndpointFromCloneURLWithConfig(url, NewConfig())
+}
+
+// NewEndpoint initializes a new Endpoint for a given URL.
+func NewEndpoint(rawurl string) Endpoint {
+	return NewEndpointWithConfig(rawurl, NewConfig())
+}
+
+// NewEndpointFromCloneURLWithConfig creates an Endpoint from a git clone URL by appending
+// "[.git]/info/lfs".
+func NewEndpointFromCloneURLWithConfig(url string, c *Configuration) Endpoint {
+	e := NewEndpointWithConfig(url, c)
 	if e.Url == EndpointUrlUnknown {
 		return e
 	}
@@ -35,8 +46,8 @@ func NewEndpointFromCloneURL(url string) Endpoint {
 	return e
 }
 
-// NewEndpoint initializes a new Endpoint for a given URL.
-func NewEndpoint(rawurl string) Endpoint {
+// NewEndpointWithConfig initializes a new Endpoint for a given URL.
+func NewEndpointWithConfig(rawurl string, c *Configuration) Endpoint {
 	u, err := url.Parse(rawurl)
 	if err != nil {
 		return Endpoint{Url: EndpointUrlUnknown}
@@ -48,7 +59,7 @@ func NewEndpoint(rawurl string) Endpoint {
 	case "http", "https":
 		return endpointFromHttpUrl(u)
 	case "git":
-		return endpointFromGitUrl(u)
+		return endpointFromGitUrl(u, c)
 	case "":
 		return endpointFromBareSshUrl(u)
 	default:
@@ -128,8 +139,8 @@ func endpointFromHttpUrl(u *url.URL) Endpoint {
 	return Endpoint{Url: u.String()}
 }
 
-func endpointFromGitUrl(u *url.URL) Endpoint {
-	u.Scheme = "https"
+func endpointFromGitUrl(u *url.URL, c *Configuration) Endpoint {
+	u.Scheme = c.GitProtocol()
 	return Endpoint{Url: u.String()}
 }
 


### PR DESCRIPTION
This converts `git://SERVER/REPO` remotes to an LFS URL like `https://SERVER/REPO.git/info/lfs`. This removes the need for users to manually configure the LFS url.