### PR TITLE
setup the transfer queue watcher BEFORE processing any LFS pointers

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -242,12 +242,36 @@ func fetchPointers(pointers []*lfs.WrappedPointer, include, exclude []string) bo
 // Fetch and report completion of each OID to a channel (optional, pass nil to skip)
 // Returns true if all completed with no errors, false if errors were written to stderr/log
 func fetchAndReportToChan(pointers []*lfs.WrappedPointer, include, exclude []string, out chan<- *lfs.WrappedPointer) bool {
-
 	totalSize := int64(0)
 	for _, p := range pointers {
 		totalSize += p.Size
 	}
 	q := lfs.NewDownloadQueue(len(pointers), totalSize, false)
+
+	if out != nil {
+		dlwatch := q.Watch()
+
+		go func() {
+			// fetch only reports single OID, but OID *might* be referenced by multiple
+			// WrappedPointers if same content is at multiple paths, so map oid->slice
+			oidToPointers := make(map[string][]*lfs.WrappedPointer, len(pointers))
+			for _, pointer := range pointers {
+				plist := oidToPointers[pointer.Oid]
+				oidToPointers[pointer.Oid] = append(plist, pointer)
+			}
+
+			for oid := range dlwatch {
+				plist, ok := oidToPointers[oid]
+				if !ok {
+					continue
+				}
+				for _, p := range plist {
+					out <- p
+				}
+			}
+			close(out)
+		}()
+	}
 
 	for _, p := range pointers {
 		// Only add to download queue if local file is not the right size already
@@ -273,31 +297,6 @@ func fetchAndReportToChan(pointers []*lfs.WrappedPointer, include, exclude []str
 		}
 	}
 
-	if out != nil {
-		dlwatch := q.Watch()
-
-		go func() {
-			// fetch only reports single OID, but OID *might* be referenced by multiple
-			// WrappedPointers if same content is at multiple paths, so map oid->slice
-			oidToPointers := make(map[string][]*lfs.WrappedPointer, len(pointers))
-			for _, pointer := range pointers {
-				plist := oidToPointers[pointer.Oid]
-				oidToPointers[pointer.Oid] = append(plist, pointer)
-			}
-
-			for oid := range dlwatch {
-				plist, ok := oidToPointers[oid]
-				if !ok {
-					continue
-				}
-				for _, p := range plist {
-					out <- p
-				}
-			}
-			close(out)
-		}()
-
-	}
 	processQueue := time.Now()
 	q.Wait()
 	tracerx.PerformanceSince("process queue", processQueue)


### PR DESCRIPTION
Finally tracked down and fixed the bug in reproduced from https://github.com/github/git-lfs/issues/904#issuecomment-169010912.

I couldn't replicate the issue with `git lfs fetch` and `git lfs checkout` individually, so I assumed the problem [came from `command_pull.go`](https://github.com/github/git-lfs/blob/064043040e1003b51f86b65c14d3f9bedc137f30/commands/command_pull.go#L45-L46).

I added some trace messages and noticed `fetchAndReportToChan()` wasn't [receiving all of the oids](https://github.com/github/git-lfs/blob/064043040e1003b51f86b65c14d3f9bedc137f30/commands/command_fetch.go#L288-L296), even though everything was downloading just fine. Turns out the transfer queues start working in the background as soon as [something is added to the queue](https://github.com/github/git-lfs/blob/064043040e1003b51f86b65c14d3f9bedc137f30/commands/command_fetch.go#L259). Moving the code that registers the transfer queue watcher above where the LFS pointers get added to the queue fixed the bug.

/cc @sinbad @rubyist I'd appreciate another set of :eyes: on this.