### PR TITLE
extract common pre-push and push uploading code

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -43,13 +43,11 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if len(args) > 1 {
-		for _, r := range args[1:] {
-			ref, err := git.ResolveRef(r)
-			if err != nil {
-				Panic(err, "Invalid ref argument")
-			}
-			refs = append(refs, ref)
+		resolvedrefs, err := git.ResolveRefs(args[1:])
+		if err != nil {
+			Panic(err, "Invalid ref argument")
 		}
+		refs = resolvedrefs
 	} else {
 		ref, err := git.CurrentRef()
 		if err != nil {
@@ -122,7 +120,7 @@ func fetchRefToChan(ref *git.Ref, include, exclude []string) chan *lfs.WrappedPo
 		Panic(err, "Could not scan for Git LFS files")
 	}
 
-	metadata := lfs.NewTransferMetadata(ref.Name)
+	metadata := lfs.NewTransferMetadata(ref.NameOnRemote(lfs.Config.CurrentRemote))
 	go fetchAndReportToChan(pointers, include, exclude, metadata, c)
 
 	return c
@@ -134,7 +132,7 @@ func fetchRef(ref *git.Ref, include, exclude []string) bool {
 	if err != nil {
 		Panic(err, "Could not scan for Git LFS files")
 	}
-	metadata := lfs.NewTransferMetadata(ref.Name)
+	metadata := lfs.NewTransferMetadata(ref.NameOnRemote(lfs.Config.CurrentRemote))
 	return fetchPointers(pointers, include, exclude, metadata)
 }
 
@@ -145,7 +143,7 @@ func fetchPreviousVersions(ref *git.Ref, since time.Time, include, exclude []str
 	if err != nil {
 		Panic(err, "Could not scan for Git LFS previous versions")
 	}
-	metadata := lfs.NewTransferMetadata(ref.Name)
+	metadata := lfs.NewTransferMetadata(ref.NameOnRemote(lfs.Config.CurrentRemote))
 	return fetchPointers(pointers, include, exclude, metadata)
 }
 

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -77,7 +77,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored
 		for _, ref := range refs {
 			Print("Fetching %v", ref.Name)
-			s := fetchRef(ref.Sha, includePaths, excludePaths)
+			s := fetchRef(ref, includePaths, excludePaths)
 			success = success && s
 		}
 
@@ -115,35 +115,38 @@ func pointersToFetchForRef(ref string) ([]*lfs.WrappedPointer, error) {
 	return lfs.ScanRefs(ref, "", opts)
 }
 
-func fetchRefToChan(ref string, include, exclude []string) chan *lfs.WrappedPointer {
+func fetchRefToChan(ref *git.Ref, include, exclude []string) chan *lfs.WrappedPointer {
 	c := make(chan *lfs.WrappedPointer)
-	pointers, err := pointersToFetchForRef(ref)
+	pointers, err := pointersToFetchForRef(ref.Sha)
 	if err != nil {
 		Panic(err, "Could not scan for Git LFS files")
 	}
 
-	go fetchAndReportToChan(pointers, include, exclude, c)
+	metadata := lfs.NewTransferMetadata(ref.Name)
+	go fetchAndReportToChan(pointers, include, exclude, metadata, c)
 
 	return c
 }
 
 // Fetch all binaries for a given ref (that we don't have already)
-func fetchRef(ref string, include, exclude []string) bool {
-	pointers, err := pointersToFetchForRef(ref)
+func fetchRef(ref *git.Ref, include, exclude []string) bool {
+	pointers, err := pointersToFetchForRef(ref.Sha)
 	if err != nil {
 		Panic(err, "Could not scan for Git LFS files")
 	}
-	return fetchPointers(pointers, include, exclude)
+	metadata := lfs.NewTransferMetadata(ref.Name)
+	return fetchPointers(pointers, include, exclude, metadata)
 }
 
 // Fetch all previous versions of objects from since to ref (not including final state at ref)
 // So this will fetch all the '-' sides of the diff from since to ref
-func fetchPreviousVersions(ref string, since time.Time, include, exclude []string) bool {
-	pointers, err := lfs.ScanPreviousVersions(ref, since)
+func fetchPreviousVersions(ref *git.Ref, since time.Time, include, exclude []string) bool {
+	pointers, err := lfs.ScanPreviousVersions(ref.Sha, since)
 	if err != nil {
 		Panic(err, "Could not scan for Git LFS previous versions")
 	}
-	return fetchPointers(pointers, include, exclude)
+	metadata := lfs.NewTransferMetadata(ref.Name)
+	return fetchPointers(pointers, include, exclude, metadata)
 }
 
 // Fetch recent objects based on config
@@ -177,7 +180,7 @@ func fetchRecent(alreadyFetchedRefs []*git.Ref, include, exclude []string) bool 
 			} else {
 				uniqueRefShas[ref.Sha] = ref.Name
 				Print("Fetching %v", ref.Name)
-				k := fetchRef(ref.Sha, include, exclude)
+				k := fetchRef(ref, include, exclude)
 				ok = ok && k
 			}
 		}
@@ -193,7 +196,8 @@ func fetchRecent(alreadyFetchedRefs []*git.Ref, include, exclude []string) bool 
 			}
 			Print("Fetching changes within %v days of %v", fetchconf.FetchRecentCommitsDays, refName)
 			commitsSince := summ.CommitDate.AddDate(0, 0, -fetchconf.FetchRecentCommitsDays)
-			k := fetchPreviousVersions(commit, commitsSince, include, exclude)
+			commitRef := &git.Ref{Name: refName, Sha: commit}
+			k := fetchPreviousVersions(commitRef, commitsSince, include, exclude)
 			ok = ok && k
 		}
 
@@ -204,7 +208,7 @@ func fetchRecent(alreadyFetchedRefs []*git.Ref, include, exclude []string) bool 
 func fetchAll() bool {
 	pointers := scanAll()
 	Print("Fetching objects...")
-	return fetchPointers(pointers, nil, nil)
+	return fetchPointers(pointers, nil, nil, nil)
 }
 
 func scanAll() []*lfs.WrappedPointer {
@@ -235,18 +239,19 @@ func scanAll() []*lfs.WrappedPointer {
 	return pointers
 }
 
-func fetchPointers(pointers []*lfs.WrappedPointer, include, exclude []string) bool {
-	return fetchAndReportToChan(pointers, include, exclude, nil)
+func fetchPointers(pointers []*lfs.WrappedPointer, include, exclude []string, metadata *lfs.TransferMetadata) bool {
+	return fetchAndReportToChan(pointers, include, exclude, metadata, nil)
 }
 
 // Fetch and report completion of each OID to a channel (optional, pass nil to skip)
 // Returns true if all completed with no errors, false if errors were written to stderr/log
-func fetchAndReportToChan(pointers []*lfs.WrappedPointer, include, exclude []string, out chan<- *lfs.WrappedPointer) bool {
+func fetchAndReportToChan(pointers []*lfs.WrappedPointer, include, exclude []string, metadata *lfs.TransferMetadata, out chan<- *lfs.WrappedPointer) bool {
+
 	totalSize := int64(0)
 	for _, p := range pointers {
 		totalSize += p.Size
 	}
-	q := lfs.NewDownloadQueue(len(pointers), totalSize, false)
+	q := lfs.NewDownloadQueue(len(pointers), totalSize, false, metadata)
 
 	if out != nil {
 		dlwatch := q.Watch()

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -71,35 +71,41 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 			continue
 		}
 
-		left, right := decodeRefs(line)
+		left, right, destRef := decodeRefs(line)
 		if left == prePushDeleteBranch {
 			continue
 		}
 
 		pointers, err := lfs.ScanRefs(left, right, scanOpt)
+
 		if err != nil {
 			Panic(err, "Error scanning for Git LFS files")
 		}
 
-		cli.Upload(pointers)
+		metadata := lfs.NewTransferMetadata(destRef)
+		cli.Upload(metadata, pointers)
 	}
 }
 
-// decodeRefs pulls the sha1s out of the line read from the pre-push
+// decodeRefs pulls the sha1s and destination ref out of the line read from the pre-push
 // hook's stdin.
-func decodeRefs(input string) (string, string) {
+func decodeRefs(input string) (string, string, string) {
 	refs := strings.Split(strings.TrimSpace(input), " ")
-	var left, right string
+	var left, right, destRef string
 
 	if len(refs) > 1 {
 		left = refs[1]
+	}
+
+	if len(refs) > 2 {
+		destRef = refs[2]
 	}
 
 	if len(refs) > 3 {
 		right = "^" + refs[3]
 	}
 
-	return left, right
+	return left, right, destRef
 }
 
 func init() {

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -40,15 +40,13 @@ func pullCommand(cmd *cobra.Command, args []string) {
 }
 
 func pull(includePaths, excludePaths []string) {
-
 	ref, err := git.CurrentRef()
 	if err != nil {
 		Panic(err, "Could not pull")
 	}
 
-	c := fetchRefToChan(ref.Sha, includePaths, excludePaths)
+	c := fetchRefToChan(ref, includePaths, excludePaths)
 	checkoutFromFetchChan(includePaths, excludePaths, c)
-
 }
 
 func init() {

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -36,7 +36,7 @@ func uploadsBetweenRefs(cli *clientContext, left string, right string) {
 		Panic(err, "Error scanning for Git LFS files")
 	}
 
-	cli.Upload(pointers)
+	cli.Upload(nil, pointers)
 }
 
 func uploadsBetweenRefAndRemote(cli *clientContext, refs []string) {
@@ -70,7 +70,7 @@ func uploadsBetweenRefAndRemote(cli *clientContext, refs []string) {
 			Panic(err, "Error scanning for Git LFS files in the %q ref", ref)
 		}
 
-		cli.Upload(pointers)
+		cli.Upload(nil, pointers)
 	}
 }
 
@@ -81,7 +81,7 @@ func uploadsWithObjectIDs(cli *clientContext, oids []string) {
 		pointers[idx] = &lfs.WrappedPointer{Pointer: &lfs.Pointer{Oid: oid}}
 	}
 
-	cli.Upload(pointers)
+	cli.Upload(nil, pointers)
 }
 
 // pushCommand pushes local objects to a Git LFS server.  It takes two
@@ -125,7 +125,7 @@ func pushCommand(cmd *cobra.Command, args []string) {
 			return
 		}
 
-		left, right := decodeRefs(string(refsData))
+		left, right, _ := decodeRefs(string(refsData))
 		if left == pushDeleteBranch {
 			return
 		}

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -63,10 +63,7 @@ func uploadsBetweenRefAndRemote(cli *clientContext, refnames []string) {
 			Panic(err, "Error scanning for Git LFS files in the %q ref", ref.Name)
 		}
 
-		var metadata *lfs.TransferMetadata
-		if ref.Type == git.RefTypeLocalBranch && git.RemoteForBranch(ref.Name) == cli.RemoteName {
-			metadata = lfs.NewTransferMetadata(git.RemoteBranchForLocalBranch(ref.Name))
-		}
+		metadata := lfs.NewTransferMetadata(ref.NameOnRemote(cli.RemoteName))
 		cli.Upload(metadata, pointers)
 	}
 }

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -84,8 +84,8 @@ func (c *clientContext) filterUploadedObjects(pointers []*lfs.WrappedPointer) []
 }
 
 func (c *clientContext) filterServerObjects(pointers []*lfs.WrappedPointer) {
-	var missingLocalObjects []*lfs.WrappedPointer
-	var missingSize int64
+	missingLocalObjects := make([]*lfs.WrappedPointer, 0, len(pointers))
+	missingSize := int64(0)
 	for _, pointer := range pointers {
 		if !lfs.ObjectExistsOfSize(pointer.Oid, pointer.Size) {
 			// We think we need to push this but we don't have it

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -1,0 +1,116 @@
+package commands
+
+import (
+	"os"
+
+	"github.com/github/git-lfs/lfs"
+)
+
+func scanObjectsLeftToRight(config *lfs.Configuration, left, right string, scanmode lfs.ScanningMode) ([]*lfs.WrappedPointer, error) {
+	scanOpt := lfs.NewScanRefsOptions()
+	scanOpt.ScanMode = scanmode
+	scanOpt.RemoteName = config.CurrentRemote
+
+	pointers, err := lfs.ScanRefs(left, right, scanOpt)
+	if err != nil {
+		return pointers, err
+	}
+
+	return filterUploadableObjects(config, pointers), nil
+}
+
+func uploadObjects(config *lfs.Configuration, pointers []*lfs.WrappedPointer, dryRun bool) {
+	if dryRun {
+		for _, pointer := range pointers {
+			Print("push %s => %s", pointer.Oid, pointer.Name)
+			config.Uploaded(pointer.Oid)
+		}
+		return
+	}
+
+	totalSize := int64(0)
+	for _, p := range pointers {
+		totalSize += p.Size
+	}
+
+	uploadQueue := lfs.NewUploadQueue(len(pointers), totalSize, false)
+	for _, pointer := range pointers {
+		u, err := lfs.NewUploadable(pointer.Oid, pointer.Name)
+		if err != nil {
+			if lfs.IsCleanPointerError(err) {
+				Exit(prePushMissingErrMsg, pointer.Name, lfs.ErrorGetContext(err, "pointer").(*lfs.Pointer).Oid)
+			} else {
+				ExitWithError(err)
+			}
+		}
+
+		uploadQueue.Add(u)
+		config.Uploaded(pointer.Oid)
+	}
+
+	uploadQueue.Wait()
+	for _, err := range uploadQueue.Errors() {
+		if Debugging || lfs.IsFatalError(err) {
+			LoggedError(err, err.Error())
+		} else {
+			if inner := lfs.GetInnerError(err); inner != nil {
+				Error(inner.Error())
+			}
+			Error(err.Error())
+		}
+	}
+
+	if len(uploadQueue.Errors()) > 0 {
+		os.Exit(2)
+	}
+}
+
+func filterUploadableObjects(config *lfs.Configuration, pointers []*lfs.WrappedPointer) []*lfs.WrappedPointer {
+	uploadable := filterUploadedObjects(config, pointers)
+	filterServerObjects(config, uploadable)
+	return filterUploadedObjects(config, uploadable)
+}
+
+func filterUploadedObjects(config *lfs.Configuration, pointers []*lfs.WrappedPointer) []*lfs.WrappedPointer {
+	filtered := make([]*lfs.WrappedPointer, 0, len(pointers))
+	for _, pointer := range pointers {
+		if !config.HasUploaded(pointer.Oid) {
+			filtered = append(filtered, pointer)
+		}
+	}
+
+	return filtered
+}
+
+func filterServerObjects(config *lfs.Configuration, pointers []*lfs.WrappedPointer) {
+	var missingLocalObjects []*lfs.WrappedPointer
+	var missingSize int64
+	for _, pointer := range pointers {
+		if !lfs.ObjectExistsOfSize(pointer.Oid, pointer.Size) {
+			// We think we need to push this but we don't have it
+			// Store for server checking later
+			missingLocalObjects = append(missingLocalObjects, pointer)
+			missingSize += pointer.Size
+		}
+	}
+	if len(missingLocalObjects) == 0 {
+		return
+	}
+
+	checkQueue := lfs.NewDownloadCheckQueue(len(missingLocalObjects), missingSize, true)
+	for _, p := range missingLocalObjects {
+		checkQueue.Add(lfs.NewDownloadCheckable(p))
+	}
+	// this channel is filled with oids for which Check() succeeded & Transfer() was called
+	transferc := checkQueue.Watch()
+	done := make(chan int)
+	go func() {
+		for oid := range transferc {
+			config.Uploaded(oid)
+		}
+		done <- 1
+	}()
+	// Currently this is needed to flush the batch but is not enough to sync transferc completely
+	checkQueue.Wait()
+	<-done
+}

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -18,7 +18,7 @@ func newClient() *clientContext {
 	}
 }
 
-func (c *clientContext) Upload(unfilteredPointers []*lfs.WrappedPointer) {
+func (c *clientContext) Upload(metadata *lfs.TransferMetadata, unfilteredPointers []*lfs.WrappedPointer) {
 	pointers := c.filter(unfilteredPointers)
 
 	if c.DryRun {
@@ -34,7 +34,7 @@ func (c *clientContext) Upload(unfilteredPointers []*lfs.WrappedPointer) {
 		totalSize += p.Size
 	}
 
-	uploadQueue := lfs.NewUploadQueue(len(pointers), totalSize, false)
+	uploadQueue := lfs.NewUploadQueue(len(pointers), totalSize, c.DryRun, metadata)
 	for _, pointer := range pointers {
 		u, err := lfs.NewUploadable(pointer.Oid, pointer.Name)
 		if err != nil {

--- a/docs/api/http-v1.2-batch-request-schema.json
+++ b/docs/api/http-v1.2-batch-request-schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Git LFS HTTPS Batch API v1.2 Request",
+  "type": "object",
+  "properties": {
+    "operation": {
+      "type": "string"
+    },
+    "objects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "oid": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          }
+        },
+        "required": ["oid", "size"],
+        "additionalProperties": false
+      }
+    },
+    "meta": {
+      "type": "object",
+      "properties": {
+        "ref": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  },
+  "required": ["objects", "operation"],
+  "additionalProperties": false
+}

--- a/docs/api/http-v1.2-batch.md
+++ b/docs/api/http-v1.2-batch.md
@@ -1,0 +1,286 @@
+# Git LFS v1 Batch API
+
+The Git LFS Batch API works like the [original v1 API][v1], but uses a single
+endpoint that accepts multiple OIDs. All requests should have the following:
+
+    Accept: application/vnd.git-lfs+json
+    Content-Type: application/vnd.git-lfs+json
+
+[v1]: ./http-v1-original.md
+
+This is a newer API introduced in Git LFS v0.5.2, and made the default in
+Git LFS v0.6.0. The client automatically detects if the server does not
+implement the API yet, and falls back to the legacy API. You can toggle support
+manually through the Git config:
+
+    # enable batch support
+    $ git config --unset lfs.batch
+
+    # disable batch support
+    $ git config lfs.batch false
+
+## Authentication
+
+The Batch API authenticates the same as the original v1 API with one exception:
+The client will attempt to make requests without any authentication. This
+slight change allows anonymous access to public Git LFS objects. The client
+stores the result of this in the `lfs.<url>.access` config setting, where <url>
+refers to the endpoint's URL.
+
+## POST /objects/batch
+
+This request retrieves the metadata for a batch of objects, given a JSON body
+containing an object with an array of objects with the oid and size of each
+object. While the API endpoint can support requests to download AND upload
+objects in one batch, the client will usually stick to one or the other.
+
+When downloading objects through a command such as `git lfs fetch`, the client
+will initially skip authentication if it doesn't know the access level of the
+repository.
+
+* If `lfs.<url>.access` is not set, make an unauthenticated request.
+  1. If it returns 401, set `lfs.<url>.access` to `private`.
+* If `lfs.<url>.access` is `private`, always send authentication. Ask the user if
+authentication information is not readily available.
+
+When uploading objects through `git lfs push`, Git LFS will always send
+authentication info, regardless of how `lfs.<url>.access` is configured.
+
+```
+> POST https://git-lfs-server.com/objects/batch HTTP/1.1
+> Accept: application/vnd.git-lfs+json
+> Content-Type: application/vnd.git-lfs+json
+> Authorization: Basic ... (if authentication is needed)
+>
+> {
+>   "operation": "upload",
+>   "objects": [
+>     {
+>       "oid": "1111111",
+>       "size": 123
+>     }
+>   ],
+>   "meta": {
+>     "ref": "refs/heads/master"
+>   }
+> }
+>
+< HTTP/1.1 200 Ok
+< Content-Type: application/vnd.git-lfs+json
+<
+< {
+<   "objects": [
+<     {
+<       "oid": "1111111",
+<       "size": 123,
+<       "actions": {
+<         "upload": {
+<          "href": "https://some-upload.com",
+<           "header": {
+<             "Key": "value"
+<           }
+<         },
+<         "verify": {
+<           "href": "https://some-callback.com",
+<           "header": {
+<             "Key": "value"
+<           }
+<         }
+<       }
+>     }
+<   ]
+< }
+```
+
+The response will be an object containing an array of objects with one of
+multiple actions, each with an `href` property and an optional `header`
+property. The requests and responses need to validate with the included JSON
+schemas:
+
+* [Batch request](./http-v1.2-batch-request-schema.json)
+* [Batch response](./http-v1-batch-response-schema.json)
+
+Here are the valid actions:
+
+* `upload` - This relation describes how to upload the object.  Expect this with
+when the object has not been previously uploaded.
+* `verify` - The server can specify a URL for the client to hit after
+successfully uploading an object.  This is an optional relation for the case that
+the server has not verified the object.
+* `download` - This relation describes how to download the object content.  This
+only appears if an object has been previously uploaded.
+
+An action can optionally include an `expires_at`, which is an ISO 8601 formatted
+timestamp for when the given action expires (usually due to a temporary token).
+
+```json
+{
+  "objects": [
+    {
+      "oid": "1111111",
+      "size": 123,
+      "actions": {
+        "download": {
+          "href": "https://some-download.com?token=abc123",
+          "expires_at": "2015-07-27T21:15:01Z"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Successful Responses
+
+The Batch API should always return 200 unless there's an authorization problem
+between the requesting user and the repository.
+
+Here is a response to download a single object:
+
+```
+< HTTP/1.1 200 Ok
+< Content-Type: application/vnd.git-lfs+json
+<
+< {
+<   "objects": [
+<     {
+<       "oid": "1111111",
+<       "size": 123,
+<       "actions": {
+<         "download": {
+<           "href": "https://some-download.com"
+<         }
+<       }
+>     }
+<   ]
+< }
+```
+
+It is possible for servers to respond with a 200, and just annotate specific
+objects that failed through an `error` property. Here's an example request to
+download two objects, with one object that doesn't exist:
+
+```
+< HTTP/1.1 200 Ok
+< Content-Type: application/vnd.git-lfs+json
+<
+< {
+<   "objects": [
+<     {
+<       "oid": "1111111",
+<       "size": 123,
+<       "actions": {
+<         "download": {
+<           "href": "https://some-download.com"
+<         }
+<       }
+>     },
+<     {
+<       "oid": "2222222",
+<       "size": 123,
+<       "error": {
+<         "code": 404,
+<         "message": "Object does not exist on the server"
+<       }
+>     }
+<   ]
+< }
+```
+
+Object error codes should match HTTP status codes where possible:
+
+* 404 - The object does not exist on the server.
+* 410 - The object was removed by the owner.
+* 422 - Validation error.
+
+Validation errors can only occur on `upload` requests. Servers must verify
+that OIDs are valid SHA-256 strings, and that sizes are positive integers.
+Servers may also set an upper bound for the allowed object size too. Here's a
+response showing one uploadable object, and one with a validation error:
+
+```
+< HTTP/1.1 200 Ok
+< Content-Type: application/vnd.git-lfs+json
+<
+< {
+<   "objects": [
+<     {
+<       "oid": "1111111",
+<       "size": 123,
+<       "actions": {
+<         "upload": {
+<           "href": "https://some-upload.com"
+<         }
+<       }
+>     },
+<     {
+<       "oid": "2222222",
+<       "size": -1,
+<       "error": {
+<         "code": 422,
+<         "message": "Invalid object size"
+<       }
+>     }
+<   ]
+< }
+```
+
+### Response Errors
+
+Servers can respond with the following HTTP status codes:
+
+* 401 - The authentication credentials are needed, but were not sent.
+* 403 - The user has **read**, but not **write** access. Only applicable when
+the `operation` in the request is "upload."
+* 404 - The repository does not exist for the user.
+* 422 - Validation error with one or more of the objects in the request. This
+  means that _none_ of the requested objects to upload are valid.
+
+Responses will not have the `objects` property. They must have a `message`
+property, and should have `request_id` and `documentation_url` properties to
+help users.
+
+```
+< HTTP/1.1 403 Forbidden
+< Content-Type: application/vnd.git-lfs+json
+<
+< {
+<   "message": "Invalid credentials.",
+<   "documentation_url": "https://git-lfs-server.com/docs/errors",
+<   "request_id": "123"
+< }
+```
+
+401 responses should include a `LFS-Authenticate` header to tell the client what
+form of authentication it requires. This is a placeholder in case the client
+adds support for something other than Basic Authentication. This is meant to
+mirror the standard `WWW-Authenticate` header. A new header is used so it
+does not trigger the password prompt in browsers.
+
+```
+< HTTP/1.1 401 Unauthorized
+< Content-Type: application/vnd.git-lfs+json
+< LFS-Authenticate: Basic realm="Git LFS"
+<
+< {
+<   "message": "Credentials needed.",
+<   "documentation_url": "https://git-lfs-server.com/docs/errors",
+<   "request_id": "123"
+< }
+```
+
+The following status codes can optionally be returned from the API, depending on
+the server implementation.
+
+* 406 - The Accept header needs to be `application/vnd.git-lfs+json`.
+* 429 - The user has hit a rate limit with the server.  Though the API does not
+specify any rate limits, implementors are encouraged to set some for
+availability reasons.
+* 501 - The server has not implemented the current method.  Reserved for future
+use.
+* 509 - Returned if the bandwidth limit for the user or repository has been
+exceeded.  The API does not specify any bandwidth limit, but implementors may
+track usage.
+
+Some server errors may trigger the client to retry requests, such as 500, 502,
+503, and 504.

--- a/git/git.go
+++ b/git/git.go
@@ -142,7 +142,6 @@ func RemoteBranchForLocalBranch(localBranch string) string {
 	} else {
 		return localBranch
 	}
-
 }
 
 func RemoteList() ([]string, error) {

--- a/git/git.go
+++ b/git/git.go
@@ -40,6 +40,22 @@ type Ref struct {
 	Sha  string
 }
 
+func (r *Ref) NameOnRemote(remotename string) string {
+	if r.Type != RefTypeLocalBranch {
+		return r.Name
+	}
+
+	if len(remotename) == 0 {
+		return r.Name
+	}
+
+	if RemoteForBranch(r.Name) != remotename {
+		return r.Name
+	}
+
+	return RemoteBranchForLocalBranch(r.Name)
+}
+
 // Some top level information about a commit (only first line of message)
 type CommitSummary struct {
 	Sha            string
@@ -78,6 +94,19 @@ func ResolveRef(ref string) (*Ref, error) {
 	fullref := &Ref{Sha: lines[0]}
 	fullref.Type, fullref.Name = ParseRefToTypeAndName(lines[1])
 	return fullref, nil
+}
+
+func ResolveRefs(refnames []string) ([]*Ref, error) {
+	refs := make([]*Ref, len(refnames))
+	for i, name := range refnames {
+		ref, err := ResolveRef(name)
+		if err != nil {
+			return refs, err
+		}
+
+		refs[i] = ref
+	}
+	return refs, nil
 }
 
 func CurrentRef() (*Ref, error) {

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -47,7 +47,6 @@ type Configuration struct {
 	httpClient            *HttpClient
 	redirectingHttpClient *http.Client
 	ntlmSession           ntlm.ClientSession
-	uploadedOids          StringSet
 	envVars               map[string]string
 	isTracingHttp         bool
 	isDebuggingHttp       bool
@@ -68,7 +67,6 @@ func NewConfig() *Configuration {
 	c := &Configuration{
 		CurrentRemote: defaultRemote,
 		envVars:       make(map[string]string),
-		uploadedOids:  NewStringSet(),
 	}
 	c.isTracingHttp = c.GetenvBool("GIT_CURL_VERBOSE", false)
 	c.isDebuggingHttp = c.GetenvBool("LFS_DEBUG_HTTP", false)
@@ -110,14 +108,6 @@ func (c *Configuration) GetenvBool(key string, def bool) bool {
 		return def
 	}
 	return b
-}
-
-func (c *Configuration) HasUploaded(oid string) bool {
-	return c.uploadedOids.Contains(oid)
-}
-
-func (c *Configuration) Uploaded(oid string) {
-	c.uploadedOids.Add(oid)
 }
 
 // GitRemoteUrl returns the git clone/push url for a given remote (blank if not found)

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -47,6 +47,7 @@ type Configuration struct {
 	httpClient            *HttpClient
 	redirectingHttpClient *http.Client
 	ntlmSession           ntlm.ClientSession
+	uploadedOids          StringSet
 	envVars               map[string]string
 	isTracingHttp         bool
 	isDebuggingHttp       bool
@@ -67,6 +68,7 @@ func NewConfig() *Configuration {
 	c := &Configuration{
 		CurrentRemote: defaultRemote,
 		envVars:       make(map[string]string),
+		uploadedOids:  NewStringSet(),
 	}
 	c.isTracingHttp = c.GetenvBool("GIT_CURL_VERBOSE", false)
 	c.isDebuggingHttp = c.GetenvBool("LFS_DEBUG_HTTP", false)
@@ -108,6 +110,14 @@ func (c *Configuration) GetenvBool(key string, def bool) bool {
 		return def
 	}
 	return b
+}
+
+func (c *Configuration) HasUploaded(oid string) bool {
+	return c.uploadedOids.Contains(oid)
+}
+
+func (c *Configuration) Uploaded(oid string) {
+	c.uploadedOids.Add(oid)
 }
 
 // GitRemoteUrl returns the git clone/push url for a given remote (blank if not found)

--- a/lfs/download_queue.go
+++ b/lfs/download_queue.go
@@ -66,8 +66,9 @@ func (d *Downloadable) Transfer(cb CopyCallback) error {
 }
 
 // NewDownloadQueue builds a DownloadQueue, allowing `workers` concurrent downloads.
-func NewDownloadQueue(files int, size int64, dryRun bool) *TransferQueue {
+func NewDownloadQueue(files int, size int64, dryRun bool, metadata *TransferMetadata) *TransferQueue {
 	q := newTransferQueue(files, size, dryRun)
 	q.transferKind = "download"
+	q.metadata = metadata
 	return q
 }

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -71,9 +71,10 @@ func (u *Uploadable) SetObject(o *ObjectResource) {
 }
 
 // NewUploadQueue builds an UploadQueue, allowing `workers` concurrent uploads.
-func NewUploadQueue(files int, size int64, dryRun bool) *TransferQueue {
+func NewUploadQueue(files int, size int64, dryRun bool, metadata *TransferMetadata) *TransferQueue {
 	q := newTransferQueue(files, size, dryRun)
 	q.transferKind = "upload"
+	q.metadata = metadata
 	return q
 }
 

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -154,8 +154,10 @@ func buildTestData() (oidsExist, oidsMissing []TestObject, err error) {
 	}
 	outputs := repo.AddCommits([]*test.CommitInput{&commit})
 
+	// create metadata
+	metadata := lfs.NewTransferMetadata("refs/heads/master")
 	// now upload
-	uploadQueue := lfs.NewUploadQueue(len(oidsExist), totalSize, false)
+	uploadQueue := lfs.NewUploadQueue(len(oidsExist), totalSize, false, metadata)
 	for _, f := range outputs[0].Files {
 		oidsExist = append(oidsExist, TestObject{Oid: f.Oid, Size: f.Size})
 
@@ -248,7 +250,8 @@ func callBatchApi(op string, objs []TestObject) ([]*lfs.ObjectResource, error) {
 	for _, o := range objs {
 		apiobjs = append(apiobjs, &lfs.ObjectResource{Oid: o.Oid, Size: o.Size})
 	}
-	return lfs.Batch(apiobjs, op)
+	metadata := lfs.NewTransferMetadata("refs/heads/master")
+	return lfs.Batch(apiobjs, op, metadata)
 }
 
 // Combine 2 slices into one by "randomly" interleaving

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -333,29 +333,30 @@ begin_test "push object id(s)"
 (
   set -e
 
-  reponame="$(basename "$0" ".sh")"
+  reponame="$(basename "$0" ".sh")-object-ids"
   setup_remote_repo "$reponame"
-  clone_repo "$reponame" repo2
+  clone_repo "$reponame" repo-object-ids
 
   git lfs track "*.dat"
-  echo "push a" > a.dat
+  echo "push object a" > a.dat
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
   git lfs push --object-id origin \
-    4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
+    c1a338929270651d8fb132411d725518353650bfc9ac991991dd4a8c2139d97a \
     2>&1 | tee push.log
-  grep "(0 of 1 files, 1 skipped)" push.log
+  grep "(1 of 1 files)" push.log
 
-  echo "push b" > b.dat
+  echo "push object b" > b.dat
   git add b.dat
   git commit -m "add b.dat"
+  git show
 
   git lfs push --object-id origin \
-    4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
-    82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 \
+    c1a338929270651d8fb132411d725518353650bfc9ac991991dd4a8c2139d97a \
+    7098284b1b16d67681313247191c217c5f185acaa40b5f00731574d70d75f2e1 \
     2>&1 | tee push.log
-  grep "(0 of 2 files, 2 skipped)" push.log
+  grep "(1 of 1 files)" push.log
 )
 end_test
 


### PR DESCRIPTION
I have some issues with this code. But at least now pre-push and push both call shared functions to upload objects.

From https://github.com/github/git-lfs/pull/1040#discussion_r55821731:

> Now that filteredPointers is used in multiple places, maybe promote it to the lfs package for re-use rather than keep it in the pre-push source file?

This PR is a start towards shared functions for pre-push and push commands. While it seems to work, there are a number of things I'd like to change:

* I don't like using `lfs.Configuration` like this. I wanted something more than a `StringSet` to share between multiple ref uploads in the same command.
* Filtering could probably be cleaned up.

EDIT: Fixed this in a later commit ^^^

Instead of promoting to the lfs package, what if we started on a high level client like we discussed in https://github.com/github/git-lfs/issues/779? I am a little concerned that my yak shave trying to get #969 merged is going on too long though :)

I don't think the commands should be assembling upload queue objects or anything. I think they should just be responsible for turning the CLI or STDIN arguments into code like this:

```go
c := client.New("origin")
c.DryRun = false

for _, ref := range args[1:] {
  c.Upload(scanObjectsLeftToRight(ref, "", lfs.ScanRefsMode))
}

errs := c.Errors()
// error handling, os.Exit(2), etc
```