### PR TITLE
pass gitattributes patterns (mostly) unchanged

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -56,36 +56,27 @@ func trackCommand(cmd *cobra.Command, args []string) {
 	}
 
 	wd, _ := os.Getwd()
+	relpath, err := filepath.Rel(lfs.LocalWorkingDir, wd)
+	if err != nil {
+		Exit("Current directory %q outside of git working directory %q.", wd, lfs.LocalWorkingDir)
+	}
 
 ArgsLoop:
-	for _, t := range args {
-		absT, relT := absRelPath(t, wd)
-
-		if !filepath.HasPrefix(absT, lfs.LocalWorkingDir) {
-			// check symlinks; LocalWorkingDir has symlinks resolved by rev-parse
-			// have to resolve dir without track pattern
-			actualDirT, err := filepath.EvalSymlinks(filepath.Dir(absT))
-			if err != nil || !filepath.HasPrefix(actualDirT, lfs.LocalWorkingDir) {
-				Print("%s is outside repository", t)
-				os.Exit(128)
-			}
-		}
-
-		for _, k := range knownPaths {
-			absK, _ := absRelPath(k.Path, filepath.Join(wd, filepath.Dir(k.Source)))
-			if absT == absK {
-				Print("%s already supported", t)
+	for _, pattern := range args {
+		for _, known := range knownPaths {
+			if known.Path == filepath.Join(relpath, pattern) {
+				Print("%s already supported", pattern)
 				continue ArgsLoop
 			}
 		}
 
-		encodedArg := strings.Replace(relT, " ", "[[:space:]]", -1)
+		encodedArg := strings.Replace(pattern, " ", "[[:space:]]", -1)
 		_, err := attributesFile.WriteString(fmt.Sprintf("%s filter=lfs diff=lfs merge=lfs -text\n", encodedArg))
 		if err != nil {
-			Print("Error adding path %s", t)
+			Print("Error adding path %s", pattern)
 			continue
 		}
-		Print("Tracking %s", t)
+		Print("Tracking %s", pattern)
 	}
 }
 
@@ -96,7 +87,6 @@ type mediaPath struct {
 
 func findPaths() []mediaPath {
 	paths := make([]mediaPath, 0)
-	wd, _ := os.Getwd()
 
 	for _, path := range findAttributeFiles() {
 		attributes, err := os.Open(path)
@@ -105,12 +95,18 @@ func findPaths() []mediaPath {
 		}
 
 		scanner := bufio.NewScanner(attributes)
+
 		for scanner.Scan() {
 			line := scanner.Text()
 			if strings.Contains(line, "filter=lfs") {
 				fields := strings.Fields(line)
-				relPath, _ := filepath.Rel(wd, path)
-				paths = append(paths, mediaPath{Path: fields[0], Source: relPath})
+				relfile, _ := filepath.Rel(lfs.LocalWorkingDir, path)
+				pattern := fields[0]
+				if reldir := filepath.Dir(relfile); len(reldir) > 0 {
+					pattern = filepath.Join(reldir, pattern)
+				}
+
+				paths = append(paths, mediaPath{Path: pattern, Source: relfile})
 			}
 		}
 	}
@@ -160,18 +156,6 @@ func needsTrailingLinebreak(filename string) bool {
 	}
 
 	return !strings.HasSuffix(string(buf[0:bytesRead]), "\n")
-}
-
-// absRelPath takes a path and a working directory and
-// returns an absolute and a relative representation of path based on the working directory
-func absRelPath(path, wd string) (string, string) {
-	if filepath.IsAbs(path) {
-		relPath, _ := filepath.Rel(wd, path)
-		return path, relPath
-	}
-
-	absPath := filepath.Join(wd, path)
-	return absPath, path
 }
 
 func init() {

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -134,21 +134,6 @@ begin_test "track representation"
   cd track-representation
 
   git lfs track "*.jpg"
-  out=$(git lfs track "$(native_path "$PWD/")*.jpg")
-
-  if [ "$out" != "$(native_path "$PWD/")*.jpg already supported" ]; then
-    echo "Track didn't recognize duplicate path"
-    cat .gitattributes
-    exit 1
-  fi
-
-  out2=$(git lfs track "a/../*.jpg")
-
-  if [ "$out2" != "a/../*.jpg already supported" ]; then
-    echo "Track didn't recognize duplicate path"
-    cat .gitattributes
-    exit 1
-  fi
 
   mkdir a
   git lfs track "a/test.file"
@@ -179,12 +164,9 @@ begin_test "track absolute"
   git init track-absolute
   cd track-absolute
 
-  git lfs track "$(native_path "$PWD/")*.jpg"
-  grep "^*.jpg" .gitattributes || {
-    echo ".gitattributes doesn't contain the expected relative path *.jpg:"
-    cat .gitattributes
-    exit 1
-  }
+  git lfs track "/images"
+  cat .gitattributes
+  grep "^/images" .gitattributes
 )
 end_test
 


### PR DESCRIPTION
Attempt to fix #870. The `git lfs track` command currently checks given patterns against the current working directory, preventing users from tracking files outside the repository. As pointed out in #870, this is actually incorrect. Via [gitignore docs](https://github.com/git/git/blob/f5b6079871904ba5b0a8548f91545f126caf898b/Documentation/gitignore.txt#L112-L114):

> A leading slash matches the beginning of the pathname. For example, `/{asterisk}.c` matches `cat-file.c` but not `mozilla-sha1/sha1.c`.

This removes that check, and the related tests.