### PR TITLE
Fix `git rev-list` when a file exists with the same name as the branch

### DIFF
--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -316,6 +316,11 @@ func revListShas(refLeft, refRight string, opt *ScanRefsOptions) (chan string, e
 		return nil, errors.New("scanner: unknown scan type: " + strconv.Itoa(int(opt.ScanMode)))
 	}
 
+	// Use "--" at the end of the command to disambiguate arguments as refs,
+	// so Git doesn't complain about ambiguity if you happen to also have a
+	// file named "master".
+	refArgs = append(refArgs, "--")
+
 	cmd, err := startCommand("git", refArgs...)
 	if err != nil {
 		return nil, err

--- a/test/test-push-file-with-branch-name.sh
+++ b/test/test-push-file-with-branch-name.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "push a file with the same name as a branch"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" repo
+
+  git lfs track "master"
+  echo "master" > master
+  git add .gitattributes master
+  git commit -m "add master"
+
+  git lfs push --all origin master 2>&1 | tee push.log
+  grep "(1 of 1 files)" push.log
+)
+end_test


### PR DESCRIPTION
Fixes issue #1056.

When you try to push `master` but also have a file named  `master`, we run
`git rev-list ... master`. This is ambiguous, because `rev-list` accepts
paths or refs and `git` is unsure whether you mean the ref `master` or the
path `master`.

Instead, run `git rev-list ... master --`, which is unambiguous.

This adds a failing test (trying to push a file named `master` to LFS), then
fixes the test by appending `--` to the command.