### PR TITLE
Added GO15VENDOREXPERIMENT=0 to dpkg dh build, follow-on from #1025.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 export DH_OPTIONS
+export GO15VENDOREXPERIMENT=0
 
 #dh_golang doesn't do this for you
 ifeq ($(DEB_HOST_ARCH), i386)


### PR DESCRIPTION
Following from #1025.  If you want to run the Debian dpkg build using Go 1.6, you need this change, otherwise the import problems noted in https://github.com/github/git-lfs/pull/1076#issuecomment-199062143 will occur.

It is super-likely that the same need to be added to RPM build `rpm/build_rpms.bsh`, and this could be added on speculation, but I don't have a current build environment on a yum-packaged dist.