### PR TITLE
Added zombie cleanups for external git command calls.

### DIFF
--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -294,6 +294,7 @@ func revListShas(refLeft, refRight string, opt *ScanRefsOptions) (chan string, e
 			revs <- sha1
 		}
 		close(revs)
+		cmd.Cmd.Wait()
 	}()
 
 	return revs, nil
@@ -344,6 +345,7 @@ func revListIndex(cache bool, indexMap *indexFileMap) (chan string, error) {
 			}
 		}
 		close(revs)
+		cmd.Cmd.Wait()
 	}()
 
 	return revs, nil
@@ -388,6 +390,7 @@ func catFileBatchCheck(revs chan string) (chan string, error) {
 			cmd.Stdin.Write([]byte(r + "\n"))
 		}
 		cmd.Stdin.Close()
+		cmd.Cmd.Wait()
 	}()
 
 	return smallRevs, nil
@@ -445,6 +448,7 @@ func catFileBatch(revs chan string) (chan *WrappedPointer, error) {
 			cmd.Stdin.Write([]byte(r + "\n"))
 		}
 		cmd.Stdin.Close()
+		cmd.Cmd.Wait()
 	}()
 
 	return pointers, nil


### PR DESCRIPTION
For issue #996 

When pushing a large amount of commits, an increase in the number of zombie processes can be detected from the process table, specifically 3 new zombies for each commit that is handled. This was fixed by calling exec.Wait() for the commands that were called using exec.Start().

I'm not entirely sure if the calls for exec.Wait() are in their appropriate places here, but at least this seems to do the trick for me.