### PR TITLE
improve initial pre-push imports

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -125,6 +125,9 @@ func prePushRef(left, right string, uploadedOids lfs.StringSet) {
 			if Debugging || lfs.IsFatalError(err) {
 				LoggedError(err, err.Error())
 			} else {
+				if inner := lfs.GetInnerError(err); inner != nil {
+					Error(inner.Error())
+				}
 				Error(err.Error())
 			}
 		}

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -40,15 +40,13 @@ func pullCommand(cmd *cobra.Command, args []string) {
 }
 
 func pull(includePaths, excludePaths []string) {
-
 	ref, err := git.CurrentRef()
 	if err != nil {
 		Panic(err, "Could not pull")
 	}
 
-	c := fetchRefToChan(ref.Sha, includePaths, excludePaths)
+	c := fetchRefToChan(ref, includePaths, excludePaths)
 	checkoutFromFetchChan(includePaths, excludePaths, c)
-
 }
 
 func init() {

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -24,7 +24,7 @@ var (
 	// shares some global vars and functions with command_pre_push.go
 )
 
-func uploadsBetweenRefs(left string, right string) *lfs.TransferQueue {
+func uploadsBetweenRefs(left string, right string) {
 	tracerx.Printf("Upload between %v and %v", left, right)
 
 	// Just use scanner here
@@ -32,10 +32,11 @@ func uploadsBetweenRefs(left string, right string) *lfs.TransferQueue {
 	if err != nil {
 		Panic(err, "Error scanning for Git LFS files")
 	}
-	return uploadPointers(pointers)
+
+	uploadPointers(pointers)
 }
 
-func uploadsBetweenRefAndRemote(remote string, refs []string) *lfs.TransferQueue {
+func uploadsBetweenRefAndRemote(remote string, refs []string) {
 	tracerx.Printf("Upload refs %v to remote %v", remote, refs)
 
 	scanOpt := lfs.NewScanRefsOptions()
@@ -44,16 +45,20 @@ func uploadsBetweenRefAndRemote(remote string, refs []string) *lfs.TransferQueue
 
 	if pushAll {
 		if len(refs) == 0 {
-			pointers := scanAll()
-			Print("Pushing objects...")
-			return uploadPointers(pointers)
-		} else {
-			scanOpt.ScanMode = lfs.ScanRefsMode
-		}
-	}
+			gitrefs, err := git.LocalRefs()
+			if err != nil {
+				Error(err.Error())
+				Exit("Error getting local refs.")
+			}
 
-	// keep a unique set of pointers
-	oidPointerMap := make(map[string]*lfs.WrappedPointer)
+			refs = make([]string, len(gitrefs))
+			for idx, gitref := range gitrefs {
+				refs[idx] = gitref.Name
+			}
+		}
+
+		scanOpt.ScanMode = lfs.ScanRefsMode
+	}
 
 	for _, ref := range refs {
 		pointers, err := lfs.ScanRefs(ref, "", scanOpt)
@@ -61,22 +66,11 @@ func uploadsBetweenRefAndRemote(remote string, refs []string) *lfs.TransferQueue
 			Panic(err, "Error scanning for Git LFS files in the %q ref", ref)
 		}
 
-		for _, p := range pointers {
-			oidPointerMap[p.Oid] = p
-		}
+		uploadPointers(pointers)
 	}
-
-	i := 0
-	pointers := make([]*lfs.WrappedPointer, len(oidPointerMap))
-	for _, pointer := range oidPointerMap {
-		pointers[i] = pointer
-		i += 1
-	}
-
-	return uploadPointers(pointers)
 }
 
-func uploadPointers(pointers []*lfs.WrappedPointer) *lfs.TransferQueue {
+func uploadPointers(pointers []*lfs.WrappedPointer) {
 	totalSize := int64(0)
 	for _, p := range pointers {
 		totalSize += p.Size
@@ -105,38 +99,31 @@ func uploadPointers(pointers []*lfs.WrappedPointer) *lfs.TransferQueue {
 		uploadQueue.Add(u)
 	}
 
-	return uploadQueue
-}
-
-func uploadsWithObjectIDs(oids []string) *lfs.TransferQueue {
-	uploads := []*lfs.Uploadable{}
-	totalSize := int64(0)
-
-	for i, oid := range oids {
-		if pushDryRun {
-			Print("push object ID %s", oid)
-			continue
-		}
-		tracerx.Printf("prepare upload: %s %d/%d", oid, i+1, len(oids))
-
-		u, err := lfs.NewUploadable(oid, "")
-		if err != nil {
+	if !pushDryRun {
+		uploadQueue.Wait()
+		for _, err := range uploadQueue.Errors() {
 			if Debugging || lfs.IsFatalError(err) {
-				Panic(err, err.Error())
+				LoggedError(err, err.Error())
 			} else {
-				Exit(err.Error())
+				if inner := lfs.GetInnerError(err); inner != nil {
+					Error(inner.Error())
+				}
+				Error(err.Error())
 			}
 		}
-		uploads = append(uploads, u)
+
+		if len(uploadQueue.Errors()) > 0 {
+			os.Exit(2)
+		}
 	}
+}
 
-	uploadQueue := lfs.NewUploadQueue(len(oids), totalSize, pushDryRun)
-
-	for _, u := range uploads {
-		uploadQueue.Add(u)
+func uploadsWithObjectIDs(oids []string) {
+	pointers := make([]*lfs.WrappedPointer, len(oids))
+	for idx, oid := range oids {
+		pointers[idx] = &lfs.WrappedPointer{Pointer: &lfs.Pointer{Oid: oid}}
 	}
-
-	return uploadQueue
+	uploadPointers(pointers)
 }
 
 // pushCommand pushes local objects to a Git LFS server.  It takes two
@@ -149,8 +136,6 @@ func uploadsWithObjectIDs(oids []string) *lfs.TransferQueue {
 // pushCommand calculates the git objects to send by looking comparing the range
 // of commits between the local and remote git servers.
 func pushCommand(cmd *cobra.Command, args []string) {
-	var uploadQueue *lfs.TransferQueue
-
 	if len(args) == 0 {
 		Print("Specify a remote and a remote branch name (`git lfs push origin master`)")
 		os.Exit(1)
@@ -183,36 +168,21 @@ func pushCommand(cmd *cobra.Command, args []string) {
 			return
 		}
 
-		uploadQueue = uploadsBetweenRefs(left, right)
+		uploadsBetweenRefs(left, right)
 	} else if pushObjectIDs {
 		if len(args) < 2 {
 			Print("Usage: git lfs push --object-id <remote> <lfs-object-id> [lfs-object-id] ...")
 			return
 		}
 
-		uploadQueue = uploadsWithObjectIDs(args[1:])
+		uploadsWithObjectIDs(args[1:])
 	} else {
 		if len(args) < 1 {
 			Print("Usage: git lfs push --dry-run <remote> [ref]")
 			return
 		}
 
-		uploadQueue = uploadsBetweenRefAndRemote(args[0], args[1:])
-	}
-
-	if !pushDryRun {
-		uploadQueue.Wait()
-		for _, err := range uploadQueue.Errors() {
-			if Debugging || lfs.IsFatalError(err) {
-				LoggedError(err, err.Error())
-			} else {
-				Error(err.Error())
-			}
-		}
-
-		if len(uploadQueue.Errors()) > 0 {
-			os.Exit(2)
-		}
+		uploadsBetweenRefAndRemote(args[0], args[1:])
 	}
 }
 

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -1,0 +1,117 @@
+package commands
+
+import (
+	"os"
+
+	"github.com/github/git-lfs/lfs"
+)
+
+type clientContext struct {
+	RemoteName   string
+	DryRun       bool
+	uploadedOids lfs.StringSet
+}
+
+func newClient() *clientContext {
+	return &clientContext{
+		uploadedOids: lfs.NewStringSet(),
+	}
+}
+
+func (c *clientContext) Upload(metadata *lfs.TransferMetadata, unfilteredPointers []*lfs.WrappedPointer) {
+	pointers := c.filter(unfilteredPointers)
+
+	if c.DryRun {
+		for _, pointer := range pointers {
+			Print("push %s => %s", pointer.Oid, pointer.Name)
+			c.uploadedOids.Add(pointer.Oid)
+		}
+		return
+	}
+
+	totalSize := int64(0)
+	for _, p := range pointers {
+		totalSize += p.Size
+	}
+
+	uploadQueue := lfs.NewUploadQueue(len(pointers), totalSize, c.DryRun, metadata)
+	for _, pointer := range pointers {
+		u, err := lfs.NewUploadable(pointer.Oid, pointer.Name)
+		if err != nil {
+			if lfs.IsCleanPointerError(err) {
+				Exit(prePushMissingErrMsg, pointer.Name, lfs.ErrorGetContext(err, "pointer").(*lfs.Pointer).Oid)
+			} else {
+				ExitWithError(err)
+			}
+		}
+
+		uploadQueue.Add(u)
+		c.uploadedOids.Add(pointer.Oid)
+	}
+
+	uploadQueue.Wait()
+	for _, err := range uploadQueue.Errors() {
+		if Debugging || lfs.IsFatalError(err) {
+			LoggedError(err, err.Error())
+		} else {
+			if inner := lfs.GetInnerError(err); inner != nil {
+				Error(inner.Error())
+			}
+			Error(err.Error())
+		}
+	}
+
+	if len(uploadQueue.Errors()) > 0 {
+		os.Exit(2)
+	}
+}
+
+func (c *clientContext) filter(pointers []*lfs.WrappedPointer) []*lfs.WrappedPointer {
+	uploadable := c.filterUploadedObjects(pointers)
+	c.filterServerObjects(uploadable)
+	return c.filterUploadedObjects(uploadable)
+}
+
+func (c *clientContext) filterUploadedObjects(pointers []*lfs.WrappedPointer) []*lfs.WrappedPointer {
+	filtered := make([]*lfs.WrappedPointer, 0, len(pointers))
+	for _, pointer := range pointers {
+		if !c.uploadedOids.Contains(pointer.Oid) {
+			filtered = append(filtered, pointer)
+		}
+	}
+
+	return filtered
+}
+
+func (c *clientContext) filterServerObjects(pointers []*lfs.WrappedPointer) {
+	missingLocalObjects := make([]*lfs.WrappedPointer, 0, len(pointers))
+	missingSize := int64(0)
+	for _, pointer := range pointers {
+		if !lfs.ObjectExistsOfSize(pointer.Oid, pointer.Size) {
+			// We think we need to push this but we don't have it
+			// Store for server checking later
+			missingLocalObjects = append(missingLocalObjects, pointer)
+			missingSize += pointer.Size
+		}
+	}
+	if len(missingLocalObjects) == 0 {
+		return
+	}
+
+	checkQueue := lfs.NewDownloadCheckQueue(len(missingLocalObjects), missingSize, true)
+	for _, p := range missingLocalObjects {
+		checkQueue.Add(lfs.NewDownloadCheckable(p))
+	}
+	// this channel is filled with oids for which Check() succeeded & Transfer() was called
+	transferc := checkQueue.Watch()
+	done := make(chan int)
+	go func() {
+		for oid := range transferc {
+			c.uploadedOids.Add(oid)
+		}
+		done <- 1
+	}()
+	// Currently this is needed to flush the batch but is not enough to sync transferc completely
+	checkQueue.Wait()
+	<-done
+}

--- a/docs/api/http-v1.2-batch-request-schema.json
+++ b/docs/api/http-v1.2-batch-request-schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Git LFS HTTPS Batch API v1.2 Request",
+  "type": "object",
+  "properties": {
+    "operation": {
+      "type": "string"
+    },
+    "objects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "oid": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          }
+        },
+        "required": ["oid", "size"],
+        "additionalProperties": false
+      }
+    },
+    "meta": {
+      "type": "object",
+      "properties": {
+        "ref": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  },
+  "required": ["objects", "operation"],
+  "additionalProperties": false
+}

--- a/docs/api/http-v1.2-batch.md
+++ b/docs/api/http-v1.2-batch.md
@@ -1,0 +1,286 @@
+# Git LFS v1 Batch API
+
+The Git LFS Batch API works like the [original v1 API][v1], but uses a single
+endpoint that accepts multiple OIDs. All requests should have the following:
+
+    Accept: application/vnd.git-lfs+json
+    Content-Type: application/vnd.git-lfs+json
+
+[v1]: ./http-v1-original.md
+
+This is a newer API introduced in Git LFS v0.5.2, and made the default in
+Git LFS v0.6.0. The client automatically detects if the server does not
+implement the API yet, and falls back to the legacy API. You can toggle support
+manually through the Git config:
+
+    # enable batch support
+    $ git config --unset lfs.batch
+
+    # disable batch support
+    $ git config lfs.batch false
+
+## Authentication
+
+The Batch API authenticates the same as the original v1 API with one exception:
+The client will attempt to make requests without any authentication. This
+slight change allows anonymous access to public Git LFS objects. The client
+stores the result of this in the `lfs.<url>.access` config setting, where <url>
+refers to the endpoint's URL.
+
+## POST /objects/batch
+
+This request retrieves the metadata for a batch of objects, given a JSON body
+containing an object with an array of objects with the oid and size of each
+object. While the API endpoint can support requests to download AND upload
+objects in one batch, the client will usually stick to one or the other.
+
+When downloading objects through a command such as `git lfs fetch`, the client
+will initially skip authentication if it doesn't know the access level of the
+repository.
+
+* If `lfs.<url>.access` is not set, make an unauthenticated request.
+  1. If it returns 401, set `lfs.<url>.access` to `private`.
+* If `lfs.<url>.access` is `private`, always send authentication. Ask the user if
+authentication information is not readily available.
+
+When uploading objects through `git lfs push`, Git LFS will always send
+authentication info, regardless of how `lfs.<url>.access` is configured.
+
+```
+> POST https://git-lfs-server.com/objects/batch HTTP/1.1
+> Accept: application/vnd.git-lfs+json
+> Content-Type: application/vnd.git-lfs+json
+> Authorization: Basic ... (if authentication is needed)
+>
+> {
+>   "operation": "upload",
+>   "objects": [
+>     {
+>       "oid": "1111111",
+>       "size": 123
+>     }
+>   ],
+>   "meta": {
+>     "ref": "refs/heads/master"
+>   }
+> }
+>
+< HTTP/1.1 200 Ok
+< Content-Type: application/vnd.git-lfs+json
+<
+< {
+<   "objects": [
+<     {
+<       "oid": "1111111",
+<       "size": 123,
+<       "actions": {
+<         "upload": {
+<          "href": "https://some-upload.com",
+<           "header": {
+<             "Key": "value"
+<           }
+<         },
+<         "verify": {
+<           "href": "https://some-callback.com",
+<           "header": {
+<             "Key": "value"
+<           }
+<         }
+<       }
+>     }
+<   ]
+< }
+```
+
+The response will be an object containing an array of objects with one of
+multiple actions, each with an `href` property and an optional `header`
+property. The requests and responses need to validate with the included JSON
+schemas:
+
+* [Batch request](./http-v1.2-batch-request-schema.json)
+* [Batch response](./http-v1-batch-response-schema.json)
+
+Here are the valid actions:
+
+* `upload` - This relation describes how to upload the object.  Expect this with
+when the object has not been previously uploaded.
+* `verify` - The server can specify a URL for the client to hit after
+successfully uploading an object.  This is an optional relation for the case that
+the server has not verified the object.
+* `download` - This relation describes how to download the object content.  This
+only appears if an object has been previously uploaded.
+
+An action can optionally include an `expires_at`, which is an ISO 8601 formatted
+timestamp for when the given action expires (usually due to a temporary token).
+
+```json
+{
+  "objects": [
+    {
+      "oid": "1111111",
+      "size": 123,
+      "actions": {
+        "download": {
+          "href": "https://some-download.com?token=abc123",
+          "expires_at": "2015-07-27T21:15:01Z"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Successful Responses
+
+The Batch API should always return 200 unless there's an authorization problem
+between the requesting user and the repository.
+
+Here is a response to download a single object:
+
+```
+< HTTP/1.1 200 Ok
+< Content-Type: application/vnd.git-lfs+json
+<
+< {
+<   "objects": [
+<     {
+<       "oid": "1111111",
+<       "size": 123,
+<       "actions": {
+<         "download": {
+<           "href": "https://some-download.com"
+<         }
+<       }
+>     }
+<   ]
+< }
+```
+
+It is possible for servers to respond with a 200, and just annotate specific
+objects that failed through an `error` property. Here's an example request to
+download two objects, with one object that doesn't exist:
+
+```
+< HTTP/1.1 200 Ok
+< Content-Type: application/vnd.git-lfs+json
+<
+< {
+<   "objects": [
+<     {
+<       "oid": "1111111",
+<       "size": 123,
+<       "actions": {
+<         "download": {
+<           "href": "https://some-download.com"
+<         }
+<       }
+>     },
+<     {
+<       "oid": "2222222",
+<       "size": 123,
+<       "error": {
+<         "code": 404,
+<         "message": "Object does not exist on the server"
+<       }
+>     }
+<   ]
+< }
+```
+
+Object error codes should match HTTP status codes where possible:
+
+* 404 - The object does not exist on the server.
+* 410 - The object was removed by the owner.
+* 422 - Validation error.
+
+Validation errors can only occur on `upload` requests. Servers must verify
+that OIDs are valid SHA-256 strings, and that sizes are positive integers.
+Servers may also set an upper bound for the allowed object size too. Here's a
+response showing one uploadable object, and one with a validation error:
+
+```
+< HTTP/1.1 200 Ok
+< Content-Type: application/vnd.git-lfs+json
+<
+< {
+<   "objects": [
+<     {
+<       "oid": "1111111",
+<       "size": 123,
+<       "actions": {
+<         "upload": {
+<           "href": "https://some-upload.com"
+<         }
+<       }
+>     },
+<     {
+<       "oid": "2222222",
+<       "size": -1,
+<       "error": {
+<         "code": 422,
+<         "message": "Invalid object size"
+<       }
+>     }
+<   ]
+< }
+```
+
+### Response Errors
+
+Servers can respond with the following HTTP status codes:
+
+* 401 - The authentication credentials are needed, but were not sent.
+* 403 - The user has **read**, but not **write** access. Only applicable when
+the `operation` in the request is "upload."
+* 404 - The repository does not exist for the user.
+* 422 - Validation error with one or more of the objects in the request. This
+  means that _none_ of the requested objects to upload are valid.
+
+Responses will not have the `objects` property. They must have a `message`
+property, and should have `request_id` and `documentation_url` properties to
+help users.
+
+```
+< HTTP/1.1 403 Forbidden
+< Content-Type: application/vnd.git-lfs+json
+<
+< {
+<   "message": "Invalid credentials.",
+<   "documentation_url": "https://git-lfs-server.com/docs/errors",
+<   "request_id": "123"
+< }
+```
+
+401 responses should include a `LFS-Authenticate` header to tell the client what
+form of authentication it requires. This is a placeholder in case the client
+adds support for something other than Basic Authentication. This is meant to
+mirror the standard `WWW-Authenticate` header. A new header is used so it
+does not trigger the password prompt in browsers.
+
+```
+< HTTP/1.1 401 Unauthorized
+< Content-Type: application/vnd.git-lfs+json
+< LFS-Authenticate: Basic realm="Git LFS"
+<
+< {
+<   "message": "Credentials needed.",
+<   "documentation_url": "https://git-lfs-server.com/docs/errors",
+<   "request_id": "123"
+< }
+```
+
+The following status codes can optionally be returned from the API, depending on
+the server implementation.
+
+* 406 - The Accept header needs to be `application/vnd.git-lfs+json`.
+* 429 - The user has hit a rate limit with the server.  Though the API does not
+specify any rate limits, implementors are encouraged to set some for
+availability reasons.
+* 501 - The server has not implemented the current method.  Reserved for future
+use.
+* 509 - Returned if the bandwidth limit for the user or repository has been
+exceeded.  The API does not specify any bandwidth limit, but implementors may
+track usage.
+
+Some server errors may trigger the client to retry requests, such as 500, 502,
+503, and 504.

--- a/git/git.go
+++ b/git/git.go
@@ -40,6 +40,22 @@ type Ref struct {
 	Sha  string
 }
 
+func (r *Ref) NameOnRemote(remotename string) string {
+	if r.Type != RefTypeLocalBranch {
+		return r.Name
+	}
+
+	if len(remotename) == 0 {
+		return r.Name
+	}
+
+	if RemoteForBranch(r.Name) != remotename {
+		return r.Name
+	}
+
+	return RemoteBranchForLocalBranch(r.Name)
+}
+
 // Some top level information about a commit (only first line of message)
 type CommitSummary struct {
 	Sha            string
@@ -78,6 +94,19 @@ func ResolveRef(ref string) (*Ref, error) {
 	fullref := &Ref{Sha: lines[0]}
 	fullref.Type, fullref.Name = ParseRefToTypeAndName(lines[1])
 	return fullref, nil
+}
+
+func ResolveRefs(refnames []string) ([]*Ref, error) {
+	refs := make([]*Ref, len(refnames))
+	for i, name := range refnames {
+		ref, err := ResolveRef(name)
+		if err != nil {
+			return refs, err
+		}
+
+		refs[i] = ref
+	}
+	return refs, nil
 }
 
 func CurrentRef() (*Ref, error) {
@@ -142,7 +171,6 @@ func RemoteBranchForLocalBranch(localBranch string) string {
 	} else {
 		return localBranch
 	}
-
 }
 
 func RemoteList() ([]string, error) {

--- a/git/git.go
+++ b/git/git.go
@@ -153,13 +153,49 @@ func RemoteList() ([]string, error) {
 		return nil, fmt.Errorf("Failed to call git remote: %v", err)
 	}
 	cmd.Start()
+	defer cmd.Wait()
+
 	scanner := bufio.NewScanner(outp)
 
 	var ret []string
 	for scanner.Scan() {
 		ret = append(ret, strings.TrimSpace(scanner.Text()))
 	}
+
 	return ret, nil
+}
+
+// Refs returns all of the local and remote branches and tags for the current
+// repository. Other refs (HEAD, refs/stash, git notes) are ignored.
+func LocalRefs() ([]*Ref, error) {
+	cmd := execCommand("git", "show-ref")
+
+	outp, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to call git show-ref: %v", err)
+	}
+	cmd.Start()
+	defer cmd.Wait()
+
+	var refs []*Ref
+	scanner := bufio.NewScanner(outp)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) != 2 || len(parts[0]) != 40 || len(parts[1]) < 1 {
+			tracerx.Printf("Invalid line from git show-ref: %q", line)
+			continue
+		}
+
+		rtype, name := ParseRefToTypeAndName(parts[1])
+		if rtype != RefTypeLocalBranch && rtype != RefTypeLocalTag {
+			continue
+		}
+
+		refs = append(refs, &Ref{name, rtype, parts[0]})
+	}
+
+	return refs, nil
 }
 
 // ValidateRemote checks that a named remote is valid for use
@@ -331,6 +367,8 @@ func RecentBranches(since time.Time, includeRemoteBranches bool, onlyRemote stri
 		return nil, fmt.Errorf("Failed to call git for-each-ref: %v", err)
 	}
 	cmd.Start()
+	defer cmd.Wait()
+
 	scanner := bufio.NewScanner(outp)
 
 	// Output is like this:
@@ -369,7 +407,6 @@ func RecentBranches(since time.Time, includeRemoteBranches bool, onlyRemote stri
 			ret = append(ret, &Ref{ref, reftype, sha})
 		}
 	}
-	cmd.Wait()
 
 	return ret, nil
 

--- a/git/git.go
+++ b/git/git.go
@@ -168,7 +168,7 @@ func RemoteList() ([]string, error) {
 // Refs returns all of the local and remote branches and tags for the current
 // repository. Other refs (HEAD, refs/stash, git notes) are ignored.
 func LocalRefs() ([]*Ref, error) {
-	cmd := execCommand("git", "show-ref")
+	cmd := execCommand("git", "show-ref", "--heads", "--tags")
 
 	outp, err := cmd.StdoutPipe()
 	if err != nil {

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -280,3 +280,21 @@ func TestGitAndRootDirs(t *testing.T) {
 
 	assert.Equal(t, git, filepath.Join(root, ".git"))
 }
+
+func TestLocalRefs(t *testing.T) {
+	refs, err := LocalRefs()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range refs {
+		switch r.Type {
+		case RefTypeHEAD:
+			t.Errorf("Local HEAD ref: %v", r)
+		case RefTypeOther:
+			t.Errorf("Stash or unknown ref: %v", r)
+		case RefTypeRemoteBranch, RefTypeRemoteTag:
+			t.Errorf("Remote ref: %v", r)
+		}
+	}
+}

--- a/lfs/download_queue.go
+++ b/lfs/download_queue.go
@@ -66,8 +66,9 @@ func (d *Downloadable) Transfer(cb CopyCallback) error {
 }
 
 // NewDownloadQueue builds a DownloadQueue, allowing `workers` concurrent downloads.
-func NewDownloadQueue(files int, size int64, dryRun bool) *TransferQueue {
+func NewDownloadQueue(files int, size int64, dryRun bool, metadata *TransferMetadata) *TransferQueue {
 	q := newTransferQueue(files, size, dryRun)
 	q.transferKind = "download"
+	q.metadata = metadata
 	return q
 }

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -71,9 +71,10 @@ func (u *Uploadable) SetObject(o *ObjectResource) {
 }
 
 // NewUploadQueue builds an UploadQueue, allowing `workers` concurrent uploads.
-func NewUploadQueue(files int, size int64, dryRun bool) *TransferQueue {
+func NewUploadQueue(files int, size int64, dryRun bool, metadata *TransferMetadata) *TransferQueue {
 	q := newTransferQueue(files, size, dryRun)
 	q.transferKind = "upload"
+	q.metadata = metadata
 	return q
 }
 

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -154,8 +154,10 @@ func buildTestData() (oidsExist, oidsMissing []TestObject, err error) {
 	}
 	outputs := repo.AddCommits([]*test.CommitInput{&commit})
 
+	// create metadata
+	metadata := lfs.NewTransferMetadata("refs/heads/master")
 	// now upload
-	uploadQueue := lfs.NewUploadQueue(len(oidsExist), totalSize, false)
+	uploadQueue := lfs.NewUploadQueue(len(oidsExist), totalSize, false, metadata)
 	for _, f := range outputs[0].Files {
 		oidsExist = append(oidsExist, TestObject{Oid: f.Oid, Size: f.Size})
 
@@ -248,7 +250,8 @@ func callBatchApi(op string, objs []TestObject) ([]*lfs.ObjectResource, error) {
 	for _, o := range objs {
 		apiobjs = append(apiobjs, &lfs.ObjectResource{Oid: o.Oid, Size: o.Size})
 	}
-	return lfs.Batch(apiobjs, op)
+	metadata := lfs.NewTransferMetadata("refs/heads/master")
+	return lfs.Batch(apiobjs, op, metadata)
 }
 
 // Combine 2 slices into one by "randomly" interleaving

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -132,7 +132,7 @@ begin_test "push --all (no ref args)"
   [ $(grep -c "push" < push.log) -eq 6 ]
 
   git push --all origin 2>&1 | tee push.log
-  grep "5 files" push.log # should be 6?
+  [ `grep -c "3 of 3 files" push.log` -eq 2 ]
   assert_server_object "$reponame-$suffix" "$oid1"
   assert_server_object "$reponame-$suffix" "$oid2"
   assert_server_object "$reponame-$suffix" "$oid3"
@@ -162,7 +162,9 @@ begin_test "push --all (no ref args)"
   [ $(grep -c "push" push.log) -eq 6 ]
 
   git push --all origin 2>&1 | tee push.log
-  grep "5 files, 1 skipped" push.log # should be 5?
+  [ `grep -c "2 of 2 files" push.log` -eq 1 ]
+  [ `grep -c "3 of 3 files" push.log` -eq 1 ]
+  [ `grep -c "Git LFS:" push.log` -eq 2 ]
   assert_server_object "$reponame-$suffix-2" "$oid2"
   assert_server_object "$reponame-$suffix-2" "$oid3"
   assert_server_object "$reponame-$suffix-2" "$oid4"

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -333,29 +333,30 @@ begin_test "push object id(s)"
 (
   set -e
 
-  reponame="$(basename "$0" ".sh")"
+  reponame="$(basename "$0" ".sh")-object-ids"
   setup_remote_repo "$reponame"
-  clone_repo "$reponame" repo2
+  clone_repo "$reponame" repo-object-ids
 
   git lfs track "*.dat"
-  echo "push a" > a.dat
+  echo "push object a" > a.dat
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
   git lfs push --object-id origin \
-    4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
+    c1a338929270651d8fb132411d725518353650bfc9ac991991dd4a8c2139d97a \
     2>&1 | tee push.log
-  grep "(0 of 1 files, 1 skipped)" push.log
+  grep "(1 of 1 files)" push.log
 
-  echo "push b" > b.dat
+  echo "push object b" > b.dat
   git add b.dat
   git commit -m "add b.dat"
+  git show
 
   git lfs push --object-id origin \
-    4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
-    82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 \
+    c1a338929270651d8fb132411d725518353650bfc9ac991991dd4a8c2139d97a \
+    7098284b1b16d67681313247191c217c5f185acaa40b5f00731574d70d75f2e1 \
     2>&1 | tee push.log
-  grep "(0 of 2 files, 2 skipped)" push.log
+  grep "(1 of 1 files)" push.log
 )
 end_test
 

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -153,13 +153,16 @@ begin_test "push --all (no ref args)"
 
   # dry run doesn't change
   git lfs push --dry-run --all origin 2>&1 | tee push.log
-  grep "push $oid1 => file1.dat" push.log
+  grep "push $oid1 => file1.dat" push.log && {
+    echo "Already pushed oid1"
+    exit 1
+  }
   grep "push $oid2 => file1.dat" push.log
   grep "push $oid3 => file1.dat" push.log
   grep "push $oid4 => file1.dat" push.log
   grep "push $oid5 => file1.dat" push.log
   grep "push $extraoid => file2.dat" push.log
-  [ $(grep -c "push" push.log) -eq 6 ]
+  [ $(grep -c "push" push.log) -eq 5 ]
 
   git push --all origin 2>&1 | tee push.log
   [ `grep -c "2 of 2 files" push.log` -eq 1 ]


### PR DESCRIPTION
When pushing a repository to a new host, Git LFS pushes each branch or tag individually. This leads to a lot of skipped objects. Assuming all branches are based on master, then there should be a lot of duplicate objects. Here's a push with a repository with 502 objects: 501 in master, and an extra in another branch:

```bash
$ time git push 5 --all
Git LFS: (501 of 501 files) 1.85 KB / 1.85 KB
Git LFS: (0 of 501 files, 501 skipped) 0 B / 1.85 KB, 1.85 KB skipped
Git LFS: (1 of 502 files, 501 skipped) 3 B / 1.86 KB, 1.85 KB skipped
Git LFS: (0 of 501 files, 501 skipped) 0 B / 1.85 KB, 1.85 KB skipped
Counting objects: 516, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (511/511), done.
Writing objects: 100% (516/516), 70.52 KiB | 0 bytes/s, done.
Total 516 (delta 1), reused 512 (delta 0)
To https://git-server/technoweenie/symmetrical-octo-pancake
 * [new branch]      1 -> 1
 * [new branch]      2 -> 2
 * [new branch]      3 -> 3
 * [new branch]      master -> master
git push 5 --all  2.06s user 1.51s system 7% cpu 51.051 total
```

With this PR:

```bash
$ time git push 4 --all
Git LFS: (501 of 501 files) 1.85 KB / 1.85 KB
Git LFS: (1 of 1 files) 3 B / 3 B
Counting objects: 516, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (511/511), done.
Writing objects: 100% (516/516), 70.52 KiB | 0 bytes/s, done.
Total 516 (delta 1), reused 512 (delta 0)
To https://git-server/technoweenie/symmetrical-octo-funicular
 * [new branch]      1 -> 1
 * [new branch]      2 -> 2
 * [new branch]      3 -> 3
 * [new branch]      master -> master
git push 4 --all  1.62s user 0.89s system 5% cpu 45.280 total
```