### PR TITLE
Touch tracked files that are already added to git

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -777,6 +777,6 @@ func GetTrackedFiles(pattern string) ([]string, error) {
 		line := scanner.Text()
 		ret = append(ret, strings.TrimSpace(line))
 	}
-	return ret, nil
+	return ret, cmd.Wait()
 
 }

--- a/git/git.go
+++ b/git/git.go
@@ -753,3 +753,30 @@ func RemoteRefs(remoteName string) ([]*Ref, error) {
 	}
 	return ret, nil
 }
+
+// GetTrackedFiles returns a list of files which are tracked in Git which match
+// the pattern specified (standard wildcard form)
+// Both pattern and the results are relative to the current working directory, not
+// the root of the repository
+func GetTrackedFiles(pattern string) ([]string, error) {
+	var ret []string
+	cmd := subprocess.ExecCommand("git",
+		"-c", "core.quotepath=false", // handle special chars in filenames
+		"ls-files",
+		"--cached", // include things which are staged but not committed right now
+		"--",       // no ambiguous patterns
+		pattern)
+
+	outp, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to call git ls-files: %v", err)
+	}
+	cmd.Start()
+	scanner := bufio.NewScanner(outp)
+	for scanner.Scan() {
+		line := scanner.Text()
+		ret = append(ret, strings.TrimSpace(line))
+	}
+	return ret, nil
+
+}


### PR DESCRIPTION
Resolves #1057 

If a file is already tracked in git when it's added to git-lfs tracking, that file is now 'touched' (`mtime`/`atime` file attributes updated) to ensure that it appears as modified in `git status` along with the `.gitattributes` and therefore prompts the user to re-commit it. Without doing this git doesn't detect that the index is dirty for this file and the user could commit `.gitattributes` but with the file content remaining as non-LFS, which can cause problems when checking out this commit in future. Checking out this commit will forever after show the file as modified in the working copy because `smudge` will not have LFS data to checkout from even though `.gitattributes` says it should have, and `clean` will show a diff.