### PR TITLE
Interim update for basic compatibility with go 1.6

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Compatibility with go 1.6
+export GO15VENDOREXPERIMENT=0
+
 set -e
 
 # Only set GOPATH on non-Windows platforms as Windows can't do the symlinking

--- a/script/release
+++ b/script/release
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
+
+# Compatibility with go 1.6
+export GO15VENDOREXPERIMENT=0
+
 script/fmt
 go run script/*.go -cmd release "$@"

--- a/script/run
+++ b/script/run
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Compatibility with go 1.6
+export GO15VENDOREXPERIMENT=0
+
 script/fmt
 commit=`git rev-parse --short HEAD`
 go run -ldflags="-X github.com/github/git-lfs/lfs.GitCommit $commit" ./git-lfs.go "$@"

--- a/script/test
+++ b/script/test
@@ -2,6 +2,9 @@
 #/ Usage: script/test          # run all tests
 #/        script/test <subdir> # run just a package's tests
 
+# Compatibility with go 1.6
+export GO15VENDOREXPERIMENT=0
+
 script/fmt
 suite="./${1:-"lfs"} ./${1:-"git"}"
 if [ $# -gt 0 ]; then

--- a/test/testenv.sh
+++ b/test/testenv.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Including in script/integration and every test/test-*.sh file.
 
+# Compatibility with go 1.6
+export GO15VENDOREXPERIMENT=0
+
 set -e
 
 # The root directory for the git-lfs repository by default.


### PR DESCRIPTION
Addresses #1021 in the most minimal way possible for now.

I suggest moving to standard Go vendoring and flipping this option to `GO15VENDOREXPERIMENT=1` but that will be a bigger change. We can either use `git submodule` or `git subtree` but personally I'd prefer `subtree` because it has fewer edge cases (and we've embedded the vendor packages in this repo until now anyway). I can do that as a follow up PR if you agree.