### PR TITLE
Fix installer error on win32.

### DIFF
--- a/script/windows-installer/inno-setup-git-lfs-installer.iss
+++ b/script/windows-installer/inno-setup-git-lfs-installer.iss
@@ -68,7 +68,7 @@ begin
   if LoadStringFromFile(TmpFileName, ExecStdOut) then begin
       if not (Pos('Git\cmd', ExtractFilePath(ExecStdOut)) = 0) then begin
         // Proxy Git path detected
-        Result := ExpandConstant('{pf64}')+'\Git\mingw64\bin';
+        Result := ExpandConstant('{pf}')+'\Git\mingw64\bin';
       end else begin
         Result := ExtractFilePath(ExecStdOut);
       end;


### PR DESCRIPTION
On 32-bit versions of Windows (in my case, Windows XP), the windows installer fails because it cannot expand the "pf64"constant.

By changing this very constant to "pf", it gets resolved properly on all versions of Windows.

See http://www.jrsoftware.org/ishelp/index.php?topic=consts for further explanation of the constants.