### PR TITLE
Don't create LFS pointer for empty files

### DIFF
--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -67,14 +67,16 @@ func (p *Pointer) Encode(writer io.Writer) (int, error) {
 
 func (p *Pointer) Encoded() string {
 	var buffer bytes.Buffer
-	if p.Size != 0 {
-		buffer.WriteString(fmt.Sprintf("version %s\n", latest))
-		for _, ext := range p.Extensions {
-			buffer.WriteString(fmt.Sprintf("ext-%d-%s %s:%s\n", ext.Priority, ext.Name, ext.OidType, ext.Oid))
-		}
-		buffer.WriteString(fmt.Sprintf("oid %s:%s\n", p.OidType, p.Oid))
-		buffer.WriteString(fmt.Sprintf("size %d\n", p.Size))
+	if p.Size == 0 {
+		return buffer.String()
 	}
+
+	buffer.WriteString(fmt.Sprintf("version %s\n", latest))
+	for _, ext := range p.Extensions {
+		buffer.WriteString(fmt.Sprintf("ext-%d-%s %s:%s\n", ext.Priority, ext.Name, ext.OidType, ext.Oid))
+	}
+	buffer.WriteString(fmt.Sprintf("oid %s:%s\n", p.OidType, p.Oid))
+	buffer.WriteString(fmt.Sprintf("size %d\n", p.Size))
 	return buffer.String()
 }
 

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -67,12 +67,14 @@ func (p *Pointer) Encode(writer io.Writer) (int, error) {
 
 func (p *Pointer) Encoded() string {
 	var buffer bytes.Buffer
-	buffer.WriteString(fmt.Sprintf("version %s\n", latest))
-	for _, ext := range p.Extensions {
-		buffer.WriteString(fmt.Sprintf("ext-%d-%s %s:%s\n", ext.Priority, ext.Name, ext.OidType, ext.Oid))
+	if p.Size != 0 {
+		buffer.WriteString(fmt.Sprintf("version %s\n", latest))
+		for _, ext := range p.Extensions {
+			buffer.WriteString(fmt.Sprintf("ext-%d-%s %s:%s\n", ext.Priority, ext.Name, ext.OidType, ext.Oid))
+		}
+		buffer.WriteString(fmt.Sprintf("oid %s:%s\n", p.OidType, p.Oid))
+		buffer.WriteString(fmt.Sprintf("size %d\n", p.Size))
 	}
-	buffer.WriteString(fmt.Sprintf("oid %s:%s\n", p.OidType, p.Oid))
-	buffer.WriteString(fmt.Sprintf("size %d\n", p.Size))
 	return buffer.String()
 }
 

--- a/lfs/pointer_test.go
+++ b/lfs/pointer_test.go
@@ -29,6 +29,18 @@ func TestEncode(t *testing.T) {
 	assert.Equal(t, "EOF", err.Error())
 }
 
+func TestEncodeEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	pointer := NewPointer("", 0, nil)
+	_, err := EncodePointer(&buf, pointer)
+	assert.Equal(t, nil, err)
+
+	bufReader := bufio.NewReader(&buf)
+	val, err := bufReader.ReadString('\n')
+	assert.Equal(t, "", val)
+	assert.Equal(t, "EOF", err.Error())
+}
+
 func TestEncodeExtensions(t *testing.T) {
 	var buf bytes.Buffer
 	exts := []*PointerExtension{


### PR DESCRIPTION
This PR fixes the reported behaviour in https://github.com/github/git-lfs/issues/557, where Git reports
a delta, if an attempt was made to track empty files with LFS.
If there already have been empty files tracked with LFS, these
need to be untracked manually, as this fix only prevents that
newly created, empty files can be tracked by LFS.

Problem is, that Git never runs the clean filter on 0-byte files:

https://github.com/git/git/blob/80980a1d5c2678ab9031d7c60faf38b9631eb1ce/diff.c#L2777

This leads to a diff between the file in the repository (pointer file) and 
the actual file content. Apparently the git-fat project seems to be affected 
by this, too (https://github.com/jedbrown/git-fat/issues/18).
The fix/workaround for this in LFS is simple; just don't create pointers 
for 0-byte target files, it's useless to store them in LFS anyway.

I'm not too sure though if my current patch is sufficient - it just checks
if the given file from the parameters has a size == 0, but apparently the
pointer creation + hash calculation is done from the stdin content. So just
let me know if this needs a rework with length calculation of the stdin
io.Reader.