### PR TITLE
Show refs

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -129,6 +129,9 @@ func prePushRef(left, right string) {
 			if Debugging || lfs.IsFatalError(err) {
 				LoggedError(err, err.Error())
 			} else {
+				if inner := lfs.GetInnerError(err); inner != nil {
+					Error(inner.Error())
+				}
 				Error(err.Error())
 			}
 		}

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -24,7 +24,7 @@ var (
 	// shares some global vars and functions with command_pre_push.go
 )
 
-func uploadsBetweenRefs(left string, right string) *lfs.TransferQueue {
+func uploadsBetweenRefs(left string, right string) {
 	tracerx.Printf("Upload between %v and %v", left, right)
 
 	// Just use scanner here
@@ -32,10 +32,11 @@ func uploadsBetweenRefs(left string, right string) *lfs.TransferQueue {
 	if err != nil {
 		Panic(err, "Error scanning for Git LFS files")
 	}
-	return uploadPointers(pointers)
+
+	uploadPointers(pointers)
 }
 
-func uploadsBetweenRefAndRemote(remote string, refs []string) *lfs.TransferQueue {
+func uploadsBetweenRefAndRemote(remote string, refs []string) {
 	tracerx.Printf("Upload refs %v to remote %v", remote, refs)
 
 	scanOpt := lfs.NewScanRefsOptions()
@@ -46,7 +47,8 @@ func uploadsBetweenRefAndRemote(remote string, refs []string) *lfs.TransferQueue
 		if len(refs) == 0 {
 			pointers := scanAll()
 			Print("Pushing objects...")
-			return uploadPointers(pointers)
+			uploadPointers(pointers)
+			return
 		} else {
 			scanOpt.ScanMode = lfs.ScanRefsMode
 		}
@@ -73,10 +75,10 @@ func uploadsBetweenRefAndRemote(remote string, refs []string) *lfs.TransferQueue
 		i += 1
 	}
 
-	return uploadPointers(pointers)
+	uploadPointers(pointers)
 }
 
-func uploadPointers(pointers []*lfs.WrappedPointer) *lfs.TransferQueue {
+func uploadPointers(pointers []*lfs.WrappedPointer) {
 	totalSize := int64(0)
 	for _, p := range pointers {
 		totalSize += p.Size
@@ -105,38 +107,31 @@ func uploadPointers(pointers []*lfs.WrappedPointer) *lfs.TransferQueue {
 		uploadQueue.Add(u)
 	}
 
-	return uploadQueue
-}
-
-func uploadsWithObjectIDs(oids []string) *lfs.TransferQueue {
-	uploads := []*lfs.Uploadable{}
-	totalSize := int64(0)
-
-	for i, oid := range oids {
-		if pushDryRun {
-			Print("push object ID %s", oid)
-			continue
-		}
-		tracerx.Printf("prepare upload: %s %d/%d", oid, i+1, len(oids))
-
-		u, err := lfs.NewUploadable(oid, "")
-		if err != nil {
+	if !pushDryRun {
+		uploadQueue.Wait()
+		for _, err := range uploadQueue.Errors() {
 			if Debugging || lfs.IsFatalError(err) {
-				Panic(err, err.Error())
+				LoggedError(err, err.Error())
 			} else {
-				Exit(err.Error())
+				if inner := lfs.GetInnerError(err); inner != nil {
+					Error(inner.Error())
+				}
+				Error(err.Error())
 			}
 		}
-		uploads = append(uploads, u)
+
+		if len(uploadQueue.Errors()) > 0 {
+			os.Exit(2)
+		}
 	}
+}
 
-	uploadQueue := lfs.NewUploadQueue(len(oids), totalSize, pushDryRun)
-
-	for _, u := range uploads {
-		uploadQueue.Add(u)
+func uploadsWithObjectIDs(oids []string) {
+	pointers := make([]*lfs.WrappedPointer, len(oids))
+	for idx, oid := range oids {
+		pointers[idx] = &lfs.WrappedPointer{Pointer: &lfs.Pointer{Oid: oid}}
 	}
-
-	return uploadQueue
+	uploadPointers(pointers)
 }
 
 // pushCommand pushes local objects to a Git LFS server.  It takes two
@@ -149,8 +144,6 @@ func uploadsWithObjectIDs(oids []string) *lfs.TransferQueue {
 // pushCommand calculates the git objects to send by looking comparing the range
 // of commits between the local and remote git servers.
 func pushCommand(cmd *cobra.Command, args []string) {
-	var uploadQueue *lfs.TransferQueue
-
 	if len(args) == 0 {
 		Print("Specify a remote and a remote branch name (`git lfs push origin master`)")
 		os.Exit(1)
@@ -183,36 +176,21 @@ func pushCommand(cmd *cobra.Command, args []string) {
 			return
 		}
 
-		uploadQueue = uploadsBetweenRefs(left, right)
+		uploadsBetweenRefs(left, right)
 	} else if pushObjectIDs {
 		if len(args) < 2 {
 			Print("Usage: git lfs push --object-id <remote> <lfs-object-id> [lfs-object-id] ...")
 			return
 		}
 
-		uploadQueue = uploadsWithObjectIDs(args[1:])
+		uploadsWithObjectIDs(args[1:])
 	} else {
 		if len(args) < 1 {
 			Print("Usage: git lfs push --dry-run <remote> [ref]")
 			return
 		}
 
-		uploadQueue = uploadsBetweenRefAndRemote(args[0], args[1:])
-	}
-
-	if !pushDryRun {
-		uploadQueue.Wait()
-		for _, err := range uploadQueue.Errors() {
-			if Debugging || lfs.IsFatalError(err) {
-				LoggedError(err, err.Error())
-			} else {
-				Error(err.Error())
-			}
-		}
-
-		if len(uploadQueue.Errors()) > 0 {
-			os.Exit(2)
-		}
+		uploadsBetweenRefAndRemote(args[0], args[1:])
 	}
 }
 

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -46,7 +46,7 @@ func uploadsBetweenRefAndRemote(remote string, refs []string) {
 	if pushAll {
 		if len(refs) == 0 {
 			gitrefs, err := git.LocalRefs()
-			if err == nil {
+			if err != nil {
 				Error(err.Error())
 				Exit("Error getting local refs.")
 			}

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -46,7 +46,7 @@ func uploadsBetweenRefAndRemote(remote string, refs []string) {
 	if pushAll {
 		if len(refs) == 0 {
 			gitrefs, err := git.LocalRefs()
-			if err := nil {
+			if err == nil {
 				Error(err.Error())
 				Exit("Error getting local refs.")
 			}

--- a/git/git.go
+++ b/git/git.go
@@ -153,12 +153,15 @@ func RemoteList() ([]string, error) {
 		return nil, fmt.Errorf("Failed to call git remote: %v", err)
 	}
 	cmd.Start()
+	defer cmd.Wait()
+
 	scanner := bufio.NewScanner(outp)
 
 	var ret []string
 	for scanner.Scan() {
 		ret = append(ret, strings.TrimSpace(scanner.Text()))
 	}
+
 	return ret, nil
 }
 
@@ -331,6 +334,8 @@ func RecentBranches(since time.Time, includeRemoteBranches bool, onlyRemote stri
 		return nil, fmt.Errorf("Failed to call git for-each-ref: %v", err)
 	}
 	cmd.Start()
+	defer cmd.Wait()
+
 	scanner := bufio.NewScanner(outp)
 
 	// Output is like this:
@@ -369,7 +374,6 @@ func RecentBranches(since time.Time, includeRemoteBranches bool, onlyRemote stri
 			ret = append(ret, &Ref{ref, reftype, sha})
 		}
 	}
-	cmd.Wait()
 
 	return ret, nil
 

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -280,3 +280,21 @@ func TestGitAndRootDirs(t *testing.T) {
 
 	assert.Equal(t, git, filepath.Join(root, ".git"))
 }
+
+func TestLocalRefs(t *testing.T) {
+	refs, err := LocalRefs()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range refs {
+		switch r.Type {
+		case RefTypeHEAD:
+			t.Errorf("Local HEAD ref: %v", r)
+		case RefTypeOther:
+			t.Errorf("Stash or unknown ref: %v", r)
+		case RefTypeRemoteBranch, RefTypeRemoteTag:
+			t.Errorf("Remote ref: %v", r)
+		}
+	}
+}


### PR DESCRIPTION
This is a quick code spike to getting the `git lfs push` command to run on individual local refs when given `--all`. Could be useful for sending ref info in #1036.

This may run into issues if the local branch doesn't match the remote tracking branch...