### PR TITLE
Implement `git lfs clone`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ script: script/cibuild
 notifications:
   email: false
 before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install git     ; fi
   - repo=`basename $PWD`; localDir=`dirname $PWD`; cfDir="`dirname $localDir`/github"
   - if [[ "$localDir" != "$cfDir" ]]; then mv "$localDir" "$cfDir"; cd ../../github/$repo; export TRAVIS_BUILD_DIR=`dirname $TRAVIS_BUILD_DIR`/$repo; fi
   - export GIT_LFS_TEST_DIR="$localDir/git-lfs-tests"

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -23,13 +23,13 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 	// We pass all args to git clone
 	err := git.CloneWithoutFilters(args)
 	if err != nil {
-		Panic(err, "Error(s) during clone")
+		Exit("Error(s) during clone:\n%v", err)
 	}
 
 	// now execute pull (need to be inside dir)
 	cwd, err := os.Getwd()
 	if err != nil {
-		Panic(err, "Unable to derive current working dir")
+		Exit("Unable to derive current working dir: %v", err)
 	}
 
 	// Either the last argument was a relative or local dir, or we have to
@@ -49,7 +49,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 
 	err = os.Chdir(clonedir)
 	if err != nil {
-		Panic(err, "Unable to change directory to clone dir %q", clonedir)
+		Exit("Unable to change directory to clone dir %q: %v", clonedir, err)
 	}
 
 	// Make sure we pop back to dir we started in at the end

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -1,0 +1,70 @@
+package commands
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/github/git-lfs/git"
+	"github.com/github/git-lfs/lfs"
+	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
+)
+
+var (
+	cloneCmd = &cobra.Command{
+		Use: "clone",
+		Run: cloneCommand,
+	}
+)
+
+func cloneCommand(cmd *cobra.Command, args []string) {
+
+	// We pass all args to git clone
+	err := git.CloneWithoutFilters(args)
+	if err != nil {
+		Panic(err, "Error(s) during clone")
+	}
+
+	// now execute pull (need to be inside dir)
+	cwd, err := os.Getwd()
+	if err != nil {
+		Panic(err, "Unable to derive current working dir")
+	}
+
+	// Either the last argument was a relative or local dir, or we have to
+	// derive it from the clone URL
+	clonedir, err := filepath.Abs(args[len(args)-1])
+	if err != nil || !lfs.DirExists(clonedir) {
+		// Derive from clone URL instead
+		base := path.Base(args[len(args)-1])
+		if strings.HasSuffix(base, ".git") {
+			base = base[:len(base)-4]
+		}
+		clonedir, _ = filepath.Abs(base)
+		if !lfs.DirExists(clonedir) {
+			Exit("Unable to find clone dir at %q", clonedir)
+		}
+	}
+
+	err = os.Chdir(clonedir)
+	if err != nil {
+		Panic(err, "Unable to change directory to clone dir %q", clonedir)
+	}
+
+	// Make sure we pop back to dir we started in at the end
+	defer os.Chdir(cwd)
+
+	// Also need to derive dirs now
+	lfs.ResolveDirs()
+	requireInRepo()
+
+	// Now just call pull with default args
+	lfs.Config.CurrentRemote = "origin" // always origin after clone
+	pull(nil, nil)
+
+}
+
+func init() {
+	RootCmd.AddCommand(cloneCmd)
+}

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -35,15 +35,20 @@ func pullCommand(cmd *cobra.Command, args []string) {
 		lfs.Config.CurrentRemote = defaultRemote
 	}
 
+	pull(determineIncludeExcludePaths(pullIncludeArg, pullExcludeArg))
+
+}
+
+func pull(includePaths, excludePaths []string) {
+
 	ref, err := git.CurrentRef()
 	if err != nil {
 		Panic(err, "Could not pull")
 	}
 
-	includePaths, excludePaths := determineIncludeExcludePaths(pullIncludeArg, pullExcludeArg)
-
 	c := fetchRefToChan(ref.Sha, includePaths, excludePaths)
 	checkoutFromFetchChan(includePaths, excludePaths, c)
+
 }
 
 func init() {

--- a/docs/man/git-lfs-clone.1.ronn
+++ b/docs/man/git-lfs-clone.1.ronn
@@ -1,0 +1,26 @@
+git-lfs-clone(1) -- Efficiently clone a LFS-enabled repository
+========================================================================
+
+## SYNOPSIS
+
+`git lfs clone` [git clone options] <repository> [<directory>]
+
+## DESCRIPTION
+
+Clone an LFS enabled Git repository more efficiently by disabling LFS during the
+git clone, then performing a 'git lfs pull' directly afterwards.
+
+This is faster than a regular 'git clone' because that will download LFS content
+using the smudge filter, which is executed individually per file in the working
+copy. This is relatively inefficient compared to the batch mode and parallel
+downloads performed by 'git lfs pull'.
+
+## OPTIONS
+
+All options supported by 'git clone'
+
+## SEE ALSO
+
+git-clone(1), git-lfs-pull(1).
+
+Part of the git-lfs(1) suite.

--- a/git/git.go
+++ b/git/git.go
@@ -663,6 +663,9 @@ func CloneWithoutFilters(args []string) error {
 	scanner := bufio.NewScanner(stderr)
 	for scanner.Scan() {
 		s := scanner.Text()
+		// Send all stderr to trace in case useful
+		tracerx.Printf(s)
+
 		// Swallow all the known messages from intentionally breaking filter
 		if strings.Contains(s, "error: external filter") ||
 			strings.Contains(s, "error: cannot fork") ||

--- a/git/git.go
+++ b/git/git.go
@@ -626,6 +626,11 @@ func IsVersionAtLeast(actualVersion, desiredVersion string) bool {
 // so that files in the working copy will be pointers and not real LFS data
 func CloneWithoutFilters(args []string) error {
 
+	// We can only support this on git version 2.2.0+
+	// Before that, setting filters to blank would break clone
+	if !Config.IsGitVersionAtLeast("2.2.0") {
+		return errors.New("git lfs clone requires git version 2.2.0+")
+	}
 	// Disable the LFS filters while cloning to speed things up
 	// this is especially effective on Windows where even calling git-lfs at all
 	// with --skip-smudge is costly across many files in a checkout

--- a/git/git.go
+++ b/git/git.go
@@ -630,16 +630,16 @@ func IsVersionAtLeast(actualVersion, desiredVersion string) bool {
 // so that files in the working copy will be pointers and not real LFS data
 func CloneWithoutFilters(args []string) error {
 
-	// We can only support this on git version 2.2.0+
-	// Before that, setting filters to blank would break clone
+	// Before git 2.2, setting filters to blank fails, so use cat instead (slightly slower)
+	filterOverride := ""
 	if !Config.IsGitVersionAtLeast("2.2.0") {
-		return errors.New("git lfs clone requires git version 2.2.0+")
+		filterOverride = "cat"
 	}
 	// Disable the LFS filters while cloning to speed things up
 	// this is especially effective on Windows where even calling git-lfs at all
 	// with --skip-smudge is costly across many files in a checkout
 	cmdargs := []string{
-		"-c", "filter.lfs.smudge=",
+		"-c", fmt.Sprintf("filter.lfs.smudge=%v", filterOverride),
 		"-c", "filter.lfs.required=false",
 		"clone"}
 	cmdargs = append(cmdargs, args...)

--- a/git/git.go
+++ b/git/git.go
@@ -648,22 +648,12 @@ func CloneWithoutFilters(args []string) error {
 	// Spool stdout directly to our own
 	cmd.Stdout = os.Stdout
 
-	// stderr needs filtering
-	// Known issue: because this isn't a real terminal, git progress reporting is
-	// suppressed so there's less output. We could potentially fix this by using
-	// a pseudo-TTY library like https://github.com/kr/pty
-	/*
-		stderr, err := cmd.StderrPipe()
-		if err != nil {
-			return fmt.Errorf("Failed to get stderr from git clone: %v", err)
-		}
-	*/
-
 	// Assign pty/tty so git thinks it's a real terminal
 	outpty, outtty, err := pty.Open()
 	cmd.Stdin = outtty
 	cmd.Stdout = outtty
 	errpty, errtty, err := pty.Open()
+	// stderr needs filtering
 	cmd.Stderr = errtty
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}

--- a/git/git.go
+++ b/git/git.go
@@ -661,7 +661,6 @@ func CloneWithoutFilters(args []string) error {
 			strings.Contains(s, "warning: Clone succeeded, but checkout failed") ||
 			strings.Contains(s, "You can inspect what was checked out with 'git status'") ||
 			strings.Contains(s, "retry the checkout") ||
-			strings.Contains(s, "substr") ||
 			// Windows messages
 			strings.Contains(s, "error: cannot spawn : No such file or directory") ||
 			// blank formatting

--- a/git/git.go
+++ b/git/git.go
@@ -663,8 +663,6 @@ func CloneWithoutFilters(args []string) error {
 	scanner := bufio.NewScanner(stderr)
 	for scanner.Scan() {
 		s := scanner.Text()
-		// Send all stderr to trace in case useful
-		tracerx.Printf(s)
 
 		// Swallow all the known messages from intentionally breaking filter
 		if strings.Contains(s, "error: external filter") ||
@@ -678,6 +676,8 @@ func CloneWithoutFilters(args []string) error {
 			strings.Contains(s, "error: cannot spawn : No such file or directory") ||
 			// blank formatting
 			len(strings.TrimSpace(s)) == 0 {
+			// Send filtered stderr to trace in case useful
+			tracerx.Printf(s)
 			continue
 		}
 		os.Stderr.WriteString(s)

--- a/git/git.go
+++ b/git/git.go
@@ -643,7 +643,11 @@ func CloneWithoutFilters(args []string) error {
 
 	// Spool stdout directly to our own
 	cmd.Stdout = os.Stdout
+
 	// stderr needs filtering
+	// Known issue: because this isn't a real terminal, git progress reporting is
+	// suppressed so there's less output. We could potentially fix this by using
+	// a pseudo-TTY library like https://github.com/kr/pty
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		return fmt.Errorf("Failed to get stderr from git clone: %v", err)
@@ -655,6 +659,7 @@ func CloneWithoutFilters(args []string) error {
 
 	// Filter stderr to exclude messages caused by disabling the filters
 	// As of git 2.7 it still tries to call the blank filter but required=false
+	// this problem should be gone in git 2.8 https://github.com/git/git/commit/1a8630d
 	scanner := bufio.NewScanner(stderr)
 	for scanner.Scan() {
 		s := scanner.Text()

--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -2,6 +2,8 @@
 
 . "test/testlib.sh"
 
+ensure_git_version_isnt $VERSION_LOWER "2.2.0"
+
 begin_test "clone"
 (
   set -e

--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "clone"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" repo
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \*.dat" track.log
+
+  # generate some test data & commits with random LFS data
+  echo "[
+  {
+    \"CommitDate\":\"$(get_date -10d)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":100},
+      {\"Filename\":\"file2.dat\",\"Size\":75}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -7d)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":110},
+      {\"Filename\":\"file3.dat\",\"Size\":66},
+      {\"Filename\":\"file4.dat\",\"Size\":23}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -10d)\",
+    \"Files\":[
+      {\"Filename\":\"file5.dat\",\"Size\":120},
+      {\"Filename\":\"file6.dat\",\"Size\":30}]
+  }
+  ]" | lfstest-testutils addcommits
+
+  git push origin master
+
+  # Now clone again, test specific clone dir
+  cd "$TRASHDIR"
+
+  newclonedir="testclone1"
+  git lfs clone "$GITSERVER/$reponame" "$newclonedir" 2>&1 | tee lfsclone.log
+  grep "Cloning into" lfsclone.log
+  grep "Git LFS:" lfsclone.log
+  # should be no filter errors
+  [ ! $(grep "filter" lfsclone.log) ]
+  [ ! $(grep "error" lfsclone.log) ]
+  # should be cloned into location as per arg
+  [ -d "$newclonedir" ]
+
+  # check a few file sizes to make sure pulled
+  pushd "$newclonedir"
+  [ $(wc -c < "file1.dat") -eq 110 ] 
+  [ $(wc -c < "file2.dat") -eq 75 ] 
+  [ $(wc -c < "file3.dat") -eq 66 ] 
+  popd
+  # Now check clone with implied dir
+  rm -rf "$reponame"
+  git lfs clone "$GITSERVER/$reponame" 2>&1 | tee lfsclone.log
+  grep "Cloning into" lfsclone.log
+  grep "Git LFS:" lfsclone.log
+  # should be no filter errors
+  [ ! $(grep "filter" lfsclone.log) ]
+  [ ! $(grep "error" lfsclone.log) ]
+  # clone location should be implied
+  [ -d "$reponame" ]
+  pushd "$reponame"
+  [ $(wc -c < "file1.dat") -eq 110 ] 
+  [ $(wc -c < "file2.dat") -eq 75 ] 
+  [ $(wc -c < "file3.dat") -eq 66 ] 
+  popd
+
+)
+end_test
+

--- a/test/test-credentials-no-prompt.sh
+++ b/test/test-credentials-no-prompt.sh
@@ -4,6 +4,13 @@
 
 # these tests rely on GIT_TERMINAL_PROMPT to test properly
 ensure_git_version_isnt $VERSION_LOWER "2.3.0"
+# if there is a system cred helper we can't run this test 
+# can't disable without changing state outside test & probably don't have permission
+# this is common on OS X with certain versions of Git installed, default cred helper
+if [[ "$(git config --system credential.helper)" -ne "" ]]; then
+  echo "skip: $0 (system cred helper we can't disable)"
+  exit
+fi
 
 begin_test "attempt private access without credential helper"
 (


### PR DESCRIPTION
Adds a new command `git lfs clone` which allows for more efficient cloning of LFS repositories by suppressing filters during clone/checkout then doing `git lfs pull` afterwards. Automatically suppresses error messages generated by this process. 

Addresses #931, thanks to @larsxschneider for the extensive analysis, this is 100% based on his findings.