### PR TITLE
Accept raw remote URLs as valid

### DIFF
--- a/lfs/config.go
+++ b/lfs/config.go
@@ -126,6 +126,11 @@ func (c *Configuration) GitRemoteUrl(remote string, forpush bool) string {
 		return u
 	}
 
+	err := git.ValidateRemoteURL(remote)
+	if err == nil {
+		return remote
+	}
+
 	return ""
 
 }


### PR DESCRIPTION
Fixes issue #1069, sort of, in theory. This is likely more of a starting point. Major issues:

  - No meaningful test coverage.
  - Pushing to a raw URL scans and tries to push every object in the repository.

Overview:

This treats any "ssh", "http", "https", "git" or protocol-free-with-a-colon-in-it remote name as a valid raw remote URL.

I'm not sure how to effectively test this, because it seems difficult to stub/simulate any of these protocols locally, and `git-lfs` won't work with `file://`, etc. Existing tests pass locally, and the existing test to verify that `git-lfs push not-a-remote` encounters an error passes (this is correctly detected as not being a valid remote).

I manually tested positive cases with, e.g.:

```
$ GIT_TRACE=1 git-lfs push git@github.com:epriestley/poems.git master
...
Git LFS: (1 of 7 files, 6 skipped) 11 B / 87.16 KB, 87.15 KB skipped    
```

One possible issue is that this causes this `rev-list` command to execute:

```
trace git-lfs: run_command: git rev-list --objects master --not --remotes=git@github.com:epriestley/poems.git
```

`git` runs this, but it fails to exclude anything and lists every object in the repository.

A better strategy might be:

  - If the URL is raw, run `git ls-remote <url>` instead.
  - Pass the list of remote refs to `--not` instead of `--remote <remote>`.

I can pursue this refinement, but didn't want to get too far into things if I'm on the wrong track.