### PR TITLE
Fix smudge/clean on files that begin with a dash

### DIFF
--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -21,8 +21,8 @@ var (
 	filters = &Attribute{
 		Section: "filter.lfs",
 		Properties: map[string]string{
-			"clean":    "git-lfs clean %f",
-			"smudge":   "git-lfs smudge %f",
+			"clean":    "git-lfs clean -- %f",
+			"smudge":   "git-lfs smudge -- %f",
 			"required": "true",
 		},
 	}
@@ -30,8 +30,8 @@ var (
 	passFilters = &Attribute{
 		Section: "filter.lfs",
 		Properties: map[string]string{
-			"clean":    "git-lfs clean %f",
-			"smudge":   "git-lfs smudge --skip %f",
+			"clean":    "git-lfs clean -- %f",
+			"smudge":   "git-lfs smudge --skip -- %f",
 			"required": "true",
 		},
 	}

--- a/test/test-env.sh
+++ b/test/test-env.sh
@@ -2,8 +2,8 @@
 
 . "test/testlib.sh"
 
-envInitConfig='git config filter.lfs.smudge = "git-lfs smudge %f"
-git config filter.lfs.clean = "git-lfs clean %f"'
+envInitConfig='git config filter.lfs.smudge = "git-lfs smudge -- %f"
+git config filter.lfs.clean = "git-lfs clean -- %f"'
 
 begin_test "env with no remote"
 (

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -41,8 +41,8 @@ begin_test "install with old settings"
   [ "git lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
 
   git lfs install --force
-  [ "git-lfs smudge %f" = "$(git config --global filter.lfs.smudge)" ]
-  [ "git-lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
+  [ "git-lfs smudge -- %f" = "$(git config --global filter.lfs.smudge)" ]
+  [ "git-lfs clean -- %f" = "$(git config --global filter.lfs.clean)" ]
 )
 end_test
 
@@ -130,16 +130,16 @@ begin_test "install --skip-smudge"
   set -e
 
   git lfs install
-  [ "git-lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
-  [ "git-lfs smudge %f" = "$(git config --global filter.lfs.smudge)" ]
+  [ "git-lfs clean -- %f" = "$(git config --global filter.lfs.clean)" ]
+  [ "git-lfs smudge -- %f" = "$(git config --global filter.lfs.smudge)" ]
 
   git lfs install --skip-smudge
-  [ "git-lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
-  [ "git-lfs smudge --skip %f" = "$(git config --global filter.lfs.smudge)" ]
+  [ "git-lfs clean -- %f" = "$(git config --global filter.lfs.clean)" ]
+  [ "git-lfs smudge --skip -- %f" = "$(git config --global filter.lfs.smudge)" ]
 
   git lfs install --force
-  [ "git-lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
-  [ "git-lfs smudge %f" = "$(git config --global filter.lfs.smudge)" ]
+  [ "git-lfs clean -- %f" = "$(git config --global filter.lfs.clean)" ]
+  [ "git-lfs smudge -- %f" = "$(git config --global filter.lfs.smudge)" ]
 )
 end_test
 
@@ -156,8 +156,8 @@ begin_test "install --local"
   git init
   git lfs install --local
 
-  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
-  [ "git-lfs clean %f" = "$(git config --local filter.lfs.clean)" ]
+  [ "git-lfs clean -- %f" = "$(git config filter.lfs.clean)" ]
+  [ "git-lfs clean -- %f" = "$(git config --local filter.lfs.clean)" ]
   [ "git lfs clean %f" = "$(git config --global filter.lfs.clean)" ]
 )
 end_test

--- a/test/test-uninstall.sh
+++ b/test/test-uninstall.sh
@@ -39,8 +39,8 @@ begin_test "uninstall inside repository with default pre-push hook"
   [ -f .git/hooks/pre-push ]
   grep "git-lfs" .git/hooks/pre-push
 
-  [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
-  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
+  [ "git-lfs smudge -- %f" = "$(git config filter.lfs.smudge)" ]
+  [ "git-lfs clean -- %f" = "$(git config filter.lfs.clean)" ]
 
   git lfs uninstall
 
@@ -68,8 +68,8 @@ begin_test "uninstall inside repository without git lfs pre-push hook"
   [ -f .git/hooks/pre-push ]
   [ "something something git-lfs" = "$(cat .git/hooks/pre-push)" ]
 
-  [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
-  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
+  [ "git-lfs smudge -- %f" = "$(git config filter.lfs.smudge)" ]
+  [ "git-lfs clean -- %f" = "$(git config filter.lfs.clean)" ]
 
   git lfs uninstall
 
@@ -92,8 +92,8 @@ begin_test "uninstall hooks inside repository"
   [ -f .git/hooks/pre-push ]
   grep "git-lfs" .git/hooks/pre-push
 
-  [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
-  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
+  [ "git-lfs smudge -- %f" = "$(git config filter.lfs.smudge)" ]
+  [ "git-lfs clean -- %f" = "$(git config filter.lfs.clean)" ]
 
   git lfs uninstall hooks
 
@@ -102,7 +102,7 @@ begin_test "uninstall hooks inside repository"
     exit 1
   }
 
-  [ "git-lfs smudge %f" = "$(git config filter.lfs.smudge)" ]
-  [ "git-lfs clean %f" = "$(git config filter.lfs.clean)" ]
+  [ "git-lfs smudge -- %f" = "$(git config filter.lfs.smudge)" ]
+  [ "git-lfs clean -- %f" = "$(git config filter.lfs.clean)" ]
 )
 end_test

--- a/test/test-unusual-filenames.sh
+++ b/test/test-unusual-filenames.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+reponame="$(basename "$0" ".sh")"
+
+# Leading dashes may be misinterpreted as flags if commands don't use "--"
+# before paths.
+name1='-dash.dat'
+contents1='leading dash'
+
+begin_test "push unusually named files"
+(
+  set -e
+
+  setup_remote_repo "$reponame"
+
+  clone_repo "$reponame" repo
+
+  git lfs track "*.dat"
+  echo "$content1" > "$name1"
+
+  git add -- .gitattributes *.dat
+  git commit -m "add files"
+
+  git push origin master | tee push.log
+  grep "Git LFS: (1 of 1 files)" push.log
+)
+end_test
+
+begin_test "pull unusually named files"
+(
+  set -e
+
+  clone_repo "$reponame" clone
+
+  grep "Downloading $name1" clone.log
+)
+end_test

--- a/test/test-worktree.sh
+++ b/test/test-worktree.sh
@@ -3,8 +3,8 @@
 . "test/testlib.sh"
 
 ensure_git_version_isnt $VERSION_LOWER "2.5.0"
-envInitConfig='git config filter.lfs.smudge = "git-lfs smudge %f"
-git config filter.lfs.clean = "git-lfs clean %f"'
+envInitConfig='git config filter.lfs.smudge = "git-lfs smudge -- %f"
+git config filter.lfs.clean = "git-lfs clean -- %f"'
 
 begin_test "git worktree"
 (


### PR DESCRIPTION
Fixes #1072. Currently, the filters run a command like this when a tracked file begins with a dash:

`$ git-lfs clean -filename`

The filename is then misinterpreted as short arguments.

This installs `git-lfs clean -- %f` instead of `git-lfs clean %f`, and a similar smudge filter.

A limitation of this patch is that existing installs don't automatically upgrade to the new filters until they run `git lfs install --force`. It looks like this is consistent with the `git lfs clean` vs `git-lfs clean` precedent, but maybe encountering this behavior is realistic enough to justify trying to build some sort of auto-upgrade feature which promotes known older variants of the filter (it looks like the pre-push hook has such a list already).

In any case, this should fix new installs, and allow existing installs to use `git lfs install --force` to manually apply the fix.