### PR TITLE
Add `git lfs update --manual` option & promote it on hook install fail

### DIFF
--- a/docs/man/git-lfs-update.1.ronn
+++ b/docs/man/git-lfs-update.1.ronn
@@ -3,12 +3,25 @@ git-lfs-update(1) -- Update Git hooks
 
 ## SYNOPSIS
 
-`git lfs update` [--force]
+`git lfs update` [--manual | --force]
 
 ## DESCRIPTION
 
 Updates the Git hooks used by Git LFS. Silently upgrades known hook contents.
-Pass `--force` to upgrade the hooks, clobbering any existing contents.
+If you have your own custom hooks you may need to use one of the extended
+options below.
+
+## OPTIONS
+
+* `--manual` `-m`
+    Print instructions for manually updating your hooks to include git-lfs 
+    functionality. Use this option if `git lfs update` fails because of existing
+    hooks and you want to retain their functionality.
+
+* `--force` `-f`
+    Forcibly overwrite any existing hooks with git-lfs hooks. Use this option
+    if `git lfs update` fails because of existing hooks but you don't care
+    about their current contents.
 
 ## SEE ALSO
 

--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -1,5 +1,10 @@
 package lfs
 
+import (
+	"bytes"
+	"fmt"
+)
+
 var (
 	// prePushHook invokes `git lfs push` at the pre-push phase.
 	prePushHook = &Hook{
@@ -36,6 +41,18 @@ var (
 		},
 	}
 )
+
+// Get user-readable manual install steps for hooks
+func GetHookInstallSteps() string {
+
+	var buf bytes.Buffer
+	for _, h := range hooks {
+		buf.WriteString(fmt.Sprintf("Add the following to .git/hooks/%s :\n\n", h.Type))
+		buf.WriteString(h.Contents)
+		buf.WriteString("\n")
+	}
+	return buf.String()
+}
 
 // InstallHooks installs all hooks in the `hooks` var.
 func InstallHooks(force bool) error {

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -75,7 +75,9 @@ Git LFS initialized." = "$(git lfs install)" ]
 
 test
 
-Run \`git lfs update --force\` to overwrite this hook."
+To resolve this, either:
+  1: run \`git lfs update --manual\` for instructions on how to merge hooks.
+  2: run \`git lfs update --force\` to overwrite your hook."
 
   echo "test" > .git/hooks/pre-push
   [ "test" = "$(cat .git/hooks/pre-push)" ]

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -65,7 +65,9 @@ git lfs pre-push \"$@\""
 
 test
 
-Run \`git lfs update --force\` to overwrite this hook."
+To resolve this, either:
+  1: run \`git lfs update --manual\` for instructions on how to merge hooks.
+  2: run \`git lfs update --force\` to overwrite your hook."
 
   [ "$expected" = "$(git lfs update 2>&1)" ]
   [ "test" = "$(cat .git/hooks/pre-push)" ]
@@ -78,6 +80,16 @@ Run \`git lfs update --force\` to overwrite this hook."
     exit 1
   fi
   set -e
+
+  # test manual steps
+  expected="Add the following to .git/hooks/pre-push :
+
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-push.\n\"; exit 2; }
+git lfs pre-push \"\$@\""
+
+  [ "$expected" = "$(git lfs update --manual 2>&1)" ]
+  [ "test" = "$(cat .git/hooks/pre-push)" ]
 
   # force replace unexpected hook
   [ "Updated pre-push hook." = "$(git lfs update --force)" ]


### PR DESCRIPTION
Related to #1174 

As discussed in chat, implemented as a command option rather than in docs so that we don't have to maintain the hook script in more than one location.