### PR TITLE
Applied same -ldflags -X name value -> name=value fix as in a62e510f.

### DIFF
--- a/script/run
+++ b/script/run
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 script/fmt
 commit=`git rev-parse --short HEAD`
-GO15VENDOREXPERIMENT=0 go run -ldflags="-X github.com/github/git-lfs/lfs.GitCommit $commit" ./git-lfs.go "$@"
+GO15VENDOREXPERIMENT=0 go run -ldflags="-X github.com/github/git-lfs/lfs.GitCommit=$commit" ./git-lfs.go "$@"


### PR DESCRIPTION
Squashes script/run warning:
link: warning: option -X github.com/github/git-lfs/lfs.GitCommit 54c5efa may not work in future releases; use -X github.com/github/git-lfs/lfs.GitCommit=54c5efa