### PR TITLE
Catch previously undetected errors from git exit codes in async scans

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -225,10 +225,14 @@ func scanAll() []*lfs.WrappedPointer {
 
 	pointers := make([]*lfs.WrappedPointer, 0)
 
-	for p := range pointerchan {
+	for p := range pointerchan.Results {
 		numObjs++
 		spinner.Print(OutputWriter, fmt.Sprintf("%d objects found", numObjs))
 		pointers = append(pointers, p)
+	}
+	err = pointerchan.Wait()
+	if err != nil {
+		Panic(err, "Could not scan for Git LFS files")
 	}
 
 	spinner.Finish(OutputWriter, fmt.Sprintf("%d objects found", numObjs))

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -16,7 +16,7 @@ var (
 		Run: prePushCommand,
 	}
 	prePushDryRun        = false
-	prePushDeleteBranch  = "(delete)"
+	prePushDeleteBranch  = strings.Repeat("0", 40)
 	prePushMissingErrMsg = "%s is an LFS pointer to %s, which does not exist in .git/lfs/objects.\n\nRun 'git lfs fsck' to verify Git LFS objects."
 )
 

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -311,9 +311,13 @@ func pruneTaskGetRetainedAtRef(ref string, retainChan chan string, errorChan cha
 		errorChan <- err
 		return
 	}
-	for wp := range refchan {
+	for wp := range refchan.Results {
 		retainChan <- wp.Pointer.Oid
 		tracerx.Printf("RETAIN: %v via ref %v", wp.Pointer.Oid, ref)
+	}
+	err = refchan.Wait()
+	if err != nil {
+		errorChan <- err
 	}
 }
 
@@ -326,9 +330,13 @@ func pruneTaskGetPreviousVersionsOfRef(ref string, since time.Time, retainChan c
 		errorChan <- err
 		return
 	}
-	for wp := range refchan {
+	for wp := range refchan.Results {
 		retainChan <- wp.Pointer.Oid
 		tracerx.Printf("RETAIN: %v via ref %v >= %v", wp.Pointer.Oid, ref, since)
+	}
+	err = refchan.Wait()
+	if err != nil {
+		errorChan <- err
 	}
 }
 
@@ -398,9 +406,13 @@ func pruneTaskGetRetainedUnpushed(retainChan chan string, errorChan chan error, 
 		errorChan <- err
 		return
 	}
-	for wp := range refchan {
+	for wp := range refchan.Results {
 		retainChan <- wp.Pointer.Oid
 		tracerx.Printf("RETAIN: %v unpushed", wp.Pointer.Oid)
+	}
+	err = refchan.Wait()
+	if err != nil {
+		errorChan <- err
 	}
 }
 
@@ -452,8 +464,12 @@ func pruneTaskGetReachableObjects(outObjectSet *lfs.StringSet, errorChan chan er
 		return
 	}
 
-	for p := range pointerchan {
+	for p := range pointerchan.Results {
 		outObjectSet.Add(p.Oid)
+	}
+	err = pointerchan.Wait()
+	if err != nil {
+		errorChan <- err
 	}
 
 }

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -15,11 +15,10 @@ var (
 		Use: "push",
 		Run: pushCommand,
 	}
-	pushDryRun       = false
-	pushDeleteBranch = "(delete)"
-	pushObjectIDs    = false
-	pushAll          = false
-	useStdin         = false
+	pushDryRun    = false
+	pushObjectIDs = false
+	pushAll       = false
+	useStdin      = false
 
 	// shares some global vars and functions with command_pre_push.go
 )
@@ -179,7 +178,7 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		}
 
 		left, right := decodeRefs(string(refsData))
-		if left == pushDeleteBranch {
+		if left == prePushDeleteBranch {
 			return
 		}
 

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -1055,13 +1055,14 @@ type PointerChannelWrapper struct {
 }
 
 // Construct a new channel wrapper for WrappedPointer
-// Caller can use s.Pointers directly for normal processing then call Wait() to finish & check for errors
+// Caller can use s.Results directly for normal processing then call Wait() to finish & check for errors
 // Scan function is required to create error channel large enough not to block (usually 1 is ok)
 func NewPointerChannelWrapper(pointerChan <-chan *WrappedPointer, errorChan <-chan error) *PointerChannelWrapper {
 	return &PointerChannelWrapper{&BaseChannelWrapper{errorChan}, pointerChan}
 }
 
 // ChannelWrapper for string channel functions to more easily return async error data via Wait()
+// Caller can use s.Results directly for normal processing then call Wait() to finish & check for errors
 // See NewStringChannelWrapper for construction / use
 type StringChannelWrapper struct {
 	*BaseChannelWrapper
@@ -1069,6 +1070,7 @@ type StringChannelWrapper struct {
 }
 
 // Construct a new channel wrapper for string
+// Caller can use s.Results directly for normal processing then call Wait() to finish & check for errors
 func NewStringChannelWrapper(stringChan <-chan string, errorChan <-chan error) *StringChannelWrapper {
 	return &StringChannelWrapper{&BaseChannelWrapper{errorChan}, stringChan}
 }
@@ -1081,6 +1083,7 @@ type TreeBlobChannelWrapper struct {
 }
 
 // Construct a new channel wrapper for TreeBlob
+// Caller can use s.Results directly for normal processing then call Wait() to finish & check for errors
 func NewTreeBlobChannelWrapper(treeBlobChan <-chan TreeBlob, errorChan <-chan error) *TreeBlobChannelWrapper {
 	return &TreeBlobChannelWrapper{&BaseChannelWrapper{errorChan}, treeBlobChan}
 }

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -425,11 +425,14 @@ func revListIndex(cache bool, indexMap *indexFileMap) (*StringChannelWrapper, er
 			}
 		}
 
-		stderr, _ := ioutil.ReadAll(cmd.Stderr)
-		err := cmd.Wait()
-		if err != nil {
-			errchan <- fmt.Errorf("Error in git diff-index: %v %v", err, string(stderr))
-		}
+		// Note: deliberately not checking result code here, because doing that
+		// can fail fsck process too early since clean filter will detect errors
+		// and set this to non-zero. How to cope with this better?
+		// stderr, _ := ioutil.ReadAll(cmd.Stderr)
+		// err := cmd.Wait()
+		// if err != nil {
+		// 	errchan <- fmt.Errorf("Error in git diff-index: %v %v", err, string(stderr))
+		// }
 		cmd.Wait()
 		close(revs)
 		close(errchan)

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -122,7 +122,6 @@ func ScanRefs(refLeft, refRight string, opt *ScanRefsOptions) ([]*WrappedPointer
 // ScanRefsToChan takes a ref and returns a channel of WrappedPointer objects
 // for all Git LFS pointers it finds for that ref.
 // Reports unique oids once only, not multiple times if >1 file uses the same content
-// Recommend using NewPointerChannelWrapper to wrap
 func ScanRefsToChan(refLeft, refRight string, opt *ScanRefsOptions) (*PointerChannelWrapper, error) {
 	if opt == nil {
 		opt = NewScanRefsOptions()

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -104,23 +104,25 @@ func NewScanRefsOptions() *ScanRefsOptions {
 // for all Git LFS pointers it finds for that ref.
 // Reports unique oids once only, not multiple times if >1 file uses the same content
 func ScanRefs(refLeft, refRight string, opt *ScanRefsOptions) ([]*WrappedPointer, error) {
-	c, err := ScanRefsToChan(refLeft, refRight, opt)
+	s, err := ScanRefsToChan(refLeft, refRight, opt)
 	if err != nil {
 		return nil, err
 	}
 	pointers := make([]*WrappedPointer, 0)
-	for p := range c {
+	for p := range s.Results {
 		pointers = append(pointers, p)
 	}
+	err = s.Wait()
 
-	return pointers, nil
+	return pointers, err
 
 }
 
 // ScanRefsToChan takes a ref and returns a channel of WrappedPointer objects
 // for all Git LFS pointers it finds for that ref.
 // Reports unique oids once only, not multiple times if >1 file uses the same content
-func ScanRefsToChan(refLeft, refRight string, opt *ScanRefsOptions) (<-chan *WrappedPointer, error) {
+// Recommend using NewPointerChannelWrapper to wrap
+func ScanRefsToChan(refLeft, refRight string, opt *ScanRefsOptions) (*PointerChannelWrapper, error) {
 	if opt == nil {
 		opt = NewScanRefsOptions()
 	}
@@ -143,23 +145,29 @@ func ScanRefsToChan(refLeft, refRight string, opt *ScanRefsOptions) (<-chan *Wra
 		return nil, err
 	}
 
-	pointerc, err := catFileBatch(smallShas)
+	pointers, err := catFileBatch(smallShas)
 	if err != nil {
 		return nil, err
 	}
 
 	retchan := make(chan *WrappedPointer, chanBufSize)
+	errchan := make(chan error, 1)
 	go func() {
-		for p := range pointerc {
+		for p := range pointers.Results {
 			if name, ok := opt.GetName(p.Sha1); ok {
 				p.Name = name
 			}
 			retchan <- p
 		}
+		err := pointers.Wait()
+		if err != nil {
+			errchan <- err
+		}
 		close(retchan)
+		close(errchan)
 	}()
 
-	return retchan, nil
+	return NewPointerChannelWrapper(retchan, errchan), nil
 }
 
 type indexFileMap struct {
@@ -204,21 +212,32 @@ func ScanIndex() ([]*WrappedPointer, error) {
 		return nil, err
 	}
 
-	allRevs := make(chan string)
+	allRevsErr := make(chan error, 5) // can be multiple errors below
+	allRevsChan := make(chan string, 1)
+	allRevs := NewStringChannelWrapper(allRevsChan, allRevsErr)
 	go func() {
 		seenRevs := make(map[string]bool, 0)
 
-		for rev := range revs {
+		for rev := range revs.Results {
 			seenRevs[rev] = true
-			allRevs <- rev
+			allRevsChan <- rev
+		}
+		err := revs.Wait()
+		if err != nil {
+			allRevsErr <- err
 		}
 
-		for rev := range cachedRevs {
+		for rev := range cachedRevs.Results {
 			if _, ok := seenRevs[rev]; !ok {
-				allRevs <- rev
+				allRevsChan <- rev
 			}
 		}
-		close(allRevs)
+		err = cachedRevs.Wait()
+		if err != nil {
+			allRevsErr <- err
+		}
+		close(allRevsChan)
+		close(allRevsErr)
 	}()
 
 	smallShas, err := catFileBatchCheck(allRevs)
@@ -232,7 +251,7 @@ func ScanIndex() ([]*WrappedPointer, error) {
 	}
 
 	pointers := make([]*WrappedPointer, 0)
-	for p := range pointerc {
+	for p := range pointerc.Results {
 		if e, ok := indexMap.Get(p.Sha1); ok {
 			p.Name = e.Name
 			p.Status = e.Status
@@ -240,8 +259,9 @@ func ScanIndex() ([]*WrappedPointer, error) {
 		}
 		pointers = append(pointers, p)
 	}
+	err = pointerc.Wait()
 
-	return pointers, nil
+	return pointers, err
 
 }
 
@@ -294,7 +314,7 @@ func revListArgsRefVsRemote(refTo, remoteName string) []string {
 // revListShas uses git rev-list to return the list of object sha1s
 // for the given ref. If all is true, ref is ignored. It returns a
 // channel from which sha1 strings can be read.
-func revListShas(refLeft, refRight string, opt *ScanRefsOptions) (chan string, error) {
+func revListShas(refLeft, refRight string, opt *ScanRefsOptions) (*StringChannelWrapper, error) {
 	refArgs := []string{"rev-list", "--objects"}
 	switch opt.ScanMode {
 	case ScanRefsMode:
@@ -329,6 +349,7 @@ func revListShas(refLeft, refRight string, opt *ScanRefsOptions) (chan string, e
 	cmd.Stdin.Close()
 
 	revs := make(chan string, chanBufSize)
+	errchan := make(chan error, 1)
 
 	go func() {
 		scanner := bufio.NewScanner(cmd.Stdout)
@@ -345,17 +366,21 @@ func revListShas(refLeft, refRight string, opt *ScanRefsOptions) (chan string, e
 			revs <- sha1
 		}
 
-		cmd.Wait()
+		err := cmd.Wait()
+		if err != nil {
+			errchan <- err
+		}
 		close(revs)
+		close(errchan)
 	}()
 
-	return revs, nil
+	return NewStringChannelWrapper(revs, errchan), nil
 }
 
 // revListIndex uses git diff-index to return the list of object sha1s
 // for in the indexf. It returns a channel from which sha1 strings can be read.
 // The namMap will be filled indexFile pointers mapping sha1s to indexFiles.
-func revListIndex(cache bool, indexMap *indexFileMap) (chan string, error) {
+func revListIndex(cache bool, indexMap *indexFileMap) (*StringChannelWrapper, error) {
 	cmdArgs := []string{"diff-index", "-M"}
 	if cache {
 		cmdArgs = append(cmdArgs, "--cached")
@@ -370,6 +395,7 @@ func revListIndex(cache bool, indexMap *indexFileMap) (chan string, error) {
 	cmd.Stdin.Close()
 
 	revs := make(chan string, chanBufSize)
+	errchan := make(chan error, 1)
 
 	go func() {
 		scanner := bufio.NewScanner(cmd.Stdout)
@@ -397,11 +423,15 @@ func revListIndex(cache bool, indexMap *indexFileMap) (chan string, error) {
 			}
 		}
 
-		cmd.Wait()
+		err := cmd.Wait()
+		if err != nil {
+			errchan <- err
+		}
 		close(revs)
+		close(errchan)
 	}()
 
-	return revs, nil
+	return NewStringChannelWrapper(revs, errchan), nil
 }
 
 // catFileBatchCheck uses git cat-file --batch-check to get the type
@@ -409,13 +439,14 @@ func revListIndex(cache bool, indexMap *indexFileMap) (chan string, error) {
 // under the blobSizeCutoff will be ignored. revs is a channel over
 // which strings containing git sha1s will be sent. It returns a channel
 // from which sha1 strings can be read.
-func catFileBatchCheck(revs chan string) (chan string, error) {
+func catFileBatchCheck(revs *StringChannelWrapper) (*StringChannelWrapper, error) {
 	cmd, err := startCommand("git", "cat-file", "--batch-check")
 	if err != nil {
 		return nil, err
 	}
 
 	smallRevs := make(chan string, chanBufSize)
+	errchan := make(chan error, 2) // up to 2 errors, one from each goroutine
 
 	go func() {
 		scanner := bufio.NewScanner(cmd.Stdout)
@@ -445,31 +476,43 @@ func catFileBatchCheck(revs chan string) (chan string, error) {
 			}
 		}
 
-		cmd.Wait()
+		err := cmd.Wait()
+		if err != nil {
+			errchan <- err
+		}
 		close(smallRevs)
+		close(errchan)
 	}()
 
 	go func() {
-		for r := range revs {
+		for r := range revs.Results {
 			cmd.Stdin.Write([]byte(r + "\n"))
 		}
+		err := revs.Wait()
+		if err != nil {
+			// We can share errchan with other goroutine since that won't close it
+			// until we close the stdin below
+			errchan <- err
+		}
+
 		cmd.Stdin.Close()
 	}()
 
-	return smallRevs, nil
+	return NewStringChannelWrapper(smallRevs, errchan), nil
 }
 
 // catFileBatch uses git cat-file --batch to get the object contents
 // of a git object, given its sha1. The contents will be decoded into
 // a Git LFS pointer. revs is a channel over which strings containing Git SHA1s
 // will be sent. It returns a channel from which point.Pointers can be read.
-func catFileBatch(revs chan string) (chan *WrappedPointer, error) {
+func catFileBatch(revs *StringChannelWrapper) (*PointerChannelWrapper, error) {
 	cmd, err := startCommand("git", "cat-file", "--batch")
 	if err != nil {
 		return nil, err
 	}
 
 	pointers := make(chan *WrappedPointer, chanBufSize)
+	errchan := make(chan error, 5) // shared by 2 goroutines & may add more detail errors?
 
 	go func() {
 		for {
@@ -504,18 +547,28 @@ func catFileBatch(revs chan string) (chan *WrappedPointer, error) {
 			}
 		}
 
-		cmd.Wait()
+		err = cmd.Wait()
+		if err != nil {
+			errchan <- err
+		}
 		close(pointers)
+		close(errchan)
 	}()
 
 	go func() {
-		for r := range revs {
+		for r := range revs.Results {
 			cmd.Stdin.Write([]byte(r + "\n"))
+		}
+		err := revs.Wait()
+		if err != nil {
+			// We can share errchan with other goroutine since that won't close it
+			// until we close the stdin below
+			errchan <- err
 		}
 		cmd.Stdin.Close()
 	}()
 
-	return pointers, nil
+	return NewPointerChannelWrapper(pointers, errchan), nil
 }
 
 type wrappedCmd struct {
@@ -574,27 +627,29 @@ func ScanTree(ref string) ([]*WrappedPointer, error) {
 	}
 
 	pointers := make([]*WrappedPointer, 0)
-	for p := range pointerc {
+	for p := range pointerc.Results {
 		pointers = append(pointers, p)
 	}
+	err = pointerc.Wait()
 
-	return pointers, nil
+	return pointers, err
 }
 
 // catFileBatchTree uses git cat-file --batch to get the object contents
 // of a git object, given its sha1. The contents will be decoded into
 // a Git LFS pointer. treeblobs is a channel over which blob entries
 // will be sent. It returns a channel from which point.Pointers can be read.
-func catFileBatchTree(treeblobs chan TreeBlob) (chan *WrappedPointer, error) {
+func catFileBatchTree(treeblobs *TreeBlobChannelWrapper) (*PointerChannelWrapper, error) {
 	cmd, err := startCommand("git", "cat-file", "--batch")
 	if err != nil {
 		return nil, err
 	}
 
 	pointers := make(chan *WrappedPointer, chanBufSize)
+	errchan := make(chan error, 10) // Multiple errors possible
 
 	go func() {
-		for t := range treeblobs {
+		for t := range treeblobs.Results {
 			cmd.Stdin.Write([]byte(t.Sha1 + "\n"))
 			l, err := cmd.Stdout.ReadBytes('\n')
 			if err != nil {
@@ -627,19 +682,30 @@ func catFileBatchTree(treeblobs chan TreeBlob) (chan *WrappedPointer, error) {
 				break
 			}
 		}
+		// Deal with nested error from incoming treeblobs
+		err := treeblobs.Wait()
+		if err != nil {
+			errchan <- err
+		}
 
 		cmd.Stdin.Close()
-		cmd.Wait()
+
+		// also errors from our command
+		err = cmd.Wait()
+		if err != nil {
+			errchan <- err
+		}
 		close(pointers)
+		close(errchan)
 	}()
 
-	return pointers, nil
+	return NewPointerChannelWrapper(pointers, errchan), nil
 }
 
 // Use ls-tree at ref to find a list of candidate tree blobs which might be lfs files
 // The returned channel will be sent these blobs which should be sent to catFileBatchTree
 // for final check & conversion to Pointer
-func lsTreeBlobs(ref string) (chan TreeBlob, error) {
+func lsTreeBlobs(ref string) (*TreeBlobChannelWrapper, error) {
 	// Snapshot using ls-tree
 	lsArgs := []string{"ls-tree",
 		"-r",          // recurse
@@ -656,14 +722,19 @@ func lsTreeBlobs(ref string) (chan TreeBlob, error) {
 	cmd.Stdin.Close()
 
 	blobs := make(chan TreeBlob, chanBufSize)
+	errchan := make(chan error, 1)
 
 	go func() {
 		parseLsTree(cmd.Stdout, blobs)
-		cmd.Wait()
+		err := cmd.Wait()
+		if err != nil {
+			errchan <- err
+		}
 		close(blobs)
+		close(errchan)
 	}()
 
-	return blobs, nil
+	return NewTreeBlobChannelWrapper(blobs, errchan), nil
 }
 
 func parseLsTree(reader io.Reader, output chan TreeBlob) {
@@ -731,10 +802,11 @@ func ScanUnpushed(remoteName string) ([]*WrappedPointer, error) {
 		return nil, err
 	}
 	pointers := make([]*WrappedPointer, 0, 10)
-	for p := range pointerchan {
+	for p := range pointerchan.Results {
 		pointers = append(pointers, p)
 	}
-	return pointers, nil
+	err = pointerchan.Wait()
+	return pointers, err
 }
 
 // ScanPreviousVersions scans changes reachable from ref (commit) back to since.
@@ -751,24 +823,25 @@ func ScanPreviousVersions(ref string, since time.Time) ([]*WrappedPointer, error
 		return nil, err
 	}
 	pointers := make([]*WrappedPointer, 0, 10)
-	for p := range pointerchan {
+	for p := range pointerchan.Results {
 		pointers = append(pointers, p)
 	}
-	return pointers, nil
+	err = pointerchan.Wait()
+	return pointers, err
 
 }
 
 // ScanPreviousVersionsToChan scans changes reachable from ref (commit) back to since.
 // Returns channel of pointers for *previous* versions that overlap that time. Does not
 // include pointers which were still in use at ref (use ScanRefsToChan for that)
-func ScanPreviousVersionsToChan(ref string, since time.Time) (chan *WrappedPointer, error) {
+func ScanPreviousVersionsToChan(ref string, since time.Time) (*PointerChannelWrapper, error) {
 	return logPreviousSHAs(ref, since)
 }
 
 // ScanUnpushedToChan scans history for all LFS pointers which have been added but
 // not pushed to the named remote. remoteName can be left blank to mean 'any remote'
 // return progressively in a channel
-func ScanUnpushedToChan(remoteName string) (chan *WrappedPointer, error) {
+func ScanUnpushedToChan(remoteName string) (*PointerChannelWrapper, error) {
 	logArgs := []string{"log",
 		"--branches", "--tags", // include all locally referenced commits
 		"--not"} // but exclude everything that comes after
@@ -789,19 +862,25 @@ func ScanUnpushedToChan(remoteName string) (chan *WrappedPointer, error) {
 	cmd.Stdin.Close()
 
 	pchan := make(chan *WrappedPointer, chanBufSize)
+	errchan := make(chan error, 1)
 
 	go func() {
 		parseLogOutputToPointers(cmd.Stdout, LogDiffAdditions, nil, nil, pchan)
-		cmd.Wait()
+		err := cmd.Wait()
+		if err != nil {
+			errchan <- err
+		}
+		close(pchan)
+		close(errchan)
 	}()
 
-	return pchan, nil
+	return NewPointerChannelWrapper(pchan, errchan), nil
 
 }
 
 // logPreviousVersions scans history for all previous versions of LFS pointers
 // from 'since' up to (but not including) the final state at ref
-func logPreviousSHAs(ref string, since time.Time) (chan *WrappedPointer, error) {
+func logPreviousSHAs(ref string, since time.Time) (*PointerChannelWrapper, error) {
 	logArgs := []string{"log",
 		fmt.Sprintf("--since=%v", git.FormatGitDate(since)),
 	}
@@ -818,16 +897,22 @@ func logPreviousSHAs(ref string, since time.Time) (chan *WrappedPointer, error) 
 	cmd.Stdin.Close()
 
 	pchan := make(chan *WrappedPointer, chanBufSize)
+	errchan := make(chan error, 1)
 
 	// we pull out deletions, since we want the previous SHAs at commits in the range
 	// this means we pick up all previous versions that could have been checked
 	// out in the date range, not just if the commit which *introduced* them is in the range
 	go func() {
 		parseLogOutputToPointers(cmd.Stdout, LogDiffDeletions, nil, nil, pchan)
-		cmd.Wait()
+		err := cmd.Wait()
+		if err != nil {
+			errchan <- err
+		}
+		close(pchan)
+		close(errchan)
 	}()
 
-	return pchan, nil
+	return NewPointerChannelWrapper(pchan, errchan), nil
 
 }
 
@@ -844,7 +929,7 @@ const (
 // log: a stream of output from git log with at least logLfsSearchArgs specified
 // dir: whether to include results from + or - diffs
 // includePaths, excludePaths: filter the results by filename
-// results: a channel which will receive the pointers
+// results: a channel which will receive the pointers (caller must close)
 func parseLogOutputToPointers(log io.Reader, dir LogDiffDirection,
 	includePaths, excludePaths []string, results chan *WrappedPointer) {
 
@@ -930,7 +1015,72 @@ func parseLogOutputToPointers(log io.Reader, dir LogDiffDirection,
 	}
 	// Final pointer if in progress
 	finishLastPointer()
+}
 
-	close(results)
+// Interface for all types of wrapper around a channel of results and an error channel
+// Implementors will expose a type-specific channel for results
+// Call the Wait() function after processing the results channel to catch any errors
+// that occurred during the async processing
+type ChannelWrapper interface {
+	// Call this after processing results channel to check for async errors
+	Wait() error
+}
 
+// Base implementation of channel wrapper to just deal with errors
+type BaseChannelWrapper struct {
+	errorChan <-chan error
+}
+
+func (w *BaseChannelWrapper) Wait() error {
+
+	var err error
+	for e := range w.errorChan {
+		if err != nil {
+			// Combine in case multiple errors
+			err = fmt.Errorf("%v\n%v", err, e)
+
+		} else {
+			err = e
+		}
+	}
+
+	return err
+}
+
+// ChannelWrapper for pointer Scan* functions to more easily return async error data via Wait()
+// See NewPointerChannelWrapper for construction / use
+type PointerChannelWrapper struct {
+	*BaseChannelWrapper
+	Results <-chan *WrappedPointer
+}
+
+// Construct a new channel wrapper for WrappedPointer
+// Caller can use s.Pointers directly for normal processing then call Wait() to finish & check for errors
+// Scan function is required to create error channel large enough not to block (usually 1 is ok)
+func NewPointerChannelWrapper(pointerChan <-chan *WrappedPointer, errorChan <-chan error) *PointerChannelWrapper {
+	return &PointerChannelWrapper{&BaseChannelWrapper{errorChan}, pointerChan}
+}
+
+// ChannelWrapper for string channel functions to more easily return async error data via Wait()
+// See NewStringChannelWrapper for construction / use
+type StringChannelWrapper struct {
+	*BaseChannelWrapper
+	Results <-chan string
+}
+
+// Construct a new channel wrapper for string
+func NewStringChannelWrapper(stringChan <-chan string, errorChan <-chan error) *StringChannelWrapper {
+	return &StringChannelWrapper{&BaseChannelWrapper{errorChan}, stringChan}
+}
+
+// ChannelWrapper for TreeBlob channel functions to more easily return async error data via Wait()
+// See NewTreeBlobChannelWrapper for construction / use
+type TreeBlobChannelWrapper struct {
+	*BaseChannelWrapper
+	Results <-chan TreeBlob
+}
+
+// Construct a new channel wrapper for TreeBlob
+func NewTreeBlobChannelWrapper(treeBlobChan <-chan TreeBlob, errorChan <-chan error) *TreeBlobChannelWrapper {
+	return &TreeBlobChannelWrapper{&BaseChannelWrapper{errorChan}, treeBlobChan}
 }

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -376,7 +376,7 @@ func revListShas(refLeft, refRight string, opt *ScanRefsOptions) (*StringChannel
 			ambiguousRegex := regexp.MustCompile(`warning: refname (.*) is ambiguous`)
 			if match := ambiguousRegex.FindStringSubmatch(string(stderr)); match != nil {
 				// Promote to fatal & exit
-				errchan <- fmt.Errorf("Error: ref %q is ambiguous", match[1])
+				errchan <- fmt.Errorf("Error: ref %s is ambiguous", match[1])
 			}
 		}
 		close(revs)

--- a/lfs/scanner_test.go
+++ b/lfs/scanner_test.go
@@ -100,7 +100,10 @@ func TestParseLogOutputToPointersAdditions(t *testing.T) {
 	// test + diff, no filtering
 	r := strings.NewReader(pointerParseLogOutput)
 	pchan := make(chan *WrappedPointer, chanBufSize)
-	go parseLogOutputToPointers(r, LogDiffAdditions, nil, nil, pchan)
+	go func() {
+		parseLogOutputToPointers(r, LogDiffAdditions, nil, nil, pchan)
+		close(pchan)
+	}()
 	pointers := make([]*WrappedPointer, 0, 5)
 	for p := range pchan {
 		pointers = append(pointers, p)
@@ -132,7 +135,10 @@ func TestParseLogOutputToPointersAdditions(t *testing.T) {
 	r = strings.NewReader(pointerParseLogOutput)
 	pointers = pointers[:0]
 	pchan = make(chan *WrappedPointer, chanBufSize)
-	go parseLogOutputToPointers(r, LogDiffAdditions, []string{"wave*"}, nil, pchan)
+	go func() {
+		parseLogOutputToPointers(r, LogDiffAdditions, []string{"wave*"}, nil, pchan)
+		close(pchan)
+	}()
 	for p := range pchan {
 		pointers = append(pointers, p)
 	}
@@ -145,7 +151,10 @@ func TestParseLogOutputToPointersAdditions(t *testing.T) {
 	r = strings.NewReader(pointerParseLogOutput)
 	pointers = pointers[:0]
 	pchan = make(chan *WrappedPointer, chanBufSize)
-	go parseLogOutputToPointers(r, LogDiffAdditions, nil, []string{"wave*"}, pchan)
+	go func() {
+		parseLogOutputToPointers(r, LogDiffAdditions, nil, []string{"wave*"}, pchan)
+		close(pchan)
+	}()
 	for p := range pchan {
 		pointers = append(pointers, p)
 	}
@@ -170,7 +179,10 @@ func TestParseLogOutputToPointersDeletion(t *testing.T) {
 	// test - diff, no filtering
 	r := strings.NewReader(pointerParseLogOutput)
 	pchan := make(chan *WrappedPointer, chanBufSize)
-	go parseLogOutputToPointers(r, LogDiffDeletions, nil, nil, pchan)
+	go func() {
+		parseLogOutputToPointers(r, LogDiffDeletions, nil, nil, pchan)
+		close(pchan)
+	}()
 	pointers := make([]*WrappedPointer, 0, 5)
 	for p := range pchan {
 		pointers = append(pointers, p)
@@ -199,7 +211,10 @@ func TestParseLogOutputToPointersDeletion(t *testing.T) {
 	r = strings.NewReader(pointerParseLogOutput)
 	pointers = pointers[:0]
 	pchan = make(chan *WrappedPointer, chanBufSize)
-	go parseLogOutputToPointers(r, LogDiffDeletions, []string{"flare*"}, nil, pchan)
+	go func() {
+		parseLogOutputToPointers(r, LogDiffDeletions, []string{"flare*"}, nil, pchan)
+		close(pchan)
+	}()
 	for p := range pchan {
 		pointers = append(pointers, p)
 	}
@@ -212,7 +227,10 @@ func TestParseLogOutputToPointersDeletion(t *testing.T) {
 	r = strings.NewReader(pointerParseLogOutput)
 	pointers = pointers[:0]
 	pchan = make(chan *WrappedPointer, chanBufSize)
-	go parseLogOutputToPointers(r, LogDiffDeletions, nil, []string{"flare*"}, pchan)
+	go func() {
+		parseLogOutputToPointers(r, LogDiffDeletions, nil, []string{"flare*"}, pchan)
+		close(pchan)
+	}()
 	for p := range pchan {
 		pointers = append(pointers, p)
 	}


### PR DESCRIPTION
Fixes #1100 as well as surfacing a number of other fail states previously missed.

Wraps all scanner channels so that consumer only has to worry about primary results as channels, then check error result from `wrapper.Wait()` at the end to pick up any bad exit conditions (rather than having to handle 2 channels themselves).

Fixed a bunch of other issues while I was at it.