### PR TITLE
push with ambiguous branch fails

### DIFF
--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -2,6 +2,29 @@
 
 . "test/testlib.sh"
 
+begin_test "push with filename / branch mismatch"
+(
+  set -e
+  reponame="$(basename "$0" ".sh")-ambiguous-branch-name"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" repo
+
+  git checkout -b ambiguous-branch-name
+  git lfs track "*.dat"
+  echo "push me" > push.dat
+  echo "ambiguous-branch-name" > ambiguous-branch-name
+  git add .gitattributes push.dat ambiguous-branch-name
+  git commit -m "ambiguous-branch-name"
+
+  git lfs push --dry-run origin ambiguous-branch-name 2>&1 | tee push.log
+  echo "actual git command:"
+  git rev-list --objects ambiguous-branch-name --not --remotes=origin
+  exit 1
+)
+end_test
+
+exit 0
+
 begin_test "push"
 (
   set -e


### PR DESCRIPTION
The scanner code doesn't handle git errors at all. I would expect this `git lfs push` command to fail, but it just returns successfully with no output. The problem is that the rev-list call is erroring, and git lfs is just rolling with it.

```
    + git lfs push --dry-run origin ambiguous-branch-name
    + tee push.log
    + echo 'actual git command:'
    + git rev-list --objects ambiguous-branch-name --not --remotes=origin
    fatal: ambiguous argument 'ambiguous-branch-name': both revision and filename
    Use '--' to separate paths from revisions, like this:
    'git <command> [<revision>...] -- [<file>...]'
```