### PR TITLE
update "ls-tree" command to use -z

### DIFF
--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -606,7 +606,7 @@ func lsTreeBlobs(ref string) (chan TreeBlob, error) {
 
 func parseLsTree(reader io.Reader, output chan TreeBlob) {
 	scanner := bufio.NewScanner(reader)
-	scanner.Split(ScanNullLines)
+	scanner.Split(scanNullLines)
 	for scanner.Scan() {
 		line := scanner.Text()
 		parts := strings.SplitN(line, "\t", 2)
@@ -636,7 +636,7 @@ func parseLsTree(reader io.Reader, output chan TreeBlob) {
 	}
 }
 
-func ScanNullLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+func scanNullLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	if atEOF && len(data) == 0 {
 		return 0, nil, nil
 	}

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -582,6 +582,7 @@ func lsTreeBlobs(ref string) (chan TreeBlob, error) {
 	lsArgs := []string{"ls-tree",
 		"-r",          // recurse
 		"-l",          // report object size (we'll need this)
+		"-z",          // null line termination
 		"--full-tree", // start at the root regardless of where we are in it
 		ref}
 

--- a/lfs/scanner_test.go
+++ b/lfs/scanner_test.go
@@ -246,3 +246,13 @@ func TestLsTreeParser(t *testing.T) {
 		t.Errorf("Bad name: %q", blob.Filename)
 	}
 }
+
+func BenchmarkLsTreeParser(b *testing.B) {
+	stdout := "100644 blob d899f6551a51cf19763c5955c7a06a2726f018e9      42	.gitattributes\000100644 blob 4d343e022e11a8618db494dc3c501e80c7e18197     126	PB SCN 16 Odhrán.wav"
+	blobs := make(chan TreeBlob, b.N*2)
+	// run the Fib function b.N times
+	for n := 0; n < b.N; n++ {
+		parseLsTree(strings.NewReader(stdout), blobs)
+	}
+	close(blobs)
+}

--- a/lfs/scanner_test.go
+++ b/lfs/scanner_test.go
@@ -228,3 +228,21 @@ func TestParseLogOutputToPointersDeletion(t *testing.T) {
 	assert.Equal(t, int64(16849), pointers[2].Size)
 
 }
+
+func TestLsTreeParser(t *testing.T) {
+	stdout := "100644 blob d899f6551a51cf19763c5955c7a06a2726f018e9      42	.gitattributes\000100644 blob 4d343e022e11a8618db494dc3c501e80c7e18197     126	PB SCN 16 Odhrán.wav"
+
+	blobs := make(chan TreeBlob, 2)
+	parseLsTree(strings.NewReader(stdout), blobs)
+	close(blobs)
+
+	<-blobs // gitattributes
+	blob := <-blobs
+	if blob.Sha1 != "4d343e022e11a8618db494dc3c501e80c7e18197" {
+		t.Errorf("Bad sha1: %q", blob.Sha1)
+	}
+
+	if blob.Filename != "PB SCN 16 Odhrán.wav" {
+		t.Errorf("Bad name: %q", blob.Filename)
+	}
+}

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -10,8 +10,12 @@ assert_pointer() {
   local oid="$3"
   local size="$4"
 
-  tree=$(git ls-tree -lr "$ref")
-  gitblob=$(echo "$tree" | grep "$path" | cut -f 3 -d " ")
+  gitblob=$(git ls-tree -lrz "$ref" |
+    while read -r -d $'\0' x; do
+      echo $x
+    done |
+    grep "$path" | cut -f 3 -d " ")
+
   actual=$(git cat-file -p $gitblob)
   expected=$(pointer $oid $size)
 


### PR DESCRIPTION
This updates the `ls-tree` command parser to use `-z`, which tells git to return lines split by a null terminator. This output is designed for scripts, and represents filenames with spaces and unicode better. See https://github.com/github/git-lfs/issues/987#issuecomment-186337634 for a more detailed writeup.

/cc @sinbad: I think we should try and use `-z` where possible. I copied `bufio.ScanLines()` and made `scanNullLines()`, so it should be easy to apply to other commands.

I also made sure `lsTreeBlobs()` calls `Wait()` on the `*exec.Command` object. Don't want another zombie herd (#1012).