### PR TITLE
Fix issues with server-side branch deletion out of sync with cached remote refs

### DIFF
--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -144,7 +144,7 @@ func uploadsWithObjectIDs(oids []string) *lfs.TransferQueue {
 //
 //   `<remote> <remote ref>`
 //
-// Both a remote name ("origin") or a remote URL are accepted.
+// Remote must be a remote name, not a URL
 //
 // pushCommand calculates the git objects to send by looking comparing the range
 // of commits between the local and remote git servers.

--- a/git/git.go
+++ b/git/git.go
@@ -732,11 +732,13 @@ func CachedRemoteRefs(remoteName string) ([]*Ref, error) {
 	for scanner.Scan() {
 		if match := r.FindStringSubmatch(scanner.Text()); match != nil {
 			name := strings.TrimSpace(match[2])
-			sha := match[1]
 			// Don't match head
-			if name != "HEAD" {
-				ret = append(ret, &Ref{name, RefTypeRemoteBranch, sha})
+			if name == "HEAD" {
+				continue
 			}
+
+			sha := match[1]
+			ret = append(ret, &Ref{name, RefTypeRemoteBranch, sha})
 		}
 	}
 	return ret, nil
@@ -760,14 +762,16 @@ func RemoteRefs(remoteName string) ([]*Ref, error) {
 	for scanner.Scan() {
 		if match := r.FindStringSubmatch(scanner.Text()); match != nil {
 			name := strings.TrimSpace(match[3])
-			sha := match[1]
 			// Don't match head
-			if name != "HEAD" {
-				if match[2] == "heads" {
-					ret = append(ret, &Ref{name, RefTypeRemoteBranch, sha})
-				} else {
-					ret = append(ret, &Ref{name, RefTypeRemoteTag, sha})
-				}
+			if name == "HEAD" {
+				continue
+			}
+
+			sha := match[1]
+			if match[2] == "heads" {
+				ret = append(ret, &Ref{name, RefTypeRemoteBranch, sha})
+			} else {
+				ret = append(ret, &Ref{name, RefTypeRemoteTag, sha})
 			}
 		}
 	}

--- a/git/git.go
+++ b/git/git.go
@@ -714,56 +714,59 @@ func CloneWithoutFilters(args []string) error {
 	return nil
 }
 
-// RemoteRefs returns a list of branches & tags for a remote
-// If retrieveFromRemote is true, this information is built by actually calling
-// the remote using 'git ls-remote'. Otherwise the cached remote branch
-// information held locally is used instead.
-func RemoteRefs(remoteName string, retrieveFromRemote bool) ([]*Ref, error) {
+// CachedRemoteRefs returns the list of branches & tags for a remote which are
+// currently cached locally. No remote request is made to verify them.
+func CachedRemoteRefs(remoteName string) ([]*Ref, error) {
 
 	var ret []*Ref
-	if retrieveFromRemote {
-		cmd := execCommand("git", "ls-remote", "--heads", "--tags", "-q", remoteName)
+	cmd := execCommand("git", "show-ref")
 
-		outp, err := cmd.StdoutPipe()
-		if err != nil {
-			return nil, fmt.Errorf("Failed to call git ls-remote: %v", err)
-		}
-		cmd.Start()
-		scanner := bufio.NewScanner(outp)
+	outp, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to call git show-ref: %v", err)
+	}
+	cmd.Start()
+	scanner := bufio.NewScanner(outp)
 
-		r := regexp.MustCompile(`([0-9a-fA-F]{40})\s+refs/(heads|tags)/(.*)`)
-		for scanner.Scan() {
-			if match := r.FindStringSubmatch(scanner.Text()); match != nil {
-				name := strings.TrimSpace(match[3])
-				sha := match[1]
-				// Don't match head
-				if name != "HEAD" {
-					if match[2] == "heads" {
-						ret = append(ret, &Ref{name, RefTypeRemoteBranch, sha})
-					} else {
-						ret = append(ret, &Ref{name, RefTypeRemoteTag, sha})
-					}
-				}
+	r := regexp.MustCompile(fmt.Sprintf(`([0-9a-fA-F]{40})\s+refs/remotes/%v/(.*)`, remoteName))
+	for scanner.Scan() {
+		if match := r.FindStringSubmatch(scanner.Text()); match != nil {
+			name := strings.TrimSpace(match[2])
+			sha := match[1]
+			// Don't match head
+			if name != "HEAD" {
+				ret = append(ret, &Ref{name, RefTypeRemoteBranch, sha})
 			}
 		}
-	} else {
-		cmd := execCommand("git", "show-ref")
+	}
+	return ret, nil
+}
 
-		outp, err := cmd.StdoutPipe()
-		if err != nil {
-			return nil, fmt.Errorf("Failed to call git show-ref: %v", err)
-		}
-		cmd.Start()
-		scanner := bufio.NewScanner(outp)
+// RemoteRefs returns a list of branches & tags for a remote by actually
+// accessing the remote vir git ls-remote
+func RemoteRefs(remoteName string) ([]*Ref, error) {
 
-		r := regexp.MustCompile(fmt.Sprintf(`([0-9a-fA-F]{40})\s+refs/remotes/%v/(.*)`, remoteName))
-		for scanner.Scan() {
-			if match := r.FindStringSubmatch(scanner.Text()); match != nil {
-				name := strings.TrimSpace(match[2])
-				sha := match[1]
-				// Don't match head
-				if name != "HEAD" {
+	var ret []*Ref
+	cmd := execCommand("git", "ls-remote", "--heads", "--tags", "-q", remoteName)
+
+	outp, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to call git ls-remote: %v", err)
+	}
+	cmd.Start()
+	scanner := bufio.NewScanner(outp)
+
+	r := regexp.MustCompile(`([0-9a-fA-F]{40})\s+refs/(heads|tags)/(.*)`)
+	for scanner.Scan() {
+		if match := r.FindStringSubmatch(scanner.Text()); match != nil {
+			name := strings.TrimSpace(match[3])
+			sha := match[1]
+			// Don't match head
+			if name != "HEAD" {
+				if match[2] == "heads" {
 					ret = append(ret, &Ref{name, RefTypeRemoteBranch, sha})
+				} else {
+					ret = append(ret, &Ref{name, RefTypeRemoteTag, sha})
 				}
 			}
 		}

--- a/git/git.go
+++ b/git/git.go
@@ -759,7 +759,7 @@ func RemoteRefs(remoteName string, retrieveFromRemote bool) ([]*Ref, error) {
 		r := regexp.MustCompile(fmt.Sprintf(`([0-9a-fA-F]{40})\s+refs/remotes/%v/(.*)`, remoteName))
 		for scanner.Scan() {
 			if match := r.FindStringSubmatch(scanner.Text()); match != nil {
-				name := strings.TrimSpace(match[3])
+				name := strings.TrimSpace(match[2])
 				sha := match[1]
 				// Don't match head
 				if name != "HEAD" {

--- a/git/git.go
+++ b/git/git.go
@@ -714,7 +714,7 @@ func CloneWithoutFilters(args []string) error {
 	return nil
 }
 
-// RemoteRefsList returns a list of branches & tags for a remote
+// RemoteRefs returns a list of branches & tags for a remote
 // If retrieveFromRemote is true, this information is built by actually calling
 // the remote using 'git ls-remote'. Otherwise the cached remote branch
 // information held locally is used instead.

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -255,8 +255,8 @@ func revListArgsRefVsRemote(refTo, remoteName string) []string {
 	// have also been deleted on the server if unreferenced.
 	// If some refs are missing on the remote, use a more explicit diff
 
-	cachedRemoteRefs, _ := git.RemoteRefs(remoteName, false)
-	actualRemoteRefs, _ := git.RemoteRefs(remoteName, true)
+	cachedRemoteRefs, _ := git.CachedRemoteRefs(remoteName)
+	actualRemoteRefs, _ := git.RemoteRefs(remoteName)
 
 	// Only check for missing refs on remote; if the ref is different it has moved
 	// forward probably, and if not and the ref has changed to a non-descendant

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -380,3 +380,83 @@ begin_test "pre-push with bad remote"
   grep "Invalid remote name" pre-push.log
 )
 end_test
+
+begin_test "pre-push unfetched deleted remote branch & server GC"
+(
+  # point of this is to simulate the case where the local cache of the remote
+  # branch state contains a branch which has actually been deleted on the remote,
+  # the client just doesn't know yet (hasn't done 'git fetch origin --prune')
+  # If the server GC'd the objects that deleted branch contained, but they were
+  # referenced by a branch being pushed (earlier commit), push might assume it
+  # doesn't have to push it, but it does. Tests that we check the real remote refs
+  # before making an assumption about the diff we need to push
+  set -e
+
+  reponame="$(basename "$0" ".sh")-server-deleted-branch-gc"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \*.dat" track.log
+
+  NUMFILES=4
+  # generate content we'll use
+  for ((a=0; a < NUMFILES ; a++))
+  do
+    content[$a]="filecontent$a"
+    oid[$a]=$(calc_oid "${content[$a]}")
+  done
+
+  echo "[
+  {
+    \"CommitDate\":\"$(get_date -10d)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":${#content[0]}, \"Data\":\"${content[0]}\"},
+      {\"Filename\":\"file2.dat\",\"Size\":${#content[1]}, \"Data\":\"${content[1]}\"}]
+  },
+  {
+    \"NewBranch\":\"branch-to-delete\",
+    \"CommitDate\":\"$(get_date -5d)\",
+    \"Files\":[
+      {\"Filename\":\"file3.dat\",\"Size\":${#content[2]}, \"Data\":\"${content[2]}\"}]
+  },
+  {
+    \"NewBranch\":\"branch-to-push-after\",
+    \"CommitDate\":\"$(get_date -2d)\",
+    \"Files\":[
+      {\"Filename\":\"file4.dat\",\"Size\":${#content[3]}, \"Data\":\"${content[3]}\"}]
+  }
+  ]" | lfstest-testutils addcommits
+
+  # push only the first 2 branches
+  git push origin master branch-to-delete
+  for ((a=0; a < 3 ; a++))
+  do
+    assert_server_object "$reponame" "${oid[$a]}"
+  done
+  # confirm we haven't pushed the last one yet
+  refute_server_object "$reponame" "${oid[3]}"
+  # copy the cached remote ref for the branch we're going to delete remotely
+  cp .git/refs/remotes/origin/branch-to-delete branch-to-delete.ref
+  # now delete the branch on the server
+  git push origin --delete branch-to-delete
+  # remove the OID in it, as if GC'd
+  delete_server_object "$reponame" "${oid[2]}"
+  refute_server_object "$reponame" "${oid[2]}"
+  # Now put the cached remote ref back, as if someone else had deleted it but
+  # we hadn't done git fetch --prune yet
+  mv branch-to-delete.ref .git/refs/remotes/origin/branch-to-delete
+  # Confirm that local cache of remote branch is back
+  git branch -r 2>&1 | tee branch-r.log 
+  grep "origin/branch-to-delete" branch-r.log
+  # Now push later branch which should now need to re-push previous commits LFS too
+  git push origin branch-to-push-after
+  # all objects should now be there even though cached remote branch claimed it already had file3.dat
+  for ((a=0; a < NUMFILES ; a++))
+  do
+    assert_server_object "$reponame" "${oid[$a]}"
+  done
+
+)
+end_test


### PR DESCRIPTION
Fixes problem described in more detail in #1014 

Verifies that server still has all the remote refs we're using to diff which LFS objects to upload, in case one has been deleted without local knowledge and LFS objects have been GC'd in the mean time, which would lead to data loss. Proved that the test I added fails without the code change.