### PR TITLE
Fix failure to return non-zero exit code when lfs install/update fails to install hooks

### DIFF
--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -24,7 +24,7 @@ func updateCommand(cmd *cobra.Command, args []string) {
 
 	if err := lfs.InstallHooks(updateForce); err != nil {
 		Error(err.Error())
-		Print("Run `git lfs update --force` to overwrite this hook.")
+		Exit("Run `git lfs update --force` to overwrite this hook.")
 	} else {
 		Print("Updated pre-push hook.")
 	}

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -22,13 +22,6 @@ var (
 func updateCommand(cmd *cobra.Command, args []string) {
 	requireInRepo()
 
-	if err := lfs.InstallHooks(updateForce); err != nil {
-		Error(err.Error())
-		Exit("Run `git lfs update --force` to overwrite this hook.")
-	} else {
-		Print("Updated pre-push hook.")
-	}
-
 	lfsAccessRE := regexp.MustCompile(`\Alfs\.(.*)\.access\z`)
 	for key, value := range lfs.Config.AllGitConfig() {
 		matches := lfsAccessRE.FindStringSubmatch(key)
@@ -46,6 +39,14 @@ func updateCommand(cmd *cobra.Command, args []string) {
 			Print("Removed invalid %s access of %s.", matches[1], value)
 		}
 	}
+
+	if err := lfs.InstallHooks(updateForce); err != nil {
+		Error(err.Error())
+		Exit("Run `git lfs update --force` to overwrite this hook.")
+	} else {
+		Print("Updated pre-push hook.")
+	}
+
 }
 
 func init() {

--- a/lfs/hook.go
+++ b/lfs/hook.go
@@ -105,7 +105,7 @@ func (h *Hook) matchesCurrent() (bool, error) {
 	}
 
 	contents := strings.TrimSpace(string(by))
-	if contents == h.Contents {
+	if contents == h.Contents || len(contents) == 0 {
 		return true, nil
 	}
 

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -83,6 +83,15 @@ Git LFS initialized."
   [ "$expected" = "$(git lfs install 2>&1)" ]
   [ "test" = "$(cat .git/hooks/pre-push)" ]
 
+  # Make sure returns non-zero
+  set +e
+  git lfs install
+  if [ $? -eq 0 ]
+  then
+    exit 1
+  fi
+  set -e
+
   # force replace unexpected hook
   [ "Updated pre-push hook.
 Git LFS initialized." = "$(git lfs install --force)" ]

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -75,8 +75,7 @@ Git LFS initialized." = "$(git lfs install)" ]
 
 test
 
-Run \`git lfs update --force\` to overwrite this hook.
-Git LFS initialized."
+Run \`git lfs update --force\` to overwrite this hook."
 
   echo "test" > .git/hooks/pre-push
   [ "test" = "$(cat .git/hooks/pre-push)" ]

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -39,6 +39,12 @@ git lfs pre-push \"\$@\"" > .git/hooks/pre-push
   [ "Updated pre-push hook." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
+  # replace blank hook
+  rm .git/hooks/pre-push
+  touch .git/hooks/pre-push
+  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
+
   # replace old hook 4
   echo "#!/bin/sh
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 0; }

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -64,6 +64,15 @@ Run \`git lfs update --force\` to overwrite this hook."
   [ "$expected" = "$(git lfs update 2>&1)" ]
   [ "test" = "$(cat .git/hooks/pre-push)" ]
 
+  # Make sure returns non-zero
+  set +e
+  git lfs update
+  if [ $? -eq 0 ]
+  then
+    exit 1
+  fi
+  set -e
+
   # force replace unexpected hook
   [ "Updated pre-push hook." = "$(git lfs update --force)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]


### PR DESCRIPTION
Fixes #1174 

Also tidies up the output a little and automatically replaces blank pre-push hooks now.