### PR TITLE
pointer: Only write the encoded pointer information to Stdout

### DIFF
--- a/commands/command_pointer.go
+++ b/commands/command_pointer.go
@@ -52,13 +52,13 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 		}
 
 		ptr := lfs.NewPointer(hex.EncodeToString(oidHash.Sum(nil)), size, nil)
-		fmt.Printf("Git LFS pointer for %s\n\n", pointerFile)
+		fmt.Fprintf(os.Stderr, "Git LFS pointer for %s\n\n", pointerFile)
 		buf := &bytes.Buffer{}
 		lfs.EncodePointer(io.MultiWriter(os.Stdout, buf), ptr)
 
 		if comparing {
 			buildOid = gitHashObject(buf.Bytes())
-			fmt.Printf("\nGit blob OID: %s\n\n", buildOid)
+			fmt.Fprintf(os.Stderr, "\nGit blob OID: %s\n\n", buildOid)
 		}
 	} else {
 		comparing = false
@@ -81,22 +81,22 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 		if !pointerStdin {
 			pointerName = pointerCompare
 		}
-		fmt.Printf("Pointer from %s\n\n", pointerName)
+		fmt.Fprintf(os.Stderr, "Pointer from %s\n\n", pointerName)
 
 		if err != nil {
 			Error(err.Error())
 			os.Exit(1)
 		}
 
-		fmt.Printf(buf.String())
+		fmt.Fprintf(os.Stderr, buf.String())
 		if comparing {
 			compareOid = gitHashObject(buf.Bytes())
-			fmt.Printf("\nGit blob OID: %s\n", compareOid)
+			fmt.Fprintf(os.Stderr, "\nGit blob OID: %s\n", compareOid)
 		}
 	}
 
 	if comparing && buildOid != compareOid {
-		fmt.Printf("\nPointers do not match\n")
+		fmt.Fprintf(os.Stderr, "\nPointers do not match\n")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This allows to create a pointer file by redirecting Stdout like

    $ git lfs pointer --file=path/to/file > pointer-to-file

Before this change, "pointer-to-file" would also contain the line saying

    "Git LFS pointer for path/to/file"

which makes the pointer file invalid.