### PR TITLE
Pass `git lfs clone` flags through to `git clone` correctly, respect some options

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -64,8 +64,8 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 	// Now just call pull with default args
 	lfs.Config.CurrentRemote = "origin" // always origin after clone
 
-	if cloneFlags.NoCheckout {
-		// If --no-checkout then we shouldn't check out, just fetch instead
+	if cloneFlags.NoCheckout || cloneFlags.Bare {
+		// If --no-checkout or --bare then we shouldn't check out, just fetch instead
 		fetchRef("HEAD", nil, nil)
 	} else {
 		pull(nil, nil)

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -63,7 +63,13 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 
 	// Now just call pull with default args
 	lfs.Config.CurrentRemote = "origin" // always origin after clone
-	pull(nil, nil)
+
+	if cloneFlags.NoCheckout {
+		// If --no-checkout then we shouldn't check out, just fetch instead
+		fetchRef("HEAD", nil, nil)
+	} else {
+		pull(nil, nil)
+	}
 
 }
 

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -16,12 +16,14 @@ var (
 		Use: "clone",
 		Run: cloneCommand,
 	}
+
+	cloneFlags git.CloneFlags
 )
 
 func cloneCommand(cmd *cobra.Command, args []string) {
 
 	// We pass all args to git clone
-	err := git.CloneWithoutFilters(args)
+	err := git.CloneWithoutFilters(cloneFlags, args)
 	if err != nil {
 		Exit("Error(s) during clone:\n%v", err)
 	}
@@ -66,5 +68,27 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
+	// Mirror all git clone flags
+	cloneCmd.Flags().StringVarP(&cloneFlags.TemplateDirectory, "template", "", "", "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.Local, "local", "l", false, "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.Shared, "shared", "s", false, "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.NoHardlinks, "no-hardlinks", "", false, "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.Quiet, "quiet", "q", false, "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.NoCheckout, "no-checkout", "n", false, "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.Progress, "progress", "", false, "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.Bare, "bare", "", false, "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.Mirror, "mirror", "", false, "See 'git clone --help'")
+	cloneCmd.Flags().StringVarP(&cloneFlags.Origin, "origin", "o", "", "See 'git clone --help'")
+	cloneCmd.Flags().StringVarP(&cloneFlags.Branch, "branch", "b", "", "See 'git clone --help'")
+	cloneCmd.Flags().StringVarP(&cloneFlags.Upload, "upload-pack", "u", "", "See 'git clone --help'")
+	cloneCmd.Flags().StringVarP(&cloneFlags.Reference, "reference", "", "", "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.Dissociate, "dissociate", "", false, "See 'git clone --help'")
+	cloneCmd.Flags().StringVarP(&cloneFlags.SeparateGit, "separate-git-dir", "", "", "See 'git clone --help'")
+	cloneCmd.Flags().StringVarP(&cloneFlags.Depth, "depth", "", "", "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.Recursive, "recursive", "", false, "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.RecurseSubmodules, "recurse-submodules", "", false, "See 'git clone --help'")
+	cloneCmd.Flags().StringVarP(&cloneFlags.Config, "config", "c", "", "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.SingleBranch, "single-branch", "", false, "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.NoSingleBranch, "no-single-branch", "", false, "See 'git clone --help'")
 	RootCmd.AddCommand(cloneCmd)
 }

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -90,5 +90,8 @@ func init() {
 	cloneCmd.Flags().StringVarP(&cloneFlags.Config, "config", "c", "", "See 'git clone --help'")
 	cloneCmd.Flags().BoolVarP(&cloneFlags.SingleBranch, "single-branch", "", false, "See 'git clone --help'")
 	cloneCmd.Flags().BoolVarP(&cloneFlags.NoSingleBranch, "no-single-branch", "", false, "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.Verbose, "verbose", "", false, "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.Ipv4, "ipv4", "", false, "See 'git clone --help'")
+	cloneCmd.Flags().BoolVarP(&cloneFlags.Ipv6, "ipv6", "", false, "See 'git clone --help'")
 	RootCmd.AddCommand(cloneCmd)
 }

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -62,7 +62,12 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 	requireInRepo()
 
 	// Now just call pull with default args
-	lfs.Config.CurrentRemote = "origin" // always origin after clone
+	// Support --origin option to clone
+	if len(cloneFlags.Origin) > 0 {
+		lfs.Config.CurrentRemote = cloneFlags.Origin
+	} else {
+		lfs.Config.CurrentRemote = "origin"
+	}
 
 	if cloneFlags.NoCheckout || cloneFlags.Bare {
 		// If --no-checkout or --bare then we shouldn't check out, just fetch instead

--- a/git/git.go
+++ b/git/git.go
@@ -701,6 +701,12 @@ type CloneFlags struct {
 	SingleBranch bool
 	// --no-single-branch
 	NoSingleBranch bool
+	// --verbose
+	Verbose bool
+	// --ipv4
+	Ipv4 bool
+	// --ipv6
+	Ipv6 bool
 }
 
 // CloneWithoutFilters clones a git repo but without the smudge filter enabled
@@ -735,6 +741,12 @@ func CloneWithoutFilters(flags CloneFlags, args []string) error {
 	}
 	if flags.Dissociate {
 		cmdargs = append(cmdargs, "--dissociate")
+	}
+	if flags.Ipv4 {
+		cmdargs = append(cmdargs, "--ipv4")
+	}
+	if flags.Ipv6 {
+		cmdargs = append(cmdargs, "--ipv6")
 	}
 	if flags.Local {
 		cmdargs = append(cmdargs, "--local")
@@ -783,6 +795,9 @@ func CloneWithoutFilters(flags CloneFlags, args []string) error {
 	}
 	if len(flags.Upload) > 0 {
 		cmdargs = append(cmdargs, "--upload-pack", flags.Upload)
+	}
+	if flags.Verbose {
+		cmdargs = append(cmdargs, "--verbose")
 	}
 
 	// Now args

--- a/git/git.go
+++ b/git/git.go
@@ -657,9 +657,55 @@ func IsVersionAtLeast(actualVersion, desiredVersion string) bool {
 	return actual >= atleast
 }
 
+// For compatibility with git clone we must mirror all flags in CloneWithoutFilters
+type CloneFlags struct {
+	// --template <template_directory>
+	TemplateDirectory string
+	// -l --local
+	Local bool
+	// -s --shared
+	Shared bool
+	// --no-hardlinks
+	NoHardlinks bool
+	// -q --quiet
+	Quiet bool
+	// -n --no-checkout
+	NoCheckout bool
+	// --progress
+	Progress bool
+	// --bare
+	Bare bool
+	// --mirror
+	Mirror bool
+	// -o <name> --origin <name>
+	Origin string
+	// -b <name> --branch <name>
+	Branch string
+	// -u <upload-pack> --upload-pack <pack>
+	Upload string
+	// --reference <repository>
+	Reference string
+	// --dissociate
+	Dissociate bool
+	// --separate-git-dir <git dir>
+	SeparateGit string
+	// --depth <depth>
+	Depth string
+	// --recursive
+	Recursive bool
+	// --recurse-submodules
+	RecurseSubmodules bool
+	// -c <value> --config <value>
+	Config string
+	// --single-branch
+	SingleBranch bool
+	// --no-single-branch
+	NoSingleBranch bool
+}
+
 // CloneWithoutFilters clones a git repo but without the smudge filter enabled
 // so that files in the working copy will be pointers and not real LFS data
-func CloneWithoutFilters(args []string) error {
+func CloneWithoutFilters(flags CloneFlags, args []string) error {
 
 	// Before git 2.2, setting filters to blank fails, so use cat instead (slightly slower)
 	filterOverride := ""
@@ -673,6 +719,73 @@ func CloneWithoutFilters(args []string) error {
 		"-c", fmt.Sprintf("filter.lfs.smudge=%v", filterOverride),
 		"-c", "filter.lfs.required=false",
 		"clone"}
+
+	// flags
+	if flags.Bare {
+		cmdargs = append(cmdargs, "--bare")
+	}
+	if len(flags.Branch) > 0 {
+		cmdargs = append(cmdargs, "--branch", flags.Branch)
+	}
+	if len(flags.Config) > 0 {
+		cmdargs = append(cmdargs, "--config", flags.Config)
+	}
+	if len(flags.Depth) > 0 {
+		cmdargs = append(cmdargs, "--depth", flags.Depth)
+	}
+	if flags.Dissociate {
+		cmdargs = append(cmdargs, "--dissociate")
+	}
+	if flags.Local {
+		cmdargs = append(cmdargs, "--local")
+	}
+	if flags.Mirror {
+		cmdargs = append(cmdargs, "--mirror")
+	}
+	if flags.NoCheckout {
+		cmdargs = append(cmdargs, "--no-checkout")
+	}
+	if flags.NoHardlinks {
+		cmdargs = append(cmdargs, "--no-hardlinks")
+	}
+	if flags.NoSingleBranch {
+		cmdargs = append(cmdargs, "--no-single-branch")
+	}
+	if len(flags.Origin) > 0 {
+		cmdargs = append(cmdargs, "--origin", flags.Origin)
+	}
+	if flags.Progress {
+		cmdargs = append(cmdargs, "--progress")
+	}
+	if flags.Quiet {
+		cmdargs = append(cmdargs, "--quiet")
+	}
+	if flags.Recursive {
+		cmdargs = append(cmdargs, "--recursive")
+	}
+	if flags.RecurseSubmodules {
+		cmdargs = append(cmdargs, "--recurse-submodules")
+	}
+	if len(flags.Reference) > 0 {
+		cmdargs = append(cmdargs, "--reference", flags.Reference)
+	}
+	if len(flags.SeparateGit) > 0 {
+		cmdargs = append(cmdargs, "--separate-git-dir", flags.SeparateGit)
+	}
+	if flags.Shared {
+		cmdargs = append(cmdargs, "--shared")
+	}
+	if flags.SingleBranch {
+		cmdargs = append(cmdargs, "--single-branch")
+	}
+	if len(flags.TemplateDirectory) > 0 {
+		cmdargs = append(cmdargs, "--template", flags.TemplateDirectory)
+	}
+	if len(flags.Upload) > 0 {
+		cmdargs = append(cmdargs, "--upload-pack", flags.Upload)
+	}
+
+	// Now args
 	cmdargs = append(cmdargs, args...)
 	cmd := subprocess.ExecCommand("git", cmdargs...)
 


### PR DESCRIPTION
Fixes #1155 

- `git lfs clone` now correctly passes through flags to `git clone`
- `--no-checkout` and `--bare` now cause `git lfs clone` to `git lfs fetch` rather than pull
- `--origin` option is respected and changes how lfs fetches/pulls after clone