### PR TITLE
Changelog after v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Git LFS Changelog
 
+## Next
+
+* Pass `git lfs clone` flags through to `git clone` properly. [#1160](https://github.com/github/git-lfs/pull/1160) (@sinbad)
+
 ## 1.2.0 (14 April 2016)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Return non-zero exit code when `git lfs install/update` fails to install hooks #1178 (@sinbad)
 * Fix problems with user prompts in `git lfs clone` #1185 (@sinbad)
 * fix concurrent map read and map write #1179 (@technoweenie)
+* `git lfs update` now has a `--manual` flag to assist with merging hooks #1182 (@sinbad)
 
 ## 1.2.0 (14 April 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Pass `git lfs clone` flags through to `git clone` properly. #1160 (@sinbad)
 * Return non-zero exit code when `git lfs install/update` fails to install hooks #1178 (@sinbad)
+* Fix problems with user prompts in `git lfs clone` #1185 (@sinbad)
 
 ## 1.2.0 (14 April 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-* Pass `git lfs clone` flags through to `git clone` properly. [#1160](https://github.com/github/git-lfs/pull/1160) (@sinbad)
+* Pass `git lfs clone` flags through to `git clone` properly. #1160 (@sinbad)
 
 ## 1.2.0 (14 April 2016)
 
@@ -22,7 +22,7 @@
 * Fix silent failure to push LFS objects when ref matches a filename in the working copy #1096 (@epriestley)
 * Fix problems with using LFS in symlinked folders #818 (@sinbad)
 * Fix git lfs push silently misbehaving on ambiguous refs; fail like git push instead #1118 (@sinbad)
-* Whitelist lfs.*.access config in local ~/.lfsconfig #1122 (@rjbell4)
+* Whitelist `lfs.*.access` config in local ~/.lfsconfig #1122 (@rjbell4)
 * Only write the encoded pointer information to Stdout #1105 (@sschuberth)
 * Use hardcoded auth from remote or lfs config when accessing the storage api #1136 (@technoweenie, @jonmagic)
 * SSH should be called more strictly with command as one argument #1134 (@sinbad)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Pass `git lfs clone` flags through to `git clone` properly. #1160 (@sinbad)
 * Return non-zero exit code when `git lfs install/update` fails to install hooks #1178 (@sinbad)
 * Fix problems with user prompts in `git lfs clone` #1185 (@sinbad)
+* fix concurrent map read and map write #1179 (@technoweenie)
 
 ## 1.2.0 (14 April 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix problems with user prompts in `git lfs clone` #1185 (@sinbad)
 * fix concurrent map read and map write #1179 (@technoweenie)
 * `git lfs update` now has a `--manual` flag to assist with merging hooks #1182 (@sinbad)
+* Added `lfs.skipdownloaderrors` config setting and `GIT_LFS_SKIP_DOWNLOAD_ERRORS` env var to allow smudge to continue on download fail #1213 (@sinbad)
 
 ## 1.2.0 (14 April 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 * Pass `git lfs clone` flags through to `git clone` properly. #1160 (@sinbad)
+* Return non-zero exit code when `git lfs install/update` fails to install hooks
 
 ## 1.2.0 (14 April 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next
 
 * Pass `git lfs clone` flags through to `git clone` properly. #1160 (@sinbad)
-* Return non-zero exit code when `git lfs install/update` fails to install hooks
+* Return non-zero exit code when `git lfs install/update` fails to install hooks #1178 (@sinbad)
 
 ## 1.2.0 (14 April 2016)
 


### PR DESCRIPTION
I'm trying a new thing. Previously, I created an issue [like this](https://github.com/github/git-lfs/issues/844) to track changes for the upcoming version. By making a PR against the readme, we remove any need to do any markdown cleanup with the release notes, and we rely on git to keep a history of changes to this changelog.

If we have any TODOs for upcoming releases, they can still be added as task list items to this PR thread. Only completed things will go in the changelog.

* [ ] Add --system config commands, elevate install config to system scope when root/packaged #1177 (@javabrett)
* [x] Fix user prompts in `git lfs clone` #1159 (@sinbad)
* [x] Improve guidance on how to resolve a failure of `git lfs install` because of existing hooks (@sinbad)
https://github.com/github/git-lfs/pull/1117
* [ ] Account for url.<url>.insteadOf in all operations #1117