### PR TITLE
Fixes for windows build

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -643,9 +643,6 @@ func CloneWithoutFilters(args []string) error {
 	cmdargs = append(cmdargs, args...)
 	cmd := execCommand("git", cmdargs...)
 
-	// Spool stdout directly to our own
-	cmd.Stdout = os.Stdout
-
 	// Assign pty/tty so git thinks it's a real terminal
 	tty := NewTty(cmd)
 	stdout, err := tty.Stdout()

--- a/git/git.go
+++ b/git/git.go
@@ -15,10 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
-	"github.com/github/git-lfs/vendor/_nuts/github.com/kr/pty"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/rubyist/tracerx"
 )
 
@@ -649,29 +647,27 @@ func CloneWithoutFilters(args []string) error {
 	cmd.Stdout = os.Stdout
 
 	// Assign pty/tty so git thinks it's a real terminal
-	outpty, outtty, err := pty.Open()
-	cmd.Stdin = outtty
-	cmd.Stdout = outtty
-	errpty, errtty, err := pty.Open()
-	// stderr needs filtering
-	cmd.Stderr = errtty
-	if cmd.SysProcAttr == nil {
-		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	tty := NewTty(cmd)
+	stdout, err := tty.Stdout()
+	if err != nil {
+		return fmt.Errorf("Failed to get stdout: %v", err)
 	}
-	cmd.SysProcAttr.Setctty = true
-	cmd.SysProcAttr.Setsid = true
+	stderr, err := tty.Stderr()
+	if err != nil {
+		return fmt.Errorf("Failed to get stderr: %v", err)
+	}
 
 	var outputWait sync.WaitGroup
 	outputWait.Add(2)
 	go func() {
-		io.Copy(os.Stdout, outpty)
+		io.Copy(os.Stdout, stdout)
 		outputWait.Done()
 	}()
 	go func() {
 		// Filter stderr to exclude messages caused by disabling the filters
 		// As of git 2.7 it still tries to call the blank filter but required=false
 		// this problem should be gone in git 2.8 https://github.com/git/git/commit/1a8630d
-		scanner := bufio.NewScanner(errpty)
+		scanner := bufio.NewScanner(stderr)
 		for scanner.Scan() {
 			s := scanner.Text()
 
@@ -702,8 +698,7 @@ func CloneWithoutFilters(args []string) error {
 		return fmt.Errorf("Failed to start git clone: %v", err)
 	}
 
-	outtty.Close()
-	errtty.Close()
+	tty.Close()
 
 	err = cmd.Wait()
 	outputWait.Wait()

--- a/git/pty.go
+++ b/git/pty.go
@@ -37,7 +37,7 @@ func (t *Tty) Stdout() (io.ReadCloser, error) {
 }
 
 func (t *Tty) Stderr() (io.ReadCloser, error) {
-	if t.outpty != nil {
+	if t.errpty != nil {
 		return t.errpty, nil
 	} else {
 		return t.cmd.StderrPipe()

--- a/git/pty.go
+++ b/git/pty.go
@@ -19,7 +19,7 @@ type Tty struct {
 
 func (t *Tty) Close() {
 	if t.outtty != nil {
-		t.outpty.Close()
+		t.outtty.Close()
 		t.outtty = nil
 	}
 	if t.errtty != nil {

--- a/git/pty.go
+++ b/git/pty.go
@@ -1,0 +1,45 @@
+package git
+
+import (
+	"io"
+	"os"
+	"os/exec"
+)
+
+// Tty is a convenience wrapper to allow pseudo-TTYs on *nix systems, create with NewTty()
+// Do not use any of the struct members directly, call the Stderr() and Stdout() methods
+// Remember to call Close() when finished
+type Tty struct {
+	cmd    *exec.Cmd
+	outpty *os.File
+	outtty *os.File
+	errpty *os.File
+	errtty *os.File
+}
+
+func (t *Tty) Close() {
+	if t.outtty != nil {
+		t.outpty.Close()
+		t.outtty = nil
+	}
+	if t.errtty != nil {
+		t.errtty.Close()
+		t.errtty = nil
+	}
+}
+
+func (t *Tty) Stdout() (io.ReadCloser, error) {
+	if t.outpty != nil {
+		return t.outpty, nil
+	} else {
+		return t.cmd.StdoutPipe()
+	}
+}
+
+func (t *Tty) Stderr() (io.ReadCloser, error) {
+	if t.outpty != nil {
+		return t.errpty, nil
+	} else {
+		return t.cmd.StderrPipe()
+	}
+}

--- a/git/pty_nix.go
+++ b/git/pty_nix.go
@@ -1,0 +1,30 @@
+// +build !windows
+
+package git
+
+import (
+	"os/exec"
+	"syscall"
+
+	"github.com/github/git-lfs/vendor/_nuts/github.com/kr/pty"
+)
+
+// NewTty creates a pseudo-TTY for a command and modifies it appropriately so
+// the command thinks it's a real terminal
+func NewTty(cmd *exec.Cmd) *Tty {
+	tty := &Tty{}
+	tty.cmd = cmd
+	// Assign pty/tty so git thinks it's a real terminal
+	tty.outpty, tty.outtty, _ = pty.Open()
+	cmd.Stdin = tty.outtty
+	cmd.Stdout = tty.outtty
+	tty.errpty, tty.errtty, _ = pty.Open()
+	cmd.Stderr = tty.errtty
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setctty = true
+	cmd.SysProcAttr.Setsid = true
+
+	return tty
+}

--- a/git/pty_windows.go
+++ b/git/pty_windows.go
@@ -1,0 +1,12 @@
+package git
+
+import "os/exec"
+
+// NewTty creates a pseudo-TTY for a command and modifies it appropriately so
+// the command thinks it's a real terminal
+func NewTty(cmd *exec.Cmd) *Tty {
+	// Nothing special for Windows at this time
+	tty := &Tty{}
+	tty.cmd = cmd
+	return tty
+}

--- a/lfs/config_nix.go
+++ b/lfs/config_nix.go
@@ -1,4 +1,5 @@
 // +build !windows
+
 package lfs
 
 var netrcBasename = ".netrc"

--- a/test/test-credentials.sh
+++ b/test/test-credentials.sh
@@ -140,15 +140,25 @@ password=path"
 )
 end_test
 
+
+if [[ $(uname) == *"MINGW"* ]]; then
+  NETRCFILE="$HOME/_netrc"
+else
+  NETRCFILE="$HOME/.netrc"
+fi
+
+
 begin_test "credentials from netrc"
 (
   set -e
 
-  printf "machine localhost\nlogin netrcuser\npassword netrcpass\n" >> "$HOME/.netrc"
+  printf "machine localhost\nlogin netrcuser\npassword netrcpass\n" >> "$NETRCFILE"
   echo $HOME
   echo "GITSERVER $GITSERVER"
-  cat $HOME/.netrc
+  cat $NETRCFILE
 
+  # prevent prompts on Windows particularly
+  export SSH_ASKPASS=
 
   reponame="netrctest"
   setup_remote_repo "$reponame"
@@ -173,11 +183,13 @@ begin_test "credentials from netrc with bad password"
 (
   set -e
 
-  printf "machine localhost\nlogin netrcuser\npassword badpass\n" >> "$HOME/.netrc"
+  printf "machine localhost\nlogin netrcuser\npassword badpass\n" >> "$NETRCFILE"
   echo $HOME
   echo "GITSERVER $GITSERVER"
-  cat $HOME/.netrc
+  cat $NETRCFILE
 
+  # prevent prompts on Windows particularly
+  export SSH_ASKPASS=
 
   reponame="netrctest"
   setup_remote_repo "$reponame"

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -159,6 +159,12 @@ end_test
 
 begin_test "track absolute"
 (
+  # MinGW bash intercepts '/images' and passes 'C:/Program Files/Git/images' as arg!
+  if [[ $(uname) == *"MINGW"* ]]; then
+    echo "Skipping track absolute on Windows"
+    exit 0
+  fi
+
   set -e
 
   git init track-absolute


### PR DESCRIPTION
- Referencing kr/pty breaks Windows, hide in extra layer
- netrc was breaking build on Windows due to needing a blank line after +build directive
- git lfs clone wasn't working because of a doubly-assigned stdout
- integration tests weren't running because of a bash path issue
