### PR TITLE
Create a new packagecloud Package for each upload

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -58,7 +58,6 @@ end
 package_files = Dir.glob("repos/**/*.rpm") + Dir.glob("repos/**/*.deb")
 package_files.each do |full_path|
   next if full_path =~ /repo-release/
-  pkg = Packagecloud::Package.new(:file => full_path)
   distro_names = distro_names_for(full_path)
   distro_names.map do |distro_name|
     distro_id = $distro_id_map[distro_name] ||= $client.find_distribution_id(distro_name)
@@ -67,6 +66,7 @@ package_files.each do |full_path|
     end
 
     puts "pushing #{full_path} to #{$distro_id_map.key(distro_id).inspect}"
+    pkg = Packagecloud::Package.new(:file => full_path)
     $client.put_package("git-lfs", pkg, distro_id)
   end
 end


### PR DESCRIPTION
Current API cannot re-read package File contents.  Found during work on #1074. See also https://github.com/computology/packagecloud-ruby/issues/14.

The symptoms here are that a second and subsequent upload based on the same `Package` object fail.  Proxy debug shows that the POSTed form contains empty file data.  This is because `Package` opens the `File` (when passed as a string path), but `Client` reads the contents into MIME during the put package.  There's no close/reopen/rewind on the file, so on subsequent calls there is no data left.

Ideally `Package` bug above could be fixed such that that class reads the MIME bytes and closes the file it opens, so that it can be reused.  But for now, just create a fresh `Package` for each upload.

This may or may not account for sparse package coverage for 1.1.2 on packagecloud.