### PR TITLE
Fix bug in Windows installer under Win32.

### DIFF
--- a/script/windows-installer/inno-setup-git-lfs-installer.iss
+++ b/script/windows-installer/inno-setup-git-lfs-installer.iss
@@ -68,7 +68,11 @@ begin
   if LoadStringFromFile(TmpFileName, ExecStdOut) then begin
       if not (Pos('Git\cmd', ExtractFilePath(ExecStdOut)) = 0) then begin
         // Proxy Git path detected
-        Result := ExpandConstant('{pf}')+'\Git\mingw64\bin';
+        Result := ExpandConstant('{pf}');
+      if Is64BitInstallMode then
+        Result := Result + '\Git\mingw64\bin'
+      else
+        Result := Result + '\Git\mingw32\bin';
       end else begin
         Result := ExtractFilePath(ExecStdOut);
       end;


### PR DESCRIPTION
In a previous pull request I submitted, there was an error.
The installer would write to a "mingw64" directory even on 32-bit versions of Windows.
With this patch, the installer will write to the correct "mingw32" directory under Win32.