### PR TITLE
tests for credentials in remote and lfs.url config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ env:
     - GIT_LFS_TEST_DIR="$HOME/git-lfs-tests"
 
 matrix:
+  fast_finish: true
+  allow_failures:
+    - os: osx
+    - go: 1.6
   include:
     - env: git-latest
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - os: osx
-    - go: 1.6
+      go: 1.6
   include:
     - env: git-latest
       os: linux

--- a/lfs/client.go
+++ b/lfs/client.go
@@ -527,7 +527,7 @@ func doHttpRequest(req *http.Request, creds Creds) (*http.Response, error) {
 func doApiRequestWithRedirects(req *http.Request, via []*http.Request, useCreds bool) (*http.Response, error) {
 	var creds Creds
 	if useCreds {
-		c, err := getCredsForAPI(req)
+		c, err := getCreds(req)
 		if err != nil {
 			return nil, err
 		}

--- a/lfs/credentials.go
+++ b/lfs/credentials.go
@@ -13,18 +13,7 @@ import (
 	"github.com/github/git-lfs/vendor/_nuts/github.com/rubyist/tracerx"
 )
 
-// getCreds gets the credentials for the given request's URL, and sets its
-// Authorization header with them using Basic Authentication. This is like
-// getCredsForAPI(), but skips checking the LFS url or git remote.
-func getCreds(req *http.Request) (Creds, error) {
-	if skipCredsCheck(req) {
-		return nil, nil
-	}
-
-	return fillCredentials(req, req.URL)
-}
-
-// getCredsForAPI gets the credentials for LFS API requests and sets the given
+// getCreds gets the credentials for LFS API requests and sets the given
 // request's Authorization header with them using Basic Authentication.
 // 1. Check the LFS URL for authentication. Ex: http://user:pass@example.com
 // 2. Check netrc for authentication.
@@ -35,7 +24,7 @@ func getCreds(req *http.Request) (Creds, error) {
 // This prefers the Git remote URL for checking credentials so that users only
 // have to enter their passwords once for Git and Git LFS. It uses the same
 // URL path that Git does, in case 'useHttpPath' is enabled in the Git config.
-func getCredsForAPI(req *http.Request) (Creds, error) {
+func getCreds(req *http.Request) (Creds, error) {
 	if skipCredsCheck(req) {
 		return nil, nil
 	}

--- a/lfs/credentials_test.go
+++ b/lfs/credentials_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGetCredentialsForApi(t *testing.T) {
-	checkGetCredentials(t, getCredsForAPI, []*getCredentialCheck{
+	checkGetCredentials(t, getCreds, []*getCredentialCheck{
 		{
 			Desc:     "simple",
 			Config:   map[string]string{"lfs.url": "https://git-server.com"},
@@ -107,47 +107,6 @@ func TestGetCredentialsForApi(t *testing.T) {
 			SkipAuth: true,
 		},
 	})
-}
-
-func TestGetCredentials(t *testing.T) {
-	checks := []*getCredentialCheck{
-		{
-			Desc:     "git server",
-			Method:   "GET",
-			Href:     "https://git-server.com/foo",
-			Protocol: "https",
-			Host:     "git-server.com",
-			Username: "git-server.com",
-			Password: "monkey",
-		},
-		{
-			Desc:     "separate lfs server",
-			Method:   "GET",
-			Href:     "https://lfs-server.com/foo",
-			Protocol: "https",
-			Host:     "lfs-server.com",
-			Username: "lfs-server.com",
-			Password: "monkey",
-		},
-		{
-			Desc:     "?token query",
-			Config:   map[string]string{"lfs.url": "https://git-server.com"},
-			Method:   "GET",
-			Href:     "https://git-server.com/foo?token=abc",
-			SkipAuth: true,
-		},
-	}
-
-	// these properties should not change the outcome
-	for _, check := range checks {
-		check.CurrentRemote = "origin"
-		check.Config = map[string]string{
-			"lfs.url":           "https://testuser:testuser@git-server.com",
-			"remote.origin.url": "https://gituser:gitpass@git-server.com",
-		}
-	}
-
-	checkGetCredentials(t, getCreds, checks)
 }
 
 func checkGetCredentials(t *testing.T, getCredsFunc func(*http.Request) (Creds, error), checks []*getCredentialCheck) {

--- a/lfs/ntlm.go
+++ b/lfs/ntlm.go
@@ -51,7 +51,7 @@ func DoNTLMRequest(request *http.Request, retry bool) (*http.Response, error) {
 	//If the status is 401 then we need to re-authenticate, otherwise it was successful
 	if res.StatusCode == 401 {
 
-		creds, err := getCredsForAPI(request)
+		creds, err := getCreds(request)
 		if err != nil {
 			return nil, err
 		}

--- a/script/integration.go
+++ b/script/integration.go
@@ -89,8 +89,8 @@ func runTest(output chan string, testname string) {
 		sendTestOutput(output, testname, buf, err)
 		return
 	case <-time.After(3 * time.Minute):
-		cmd.Process.Kill()
 		sendTestOutput(output, testname, buf, errors.New("Timed out"))
+		cmd.Process.Kill()
 		return
 	}
 
@@ -106,11 +106,12 @@ func sendTestOutput(output chan string, testname string, buf *bytes.Buffer, err 
 	if err == nil {
 		output <- cli
 	} else {
+		basetestname := filepath.Base(testname)
 		if debugging {
-			fmt.Printf("Error on %s: %s\n", testname, err)
+			fmt.Printf("Error on %s: %s\n", basetestname, err)
 		}
 		erroring = true
-		output <- fmt.Sprintf("error: %s => %s\n%s", testname, err, cli)
+		output <- fmt.Sprintf("error: %s => %s\n%s", basetestname, err, cli)
 	}
 }
 

--- a/script/integration.go
+++ b/script/integration.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 )
 
 var (
@@ -61,16 +64,54 @@ func mainIntegration() {
 	}
 }
 
-func runTest(output chan string, test string) {
-	out, err := exec.Command(bashPath, test).CombinedOutput()
+func runTest(output chan string, testname string) {
+	buf := &bytes.Buffer{}
+	cmd := exec.Command(bashPath, testname)
+	cmd.Stdout = buf
+	cmd.Stderr = buf
+
+	err := cmd.Start()
 	if err != nil {
-		if debugging {
-			fmt.Println("Error:", err)
-		}
-		erroring = true
+		sendTestOutput(output, testname, buf, err)
+		return
 	}
 
-	output <- strings.TrimSpace(string(out))
+	done := make(chan error)
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			done <- err
+		}
+		close(done)
+	}()
+
+	select {
+	case err = <-done:
+		sendTestOutput(output, testname, buf, err)
+		return
+	case <-time.After(3 * time.Minute):
+		cmd.Process.Kill()
+		sendTestOutput(output, testname, buf, errors.New("Timed out"))
+		return
+	}
+
+	sendTestOutput(output, testname, buf, nil)
+}
+
+func sendTestOutput(output chan string, testname string, buf *bytes.Buffer, err error) {
+	cli := strings.TrimSpace(buf.String())
+	if len(cli) == 0 {
+		cli = fmt.Sprintf("<no output for %s>", testname)
+	}
+
+	if err == nil {
+		output <- cli
+	} else {
+		if debugging {
+			fmt.Printf("Error on %s: %s\n", testname, err)
+		}
+		erroring = true
+		output <- fmt.Sprintf("error: %s => %s\n%s", testname, err, cli)
+	}
 }
 
 func printOutput(output <-chan string) {

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -277,6 +277,15 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, repo string) {
 		}
 	}
 
+	if repo == "requirecreds" {
+		user, pass, err := extractAuth(r.Header.Get("Authorization"))
+		if err != nil || (user != "requirecreds" || pass != "pass") {
+			w.Write([]byte("SUP"))
+			w.WriteHeader(403)
+			return
+		}
+	}
+
 	type batchReq struct {
 		Operation string      `json:"operation"`
 		Objects   []lfsObject `json:"objects"`
@@ -605,7 +614,7 @@ func skipIfBadAuth(w http.ResponseWriter, r *http.Request) bool {
 		if pass == "pass" {
 			return false
 		}
-	case "netrcuser":
+	case "netrcuser", "requirecreds":
 		return false
 	case "path":
 		if strings.HasPrefix(r.URL.Path, "/"+pass) {

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -277,15 +277,8 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, repo string) {
 		}
 	}
 
-	if repo == "requirecreds" {
-		auth := r.Header.Get("Authorization")
-		user, pass, err := extractAuth(auth)
-		if err != nil || (user != "requirecreds" || pass != "pass") {
-			errmsg := fmt.Sprintf("Got: '%s' => '%s' : '%s'", auth, user, pass)
-			w.Write([]byte(`{"message":"` + errmsg + `"}`))
-			w.WriteHeader(403)
-			return
-		}
+	if missingRequiredCreds(w, r, repo) {
+		return
 	}
 
 	type batchReq struct {
@@ -379,6 +372,10 @@ func storageHandler(w http.ResponseWriter, r *http.Request) {
 	repo := r.URL.Query().Get("r")
 	parts := strings.Split(r.URL.Path, "/")
 	oid := parts[len(parts)-1]
+
+	if missingRequiredCreds(w, r, repo) {
+		return
+	}
 
 	log.Printf("storage %s %s repo: %s\n", r.Method, oid, repo)
 	switch r.Method {
@@ -501,6 +498,29 @@ func redirect307Handler(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Location", redirectTo)
 	w.WriteHeader(307)
+}
+
+func missingRequiredCreds(w http.ResponseWriter, r *http.Request, repo string) bool {
+	if repo != "requirecreds" {
+		return false
+	}
+
+	auth := r.Header.Get("Authorization")
+	user, pass, err := extractAuth(auth)
+	if err != nil {
+		w.Write([]byte(`{"message":"` + err.Error() + `"}`))
+		w.WriteHeader(403)
+		return true
+	}
+
+	if user != "requirecreds" || pass != "pass" {
+		errmsg := fmt.Sprintf("Got: '%s' => '%s' : '%s'", auth, user, pass)
+		w.Write([]byte(`{"message":"` + errmsg + `"}`))
+		w.WriteHeader(403)
+		return true
+	}
+
+	return false
 }
 
 func testingChunkedTransferEncoding(r *http.Request) bool {

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -278,9 +278,11 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, repo string) {
 	}
 
 	if repo == "requirecreds" {
-		user, pass, err := extractAuth(r.Header.Get("Authorization"))
+		auth := r.Header.Get("Authorization")
+		user, pass, err := extractAuth(auth)
 		if err != nil || (user != "requirecreds" || pass != "pass") {
-			w.Write([]byte("SUP"))
+			errmsg := fmt.Sprintf("Got: '%s' => '%s' : '%s'", auth, user, pass)
+			w.Write([]byte(`{"message":"` + errmsg + `"}`))
 			w.WriteHeader(403)
 			return
 		}

--- a/test/test-credentials.sh
+++ b/test/test-credentials.sh
@@ -209,3 +209,48 @@ begin_test "credentials from netrc with bad password"
   [ "0" = "$(grep -c "(1 of 1 files)" push.log)" ]
 )
 end_test
+
+begin_test "credentials from lfs.url"
+(
+  set -e
+
+  reponame="requirecreds"
+  setup_remote_repo "$reponame"
+
+  clone_repo "$reponame" requirecreds-lfsurl
+  gitserverhost=$(echo "$GITSERVER" | cut -d'/' -f3)
+  git config lfs.url http://requirecreds:pass@$gitserverhost/$reponame.git/info/lfs
+  git lfs env
+
+  git lfs track "*.dat"
+  echo "push a" > a.dat
+  git add .gitattributes a.dat
+  git commit -m "add a.dat"
+
+  git lfs push origin master 2>&1 | tee push.log
+  grep "(1 of 1 files)" push.log
+)
+end_test
+
+begin_test "credentials from remote.origin.url"
+(
+  set -e
+
+  reponame="requirecreds"
+  setup_remote_repo "$reponame"
+
+  clone_repo "$reponame" requirecreds-remoteurl
+  gitserverhost=$(echo "$GITSERVER" | cut -d'/' -f3)
+  git config remote.origin.url http://requirecreds:pass@$gitserverhost/$reponame.git
+  git lfs env
+
+  git lfs track "*.dat"
+  echo "push b" > b.dat
+  git add .gitattributes b.dat
+  git commit -m "add b.dat"
+
+  git lfs push origin master 2>&1 | tee push.log
+  grep "(1 of 1 files)" push.log
+  exit 1
+)
+end_test

--- a/test/test-credentials.sh
+++ b/test/test-credentials.sh
@@ -216,19 +216,38 @@ begin_test "credentials from lfs.url"
 
   reponame="requirecreds"
   setup_remote_repo "$reponame"
-
   clone_repo "$reponame" requirecreds-lfsurl
-  gitserverhost=$(echo "$GITSERVER" | cut -d'/' -f3)
-  git config lfs.url http://requirecreds:pass@$gitserverhost/$reponame.git/info/lfs
-  git lfs env
 
   git lfs track "*.dat"
   echo "push a" > a.dat
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
+  echo "bad push"
+  git lfs env
+  git lfs push origin master 2>&1 | tee push.log
+  grep "(0 of 1 files)" push.log
+
+  echo "good push"
+  gitserverhost=$(echo "$GITSERVER" | cut -d'/' -f3)
+  git config lfs.url http://requirecreds:pass@$gitserverhost/$reponame.git/info/lfs
+  git lfs env
   git lfs push origin master 2>&1 | tee push.log
   grep "(1 of 1 files)" push.log
+
+  echo "bad fetch"
+  rm -rf .git/lfs/objects
+  git config lfs.url http://$gitserverhost/$reponame.git/info/lfs
+  git lfs env
+  git lfs fetch --all 2>&1 | tee fetch.log
+  grep "(0 of 1 files)" fetch.log
+
+  echo "good fetch"
+  rm -rf .git/lfs/objects
+  git config lfs.url http://requirecreds:pass@$gitserverhost/$reponame.git/info/lfs
+  git lfs env
+  git lfs fetch --all 2>&1 | tee fetch.log
+  grep "(1 of 1 files)" fetch.log
 )
 end_test
 
@@ -238,19 +257,37 @@ begin_test "credentials from remote.origin.url"
 
   reponame="requirecreds"
   setup_remote_repo "$reponame"
-
   clone_repo "$reponame" requirecreds-remoteurl
-  gitserverhost=$(echo "$GITSERVER" | cut -d'/' -f3)
-  git config remote.origin.url http://requirecreds:pass@$gitserverhost/$reponame.git
-  git lfs env
 
   git lfs track "*.dat"
   echo "push b" > b.dat
   git add .gitattributes b.dat
   git commit -m "add b.dat"
 
+  echo "bad push"
+  git lfs env
+  git lfs push origin master 2>&1 | tee push.log
+  grep "(0 of 1 files)" push.log
+
+  echo "good push"
+  gitserverhost=$(echo "$GITSERVER" | cut -d'/' -f3)
+  git config remote.origin.url http://requirecreds:pass@$gitserverhost/$reponame.git
+  git lfs env
   git lfs push origin master 2>&1 | tee push.log
   grep "(1 of 1 files)" push.log
-  exit 1
+
+  echo "bad fetch"
+  rm -rf .git/lfs/objects
+  git config remote.origin.url http://$gitserverhost/$reponame.git
+  git lfs env
+  git lfs fetch --all 2>&1 | tee fetch.log
+  grep "(0 of 1 files)" fetch.log
+
+  echo "good fetch"
+  rm -rf .git/lfs/objects
+  git config remote.origin.url http://requirecreds:pass@$gitserverhost/$reponame.git
+  git lfs env
+  git lfs fetch --all 2>&1 | tee fetch.log
+  grep "(1 of 1 files)" fetch.log
 )
 end_test


### PR DESCRIPTION
<del>Trying to replicate #906</del>

Replicated it with some more info. Running with `GIT_TRACE=1` showed me this:

```
trace git-lfs: HTTP: POST https://USER:PASS@git-lfs-server.com/repo.git/info/lfs/objects/batch
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: {"objects":[{"oid":"0000000000000000000000000000000000000000000000000000000000000000","size":1,"_links":{"download":{"href":"https://git-lfs-server.com/repo/info/lfs/objects/0000000000000000000000000000000000000000000000000000000000000000","header":{"Accept":"application/vnd.git-lfs"}}}}]}
trace git-lfs: HTTP:
Username for 'https://git-lfs-server.com':
```

The LFS client is authenticating `https://USER:PASS@git-lfs-server.com/repo.git/info/lfs/objects/batch` properly. However, the LFS server is not returning authenticated urls to the requested objects, like `https://git-lfs-server.com/repo/info/lfs/objects/0000000000000000000000000000000000000000000000000000000000000000`. This is undesirable, but should be easy enough to fix.