### PR TITLE
guard against invalid remotes passed to `git lfs push`

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
 )
@@ -48,6 +49,10 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	// Remote is first arg
+	if err := git.ValidateRemote(args[0]); err != nil {
+		Exit("Invalid remote name %q", args[0])
+	}
 	lfs.Config.CurrentRemote = args[0]
 
 	// We can be passed multiple lines of refs

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/rubyist/tracerx"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
@@ -159,6 +160,10 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	// Remote is first arg
+	if err := git.ValidateRemote(args[0]); err != nil {
+		Exit("Invalid remote name %q", args[0])
+	}
 	lfs.Config.CurrentRemote = args[0]
 
 	if useStdin {

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -538,3 +538,12 @@ begin_test "fetch --prune"
   refute_local_object "$oid_commit2"
 )
 end_test
+
+begin_test "fetch with invalid remote"
+(
+  set -e
+  cd repo
+  git lfs fetch not-a-remote 2>&1 | tee fetch.log
+  grep "Invalid remote name" fetch.log
+)
+end_test

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -367,3 +367,16 @@ begin_test "pre-push multiple branches"
 
 )
 end_test
+
+begin_test "pre-push with bad remote"
+(
+  set -e
+
+  cd repo
+
+  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+    git lfs pre-push not-a-remote "$GITSERVER/$reponame" 2>&1 |
+    tee pre-push.log
+  grep "Invalid remote name" pre-push.log
+)
+end_test

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -410,3 +410,12 @@ begin_test "push modified files"
   assert_server_object "$reponame" "$oid5"
 )
 end_test
+
+begin_test "push with invalid remote"
+(
+  set -e
+  cd repo
+  git lfs push not-a-remote 2>&1 | tee push.log
+  grep "Invalid remote name" push.log
+)
+end_test


### PR DESCRIPTION
Fixes #973