### PR TITLE
Added Linux Mint distro to packagecloud push, issue #1074.

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -90,5 +90,5 @@ package_files.each do |full_path|
 
   next unless os
 
-  puts "[#{os}](https://packagecloud.io/github/git-lfs/packages/#{distro}/#{File.basename(full_path)}/download)"
+  puts "[#{os}](https://packagecloud.io/#{packagecloud_user}/git-lfs/packages/#{distro}/#{File.basename(full_path)}/download)"
 end

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -38,6 +38,9 @@ $distro_name_map = {
   ),
   "debian/8" => %w(
     debian/jessie
+    linuxmint/rebecca
+    linuxmint/rafaela
+    linuxmint/rosa
     ubuntu/trusty
     ubuntu/vivid
     ubuntu/wily


### PR DESCRIPTION
I haven't got my deb build running yet to be able to test this via push to my packagecloud.  Can build OK but the dpkg build complains about imports.

So I'm not sure this is correct, but someone with a working build would be able to test it, perhaps for the next release.