### PR TITLE
Go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
 
-go: 1.5
+go: 1.6
 
 os:
   - linux
@@ -26,6 +26,22 @@ matrix:
       # The 'before_install' phase cannot be used here as we would override the
       # default 'before_install' phase. The 'before_script' phase is sufficient
       # for the Git install since the Git binary is only used in the tests.
+      before_script:
+        - >
+          brew update;
+          brew install git;
+    - env: git-latest-go-1.5
+      os: linux
+      go: 1.5
+      addons:
+        apt:
+          sources:
+          - git-core
+          packages:
+          - git
+    - env: git-latest-go-1.5
+      os: osx
+      go: 1.5
       before_script:
         - >
           brew update;

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -12,4 +12,4 @@ fi
 
 script/fmt
 rm -rf bin/*
-go run script/*.go -cmd build "$@"
+GO15VENDOREXPERIMENT=0 go run script/*.go -cmd build "$@"

--- a/script/build.go
+++ b/script/build.go
@@ -154,12 +154,13 @@ func buildCommand(dir, buildos, buildarch string) error {
 }
 
 func buildGoEnv(buildos, buildarch string) []string {
-	env := make([]string, 5, 8)
+	env := make([]string, 6, 9)
 	env[0] = "GOOS=" + buildos
 	env[1] = "GOARCH=" + buildarch
 	env[2] = "GOPATH=" + os.Getenv("GOPATH")
 	env[3] = "GOROOT=" + os.Getenv("GOROOT")
 	env[4] = "PATH=" + os.Getenv("PATH")
+	env[5] = "GO15VENDOREXPERIMENT=" + os.Getenv("GO15VENDOREXPERIMENT")
 	for _, key := range []string{"TMP", "TEMP", "TEMPDIR"} {
 		v := os.Getenv(key)
 		if len(v) == 0 {

--- a/script/integration
+++ b/script/integration
@@ -46,4 +46,4 @@ parallel=${GIT_LFS_TEST_MAXPROCS:-4}
 echo "Running this maxprocs=$parallel"
 echo
 
-GIT_LFS_TEST_MAXPROCS=$parallel GIT_LFS_TEST_DIR="$GIT_LFS_TEST_DIR" SHUTDOWN_LFS="no" go run script/*.go -cmd integration "$@"
+GO15VENDOREXPERIMENT=0 GIT_LFS_TEST_MAXPROCS=$parallel GIT_LFS_TEST_DIR="$GIT_LFS_TEST_DIR" SHUTDOWN_LFS="no" go run script/*.go -cmd integration "$@"

--- a/script/release
+++ b/script/release
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 script/fmt
-go run script/*.go -cmd release "$@"
+GO15VENDOREXPERIMENT=0 go run script/*.go -cmd release "$@"

--- a/script/run
+++ b/script/run
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 script/fmt
 commit=`git rev-parse --short HEAD`
-go run -ldflags="-X github.com/github/git-lfs/lfs.GitCommit $commit" ./git-lfs.go "$@"
+GO15VENDOREXPERIMENT=0 go run -ldflags="-X github.com/github/git-lfs/lfs.GitCommit $commit" ./git-lfs.go "$@"

--- a/script/test
+++ b/script/test
@@ -7,4 +7,4 @@ suite="./${1:-"lfs"} ./${1:-"git"}"
 if [ $# -gt 0 ]; then
   shift
 fi
-go test $suite "$@"
+GO15VENDOREXPERIMENT=0 go test $suite "$@"

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -215,10 +215,10 @@ setup() {
 
   if [ -z "$SKIPCOMPILE" ]; then
     for go in test/cmd/*.go; do
-      go build -o "$BINPATH/$(basename $go .go)" "$go"
+      GO15VENDOREXPERIMENT=0 go build -o "$BINPATH/$(basename $go .go)" "$go"
     done
     # Ensure API test util is built during tests to ensure it stays in sync
-    go build -o "$BINPATH/git-lfs-test-server-api" "test/git-lfs-test-server-api/main.go" "test/git-lfs-test-server-api/testdownload.go" "test/git-lfs-test-server-api/testupload.go"
+    GO15VENDOREXPERIMENT=0 go build -o "$BINPATH/git-lfs-test-server-api" "test/git-lfs-test-server-api/main.go" "test/git-lfs-test-server-api/testdownload.go" "test/git-lfs-test-server-api/testupload.go"
   fi
 
   LFSTEST_URL="$LFS_URL_FILE" LFSTEST_DIR="$REMOTEDIR" lfstest-gitserver > "$REMOTEDIR/gitserver.log" 2>&1 &


### PR DESCRIPTION
This is a quick hack that ensures builds on go 1.6 work. Eventually, I want to start using `GO15VENDOREXPERIMENT=1`.