### PR TITLE
Use the standard base64 encoding for Basic Auth header

### DIFF
--- a/lfs/client.go
+++ b/lfs/client.go
@@ -785,7 +785,7 @@ func setRequestAuth(req *http.Request, user, pass string) {
 	}
 
 	token := fmt.Sprintf("%s:%s", user, pass)
-	auth := "Basic " + base64.URLEncoding.EncodeToString([]byte(token))
+	auth := "Basic " + strings.TrimSpace(base64.StdEncoding.EncodeToString([]byte(token)))
 	req.Header.Set("Authorization", auth)
 }
 

--- a/lfs/client_test.go
+++ b/lfs/client_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -24,5 +25,5 @@ func expectedAuth(t *testing.T, server *httptest.Server) string {
 	}
 
 	token := fmt.Sprintf("%s:%s", u.Host, "monkey")
-	return "Basic " + base64.URLEncoding.EncodeToString([]byte(token))
+	return "Basic " + strings.TrimSpace(base64.StdEncoding.EncodeToString([]byte(token)))
 }

--- a/lfs/credentials_test.go
+++ b/lfs/credentials_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -75,7 +76,7 @@ func TestGetCredentialsForApi(t *testing.T) {
 			Config:        map[string]string{"lfs.url": "https://testuser:testpass@git-server.com"},
 			Method:        "GET",
 			Href:          "https://git-server.com/foo",
-			Authorization: "Basic " + base64.URLEncoding.EncodeToString([]byte("testuser:testpass")),
+			Authorization: "Basic " + strings.TrimSpace(base64.StdEncoding.EncodeToString([]byte("testuser:testpass"))),
 		},
 		{
 			Desc:          "git url auth",
@@ -86,7 +87,7 @@ func TestGetCredentialsForApi(t *testing.T) {
 			},
 			Method:        "GET",
 			Href:          "https://git-server.com/foo",
-			Authorization: "Basic " + base64.URLEncoding.EncodeToString([]byte("gituser:gitpass")),
+			Authorization: "Basic " + strings.TrimSpace(base64.StdEncoding.EncodeToString([]byte("gituser:gitpass"))),
 		},
 		{
 			Desc:     "username in url",
@@ -215,7 +216,7 @@ func checkGetCredentials(t *testing.T, getCredsFunc func(*http.Request) (Creds, 
 			}
 		} else {
 			rawtoken := fmt.Sprintf("%s:%s", check.Username, check.Password)
-			expected := "Basic " + base64.URLEncoding.EncodeToString([]byte(rawtoken))
+			expected := "Basic " + strings.TrimSpace(base64.StdEncoding.EncodeToString([]byte(rawtoken)))
 			if reqAuth != expected {
 				t.Errorf("[%s] Bad Authorization. Expected '%s', got '%s'", check.Desc, expected, reqAuth)
 			}


### PR DESCRIPTION
Not sure why I used the base64 url encoding. Fixes #938