### PR TITLE
fix netrc matching when host has no port

### DIFF
--- a/lfs/credentials.go
+++ b/lfs/credentials.go
@@ -86,13 +86,27 @@ func getCredURLForAPI(req *http.Request) (*url.URL, error) {
 }
 
 func setCredURLFromNetrc(req *http.Request) bool {
-	host, _, err := net.SplitHostPort(req.URL.Host)
-	if err != nil {
-		return false
+	hostname := req.URL.Host
+	var host string
+
+	if strings.Contains(hostname, ":") {
+		var err error
+		host, _, err = net.SplitHostPort(hostname)
+		if err != nil {
+			tracerx.Printf("netrc: error parsing %q: %s", hostname, err)
+			return false
+		}
+	} else {
+		host = hostname
 	}
 
 	machine, err := Config.FindNetrcHost(host)
-	if err != nil || machine == nil {
+	if err != nil {
+		tracerx.Printf("netrc: error finding match for %q: %s", hostname, err)
+		return false
+	}
+
+	if machine == nil {
 		return false
 	}
 


### PR DESCRIPTION
Whew, glad I QA'd against a real server, and not just a local test one :)

The `net.SplitHostPort` function expects the host string to have a port (like `localhost:8008`). Currently, it blows up if you use a host on a standard http port.