### PR TITLE
Fix an alignment typo in Git LFS batch API v1 documentation

### DIFF
--- a/docs/api/http-v1-batch.md
+++ b/docs/api/http-v1-batch.md
@@ -72,7 +72,7 @@ authentication info, regardless of how `lfs.<url>.access` is configured.
 <       "size": 123,
 <       "actions": {
 <         "upload": {
-<          "href": "https://some-upload.com",
+<           "href": "https://some-upload.com",
 <           "header": {
 <             "Key": "value"
 <           }


### PR DESCRIPTION
This JSON key is only indented one space, but should be indented two spaces to align with the rest of the structure.