### PR TITLE
Allow for an access mechanism to be specified in the .lfsconfig file

### DIFF
--- a/lfs/config.go
+++ b/lfs/config.go
@@ -522,6 +522,8 @@ func (c *Configuration) readGitConfig(output string, uniqRemotes map[string]bool
 			allowed = true
 			remote := keyParts[1]
 			uniqRemotes[remote] = remote == "origin"
+		} else if len(keyParts) > 2 && keyParts[len(keyParts)-1] == "access" {
+			allowed = true
 		}
 
 		if !allowed && keyIsUnsafe(key) {

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -15,12 +15,25 @@ begin_test "default config"
 
   git config --file=.gitconfig lfs.url http://gitconfig-file-ignored
   git config --file=.lfsconfig lfs.url http://lfsconfig-file
+  git config --file=.lfsconfig lfs.http://lfsconfig-file.access lfsconfig
   git lfs env | tee env.log
-  grep "Endpoint=http://lfsconfig-file (auth=none)" env.log
+  grep "Endpoint=http://lfsconfig-file (auth=lfsconfig)" env.log
 
+  # new endpoint url from local git config
+  # access setting no longer applied
   git config lfs.url http://local-lfsconfig
   git lfs env | tee env.log
   grep "Endpoint=http://local-lfsconfig (auth=none)" env.log
+
+  # add the access setting to lfsconfig
+  git config --file=.lfsconfig lfs.http://local-lfsconfig.access lfsconfig
+  git lfs env | tee env.log
+  grep "Endpoint=http://local-lfsconfig (auth=lfsconfig)" env.log
+
+  # add the access setting to git config
+  git config lfs.http://local-lfsconfig.access gitconfig
+  git lfs env | tee env.log
+  grep "Endpoint=http://local-lfsconfig (auth=gitconfig)" env.log
 )
 end_test
 


### PR DESCRIPTION
I don't know if you want a change this simple, as I don't know the original intent, but as mentioned in issue #1121, I was hoping to describe the access of my LFS URL as "private" in the same .lfsconfig as where I define the URL itself.  I think it makes the most sense to have this data be co-resident.  However, git-lfs won't allow me to put this content in the .lfsconfig.  This simple change allows me to define it there.