### PR TITLE
install latest Git on Travis-CI Linux to run all tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ language: go
 os:
   - linux
   - osx
+addons:
+  apt:
+    sources:
+    - git-core
+    packages:
+    - git
 go:
   - 1.5
 install: true

--- a/test/test-credentials-no-prompt.sh
+++ b/test/test-credentials-no-prompt.sh
@@ -24,6 +24,6 @@ begin_test "attempt private access without credential helper"
 
   GIT_TERMINAL_PROMPT=0 git push origin master 2>&1 | tee push.log
 
-  grep "Git credentials for $GITSERVER/$reponame not found" push.log
+  grep "Authorization error: $GITSERVER/$reponame" push.log
 )
 end_test


### PR DESCRIPTION
With the latest Git installed (2.7 right now) the following test are executed
in addition on Linux:

test/test-credentials-no-prompt.sh (git version < 2.3.0)
test/test-prune-worktree.sh (git version < 2.5.0)
test/test-push-bad-dns.sh (git version < 2.3.0)
test/test-worktree.sh (git version < 2.5.0)