### PR TITLE
run tests on Travis-CI against default Git and latest Git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,17 @@ matrix:
           brew install git;
 
 before_install:
-  - repo=`basename $PWD`; localDir=`dirname $PWD`; cfDir="`dirname $localDir`/github"
-  - if [[ "$localDir" != "$cfDir" ]]; then mv "$localDir" "$cfDir"; cd ../../github/$repo; export TRAVIS_BUILD_DIR=`dirname $TRAVIS_BUILD_DIR`/$repo; fi
-  - export GIT_LFS_TEST_DIR="$localDir/git-lfs-tests"
+  - >
+    repo=`basename $PWD`;
+    localDir=`dirname $PWD`;
+    cfDir="`dirname $localDir`/github";
+    if [[ "$localDir" != "$cfDir" ]];
+    then
+      mv "$localDir" "$cfDir";
+      cd ../../github/$repo;
+      export TRAVIS_BUILD_DIR=`dirname $TRAVIS_BUILD_DIR`/$repo;
+    fi;
+    export GIT_LFS_TEST_DIR="$localDir/git-lfs-tests";
 
 install: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,40 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
+
+go: 1.5
+
 os:
   - linux
   - osx
-addons:
-  apt:
-    sources:
-    - git-core
-    packages:
-    - git
-go:
-  - 1.5
-install: true
-script: script/cibuild
-notifications:
-  email: false
+
+matrix:
+  include:
+    - env: git-latest
+      os: linux
+      addons:
+        apt:
+          sources:
+          - git-core
+          packages:
+          - git
+    - env: git-latest
+      os: osx
+      # The 'before_install' phase cannot be used here as we would override the
+      # default 'before_install' phase. The 'before_script' phase is sufficient
+      # for the Git install since the Git binary is only used in the tests.
+      before_script:
+        - >
+          brew update;
+          brew install git;
+
 before_install:
   - repo=`basename $PWD`; localDir=`dirname $PWD`; cfDir="`dirname $localDir`/github"
   - if [[ "$localDir" != "$cfDir" ]]; then mv "$localDir" "$cfDir"; cd ../../github/$repo; export TRAVIS_BUILD_DIR=`dirname $TRAVIS_BUILD_DIR`/$repo; fi
   - export GIT_LFS_TEST_DIR="$localDir/git-lfs-tests"
+
+install: true
+
+script: script/cibuild
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ os:
   - linux
   - osx
 
+env:
+  global:
+    - GIT_LFS_TEST_DIR="$HOME/git-lfs-tests"
+
 matrix:
   include:
     - env: git-latest
@@ -38,7 +42,6 @@ before_install:
       cd ../../github/$repo;
       export TRAVIS_BUILD_DIR=`dirname $TRAVIS_BUILD_DIR`/$repo;
     fi;
-    export GIT_LFS_TEST_DIR="$localDir/git-lfs-tests";
 
 install: true
 


### PR DESCRIPTION
Run Git-LFS tests against the Travis-CI default Git version and the
latest available Git version on the respective platform.

The default Git version is currently 1.8.5.6 on Ubuntu and 1.9.3 on OSX.