### PR TITLE
Move TTY wrapper to subprocess package

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -628,7 +628,7 @@ func CloneWithoutFilters(args []string) error {
 	cmd := subprocess.ExecCommand("git", cmdargs...)
 
 	// Assign pty/tty so git thinks it's a real terminal
-	tty := NewTty(cmd)
+	tty := subprocess.NewTty(cmd)
 	stdout, err := tty.Stdout()
 	if err != nil {
 		return fmt.Errorf("Failed to get stdout: %v", err)

--- a/subprocess/pty.go
+++ b/subprocess/pty.go
@@ -1,4 +1,4 @@
-package git
+package subprocess
 
 import (
 	"io"

--- a/subprocess/pty_nix.go
+++ b/subprocess/pty_nix.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package git
+package subprocess
 
 import (
 	"os/exec"

--- a/subprocess/pty_windows.go
+++ b/subprocess/pty_windows.go
@@ -1,4 +1,4 @@
-package git
+package subprocess
 
 import "os/exec"
 


### PR DESCRIPTION
TTY abstraction and subprocess came out of different PRs, makes sense to move TTY into subprocess now they're both in master.