### PR TITLE
Better errors on push

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -304,11 +304,7 @@ func fetchAndReportToChan(pointers []*lfs.WrappedPointer, include, exclude []str
 	ok := true
 	for _, err := range q.Errors() {
 		ok = false
-		if Debugging || lfs.IsFatalError(err) {
-			LoggedError(err, err.Error())
-		} else {
-			Error(err.Error())
-		}
+		ExitWithError(err)
 	}
 	return ok
 }

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -115,10 +115,8 @@ func prePushRef(left, right string) {
 		if err != nil {
 			if lfs.IsCleanPointerError(err) {
 				Exit(prePushMissingErrMsg, pointer.Name, lfs.ErrorGetContext(err, "pointer").(*lfs.Pointer).Oid)
-			} else if Debugging || lfs.IsFatalError(err) {
-				Panic(err, err.Error())
 			} else {
-				Exit(err.Error())
+				ExitWithError(err)
 			}
 		}
 

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -100,11 +100,7 @@ func uploadPointers(pointers []*lfs.WrappedPointer) *lfs.TransferQueue {
 
 		u, err := lfs.NewUploadable(pointer.Oid, pointer.Name)
 		if err != nil {
-			if Debugging || lfs.IsFatalError(err) {
-				Panic(err, err.Error())
-			} else {
-				Exit(err.Error())
-			}
+			ExitWithError(err)
 		}
 		uploadQueue.Add(u)
 	}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -57,6 +57,17 @@ func Exit(format string, args ...interface{}) {
 	os.Exit(2)
 }
 
+func ExitWithError(err error) {
+	if Debugging || lfs.IsFatalError(err) {
+		Panic(err, err.Error())
+	} else {
+		if inner := lfs.GetInnerError(err); inner != nil {
+			Error(inner.Error())
+		}
+		Exit(err.Error())
+	}
+}
+
 // Debug prints a formatted message if debugging is enabled.  The formatted
 // message also shows up in the panic log, if created.
 func Debug(format string, args ...interface{}) {

--- a/lfs/errors.go
+++ b/lfs/errors.go
@@ -203,6 +203,15 @@ func IsRetriableError(err error) bool {
 	return false
 }
 
+func GetInnerError(err error) error {
+	if e, ok := err.(interface {
+		InnerError() error
+	}); ok {
+		return e.InnerError()
+	}
+	return nil
+}
+
 // Error wraps an error with an empty message.
 func Error(err error) error {
 	return Errorf(err, "")

--- a/lfs/errors_test.go
+++ b/lfs/errors_test.go
@@ -85,3 +85,27 @@ func TestStack(t *testing.T) {
 		t.Error("expected to get a stack from a wrapped error")
 	}
 }
+
+func TestGetInnerError(t *testing.T) {
+	i := errors.New("inner")
+	err := GetInnerError(newWrappedError(i, "wrapped"))
+	if err == nil {
+		t.Fatal("No inner error found")
+	}
+
+	if msg := err.Error(); msg != "inner" {
+		t.Errorf("bad inner error: %q", msg)
+	}
+}
+
+func TestGetNestedInnerError(t *testing.T) {
+	i := errors.New("inner")
+	err := GetInnerError(newWrappedError(newWrappedError(i, "wrapped 2"), "wrapped"))
+	if err == nil {
+		t.Fatal("No inner error found")
+	}
+
+	if msg := err.Error(); msg != "inner" {
+		t.Errorf("bad inner error: %q", msg)
+	}
+}

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -25,7 +25,7 @@ func NewUploadable(oid, filename string) (*Uploadable, error) {
 
 	if len(filename) > 0 {
 		if err := ensureFile(filename, localMediaPath); err != nil {
-			return nil, Errorf(err, "Error uploading file %s (%s)", filename, oid)
+			return nil, err
 		}
 	}
 
@@ -108,7 +108,7 @@ func ensureFile(smudgePath, cleanPath string) error {
 	}
 
 	if expectedOid != cleaned.Oid {
-		return fmt.Errorf("Expected %s to have an OID of %s, got %s", smudgePath, expectedOid, cleaned.Oid)
+		return fmt.Errorf("Trying to push %q with OID %s.\nNot found in %s.", smudgePath, expectedOid, filepath.Dir(cleanPath))
 	}
 
 	return nil


### PR DESCRIPTION
This fixes an issue when pushing or fetching where the "inner error" is dropped, making it difficult to diagnose problems.

This also tweaks an error message from `ensureFile()` /cc @rjbell4

```bash
$ git push origin master
Trying to push "a.wav" with OID 87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7.
Not found in /Users/rick/p/studious-goggles/.git/lfs/objects/87/42.
error: failed to push some refs to 'https://git-server.com/technoweenie/studious-goggles'
```