### PR TITLE
Tunable timeouts

### DIFF
--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -32,6 +32,22 @@ lfs option can be scoped inside the configuration for a remote.
   Default true. This setting transitions clients from the legacy to the newer
   batch API and will be gone in Git LFS v1.0.
 
+* `lfs.dialtimeout`
+
+  Sets the maximum time, in seconds, that the HTTP client will wait initiate a
+  connection. This does not include the time to send a request and wait for a
+  response. Default: 30 seconds
+
+* `lfs.tlstimeout`
+
+  Sets the maximum time, in seconds, that the HTTP client will wait for a TLS
+  handshake. Default: 30 seconds.
+
+* `lfs.keepalive`
+
+  Sets the maximum time, in seconds, for the HTTP client to maintain keepalive
+  connections. Default: 30 minutes.
+
 ### Fetch settings
 
 * `lfs.fetchinclude`

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -294,6 +294,21 @@ func (c *Configuration) Extensions() map[string]Extension {
 	return c.extensions
 }
 
+// GitConfigInt parses a git config value and returns it as an integer.
+func (c *Configuration) GitConfigInt(key string, def int) int {
+	s, _ := c.GitConfig(key)
+	if len(s) == 0 {
+		return def
+	}
+
+	i, _ := strconv.Atoi(s)
+	if i < 1 {
+		return def
+	}
+
+	return i
+}
+
 func (c *Configuration) GitConfig(key string) (string, bool) {
 	c.loadGitConfig()
 	value, ok := c.gitConfig[strings.ToLower(key)]

--- a/lfs/http.go
+++ b/lfs/http.go
@@ -114,6 +114,7 @@ func (c *Configuration) HttpClient() *HttpClient {
 			KeepAlive: time.Duration(keepalivetime) * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout: time.Duration(tlstime) * time.Second,
+		MaxIdleConnsPerHost: c.ConcurrentTransfers(),
 	}
 
 	sslVerify, _ := c.GitConfig("http.sslverify")

--- a/lfs/http.go
+++ b/lfs/http.go
@@ -103,13 +103,17 @@ func (c *Configuration) HttpClient() *HttpClient {
 		return c.httpClient
 	}
 
+	dialtime := c.GitConfigInt("lfs.dialtimeout", 30)
+	keepalivetime := c.GitConfigInt("lfs.keepalive", 1800) // 30 minutes
+	tlstime := c.GitConfigInt("lfs.tlstimeout", 30)
+
 	tr := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
-			Timeout:   5 * time.Second,
-			KeepAlive: 30 * time.Second,
+			Timeout:   time.Duration(dialtime) * time.Second,
+			KeepAlive: time.Duration(keepalivetime) * time.Second,
 		}).Dial,
-		TLSHandshakeTimeout: 5 * time.Second,
+		TLSHandshakeTimeout: time.Duration(tlstime) * time.Second,
 	}
 
 	sslVerify, _ := c.GitConfig("http.sslverify")


### PR DESCRIPTION
Allow clients to tweak the lfs http timeouts through the git config. It also bumps the normal timeout from 5s to 30s. I think the newer values make more sense for a command line tool.