### PR TITLE
Mention releng access rights to the git-lfs.github.com repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,8 @@ cross compiling with Mac, Linux, FreeBSD, and Windows support).
 * Run `script/release -id {id}` to upload all of the compiled binaries to the
 release.
 * Publish the Release on GitHub.
-* Update [Git LFS website](https://github.com/github/git-lfs.github.com/blob/gh-pages/_config.yml#L4).
+* Update [Git LFS website](https://github.com/github/git-lfs.github.com/blob/gh-pages/_config.yml#L4)
+(release engineer access rights required).
 * Ping external teams on GitHub:
   * @github/desktop
 * Build packages:


### PR DESCRIPTION
One needs to have release engineer access rights to https://github.com/github/git-lfs.github.com to open the [link](https://github.com/github/git-lfs.github.com/blob/gh-pages/_config.yml#L4), it will show `404` otherwise.

See #1092