### PR TITLE
don't pass GIT_TRACE to exec.Command calls in the git package

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -636,7 +636,4 @@ func init() {
 		}
 		env = append(env, kv)
 	}
-
-	fmt.Println(env)
-	fmt.Println(realEnv)
 }

--- a/git/git_nix.go
+++ b/git/git_nix.go
@@ -9,5 +9,7 @@ import (
 
 // execCommand is a small platform specific wrapper around os/exec.Command
 func execCommand(name string, arg ...string) *exec.Cmd {
-	return exec.Command(name, arg...)
+	cmd := exec.Command(name, arg...)
+	cmd.Env = env
+	return cmd
 }

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -260,7 +260,6 @@ func TestWorkTrees(t *testing.T) {
 }
 
 func TestVersionCompare(t *testing.T) {
-
 	assert.Equal(t, true, IsVersionAtLeast("2.6.0", "2.6.0"))
 	assert.Equal(t, true, IsVersionAtLeast("2.6.0", "2.6"))
 	assert.Equal(t, true, IsVersionAtLeast("2.6.0", "2"))
@@ -271,4 +270,13 @@ func TestVersionCompare(t *testing.T) {
 	assert.Equal(t, false, IsVersionAtLeast("2.5.0", "2.6"))
 	assert.Equal(t, false, IsVersionAtLeast("2.5.0", "2.5.1"))
 	assert.Equal(t, false, IsVersionAtLeast("2.5.2", "2.5.10"))
+}
+
+func TestGitAndRootDirs(t *testing.T) {
+	git, root, err := GitAndRootDirs()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, git, root+"/.git")
 }

--- a/git/git_win.go
+++ b/git/git_win.go
@@ -12,5 +12,6 @@ import (
 func execCommand(name string, arg ...string) *exec.Cmd {
 	cmd := exec.Command(name, arg...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	cmd.Env = env
 	return cmd
 }

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 set -e
 script/test
+
+# re-run test to ensure GIT_TRACE output doesn't leak into the git package
+GIT_TRACE=1 script/test git
+
 VERBOSE_LOGS=1 script/integration


### PR DESCRIPTION
The `git` package provides an api around the `git` command. It doesn't make sense to pass any `GIT_TRACE` env values to it. Here are the errors just from the tests:

```
$ GIT_TRACE=1 script/test git
trace git-lfs: run_command: 'git' config -l
trace git-lfs: run_command: 'git' rev-parse HEAD --symbolic-full-name HEAD
--- FAIL: TestCurrentRefAndCurrentRemoteRef (0.21s)
	assert.go:16: /Users/rick/go/src/github.com/github/git-lfs/git/git_test.go:53
	assert.go:25: ! Sha: "12:08:04.097045 git.c:348               trace: built-in: git 'show' '-s' '--format=%H" != "8263b6dfdc1ec816145ab1635d3719d54bfa8d67"
trace git-lfs: RECENT: Getting refs >= 2016-01-27 12:08:04.156600185 -0700 MST
trace git-lfs: RECENT: master (2016-02-03 12:08:04 -0700 MST)
trace git-lfs: RECENT: included_branch_2 (2016-01-31 12:08:04 -0700 MST)
trace git-lfs: RECENT: included_branch (2016-01-28 12:08:04 -0700 MST)
--- FAIL: TestRecentBranches (0.56s)
	assert.go:16: /Users/rick/go/src/github.com/github/git-lfs/git/git_test.go:149
	assert.go:25: ! []*git.Ref{
		    &git.Ref{Name:"master", Type:0, Sha:"12:08:04.394597 git.c:348               trace: built-in: git 'show' '-s' '--format=%H"},
		    &git.Ref{Name:"included_branch_2", Type:0, Sha:"12:08:04.359162 git.c:348               trace: built-in: git 'show' '-s' '--format=%H"},
		    &git.Ref{Name:"included_branch", Type:0, Sha:"12:08:04.323946 git.c:348               trace: built-in: git 'show' '-s' '--format=%H"},
		} != []*git.Ref{
		    &git.Ref{Name:"master", Type:0, Sha:"c767f84c80519f760b7e267fcaaf8fb3645b6b34"},
		    &git.Ref{Name:"included_branch_2", Type:0, Sha:"e608c9454073e3cda9d58cc68bb23afa5ecd8fa0"},
		    &git.Ref{Name:"included_branch", Type:0, Sha:"7a2005c9affcd46807f3f32f323fe5417f994360"},
		}
	assert.go:28: !  - Refs should be correct
trace git-lfs: run_command: 'git' rev-parse HEAD --symbolic-full-name HEAD
trace git-lfs: run_command: 'git' version
trace git-lfs: run_command: 'git' rev-parse refs/heads/branch2 --symbolic-full-name refs/heads/branch2
trace git-lfs: run_command: 'git' rev-parse refs/heads/branch4 --symbolic-full-name refs/heads/branch4
trace git-lfs: run_command: 'git' rev-parse refs/heads/master --symbolic-full-name refs/heads/master
--- FAIL: TestWorkTrees (0.36s)
	assert.go:16: /Users/rick/go/src/github.com/github/git-lfs/git/git_test.go:259
	assert.go:25: ! []*git.Ref{
		    &git.Ref{Name:"branch2", Type:0, Sha:"12:08:04.831492 git.c:348               trace: built-in: git 'show' '-s' '--format=%H"},
		    &git.Ref{Name:"branch4", Type:0, Sha:"12:08:04.946992 git.c:348               trace: built-in: git 'show' '-s' '--format=%H"},
		    &git.Ref{Name:"master", Type:0, Sha:"12:08:04.796134 git.c:348               trace: built-in: git 'show' '-s' '--format=%H"},
		} != []*git.Ref{
		    &git.Ref{Name:"branch2", Type:0, Sha:"49a0848a1391a4d0dec5cf886386849928281484"},
		    &git.Ref{Name:"branch4", Type:0, Sha:"686de8859581179d3d429bb4810da38b51e79bac"},
		    &git.Ref{Name:"master", Type:0, Sha:"b7c05066c76446f4dc84f1842d3dadbcc40ff060"},
		}
	assert.go:28: !  - Refs should be correct
FAIL
FAIL	github.com/github/git-lfs/git	1.196s
```