### PR TITLE
Fully resolve symlinks in all cases for consistency

### DIFF
--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -92,6 +92,11 @@ func ResolveDirs() {
 	var err error
 	LocalGitDir, LocalWorkingDir, err = git.GitAndRootDirs()
 	if err == nil {
+		// Make sure we've fully evaluated symlinks, failure to do consistently
+		// can cause discrepancies
+		LocalGitDir = ResolveSymlinks(LocalGitDir)
+		LocalWorkingDir = ResolveSymlinks(LocalWorkingDir)
+
 		LocalGitStorageDir = resolveGitStorageDir(LocalGitDir)
 		TempDir = filepath.Join(LocalGitDir, "lfs", "tmp") // temp files per worktree
 

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -199,6 +199,7 @@ func ConvertRepoFilesRelativeToCwd(repochan <-chan string) (<-chan string, error
 	if err != nil {
 		return nil, fmt.Errorf("Unable to get working dir: %v", err)
 	}
+	wd = ResolveSymlinks(wd)
 
 	// Early-out if working dir is root dir, same result
 	passthrough := false
@@ -238,6 +239,8 @@ func ConvertCwdFilesRelativeToRepo(cwdchan <-chan string) (<-chan string, error)
 	if err != nil {
 		return nil, fmt.Errorf("Could not retrieve current directory: %v", err)
 	}
+	// Make sure to resolve symlinks
+	curdir = ResolveSymlinks(curdir)
 
 	// Early-out if working dir is root dir, same result
 	passthrough := false
@@ -254,7 +257,7 @@ func ConvertCwdFilesRelativeToRepo(cwdchan <-chan string) (<-chan string, error)
 			}
 			var abs string
 			if filepath.IsAbs(p) {
-				abs = p
+				abs = ResolveSymlinks(p)
 			} else {
 				abs = filepath.Join(curdir, p)
 			}
@@ -271,6 +274,15 @@ func ConvertCwdFilesRelativeToRepo(cwdchan <-chan string) (<-chan string, error)
 
 	return outchan, nil
 
+}
+
+// ResolveSymlinks ensures that if the path supplied is a symlink, it is
+// resolved to the actual concrete path
+func ResolveSymlinks(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return path
 }
 
 // Are we running on Windows? Need to handle some extra path shenanigans

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -279,6 +279,10 @@ func ConvertCwdFilesRelativeToRepo(cwdchan <-chan string) (<-chan string, error)
 // ResolveSymlinks ensures that if the path supplied is a symlink, it is
 // resolved to the actual concrete path
 func ResolveSymlinks(path string) string {
+	if len(path) == 0 {
+		return path
+	}
+
 	if resolved, err := filepath.EvalSymlinks(path); err == nil {
 		return resolved
 	}

--- a/test/testenv.sh
+++ b/test/testenv.sh
@@ -3,9 +3,48 @@
 
 set -e
 
+UNAME=$(uname -s)
+IS_WINDOWS=0
+IS_MAC=0
+if [[ $UNAME == MINGW* || $UNAME == CYGWIN* ]]
+then
+  IS_WINDOWS=1
+elif [[ $UNAME == *Darwin* ]]
+then
+  IS_MAC=1
+fi
+
+resolve_symlink() {
+  local arg=$1
+  if [ $IS_WINDOWS == "1" ]; then
+    printf '%s' "$arg"
+  elif [ $IS_MAC == "1" ]; then
+    # no readlink -f on Mac
+    local oldwd=$(pwd)
+    local target=$arg
+
+    cd `dirname $target`
+    target=`basename $target`
+    while [ -L "$target" ]
+    do
+        target=`readlink $target`
+        cd `dirname $target`
+        target=`basename $target`
+    done
+
+    local resolveddir=`pwd -P`
+    cd "$oldwd"
+    printf '%s' "$resolveddir/$target"
+
+  else
+    readlink -f "$arg"
+  fi
+
+}
+
 # The root directory for the git-lfs repository by default.
 if [ -z "$ROOTDIR" ]; then
-  ROOTDIR=$(cd $(dirname "$0")/.. && pwd)
+  ROOTDIR=$(cd $(dirname "$0")/.. && pwd -P)
 fi
 
 # Where Git LFS outputs the compiled binaries
@@ -55,13 +94,6 @@ LFS_CERT_FILE="$REMOTEDIR/cert"
 TESTHOME="$REMOTEDIR/home"
 
 GIT_CONFIG_NOSYSTEM=1
-
-UNAME=$(uname -s)
-IS_WINDOWS=0
-if [[ $UNAME == MINGW* || $UNAME == CYGWIN* ]]
-then
-  IS_WINDOWS=1
-fi
 
 export CREDSDIR
 


### PR DESCRIPTION
I discovered this problem while setting up the integration tests to always run in an isolated temp dir if GIT_LFS_TEST_DIR is not set. On Mac that's `/var/temp`, which is a symlink to `/private/var/temp` and which immediately failed in all kinds of ways. The 2 main issues were: 

1. `git rev-parse` resolves symlinks but os.Getwd(), filepath.Abs() does not, causing internal inconsistencies and some weird relative paths from filepath.Rel() that didn't always work
1. Many integration tests failed because bash wasn't resolving symlinks vs Go doing so sometimes

I've chosen to resolve symlinks always to fix this. In bash this was more tricky because `readlink -f` doesn't exist on Mac so there's a helper function to do it. 