### PR TITLE
Fix "Uploading refs <remote> to remote <refs>" log string

### DIFF
--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -36,7 +36,7 @@ func uploadsBetweenRefs(left string, right string) *lfs.TransferQueue {
 }
 
 func uploadsBetweenRefAndRemote(remote string, refs []string) *lfs.TransferQueue {
-	tracerx.Printf("Upload refs %v to remote %v", remote, refs)
+	tracerx.Printf("Upload refs %v to remote %v", refs, remote)
 
 	scanOpt := lfs.NewScanRefsOptions()
 	scanOpt.ScanMode = lfs.ScanLeftToRemoteMode


### PR DESCRIPTION
The argument order and string order are flipped. Before:

```
$ GIT_TRACE=1 git-lfs push origin master
trace git-lfs: Upload refs origin to remote [master]
```

After:

```
$ GIT_TRACE=1 git-lfs push origin master
trace git-lfs: Upload refs [master] to remote origin
```