### PR TITLE
Create Makefiles for building with gccgo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 benchmark/
+out/
 
 # only allow man/*.\d.ronn files
 man/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+GOC ?= gccgo
+AR ?= ar
+
+SRCDIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
+LIBDIR := out/github.com/github/git-lfs
+GOFLAGS := -Iout
+
+ifeq ($(MAKEFILE_GEN),)
+
+MAKEFILE_GEN := out/Makefile.gen
+
+all: $(MAKEFILE_GEN)
+	@$(MAKE) -f $(lastword $(MAKEFILE_LIST)) $(MAKEFLAGS) MAKEFILE_GEN=$(MAKEFILE_GEN) $@
+
+$(MAKEFILE_GEN) : out/genmakefile $(SRCDIR)commands/mancontent_gen.go
+	@mkdir -p $(dir $@)
+	$< "$(SRCDIR)" github.com/github/git-lfs/ > $@
+
+else
+
+all : bin/git-lfs
+
+include $(MAKEFILE_GEN)
+
+$(LIBDIR)/git-lfs.o : $(SRC_main) $(DEPS_main)
+	@mkdir -p $(dir $@)
+	$(GOC) $(GOFLAGS) -c -o $@ $(SRC_main)
+
+bin/git-lfs : $(LIBDIR)/git-lfs.o $(DEPS_main)
+	@mkdir -p $(dir $@)
+	$(GOC) $(GOFLAGS) -o $@ $^
+
+%.a : %.o
+	$(AR) rc $@ $<
+
+endif
+
+$(SRCDIR)commands/mancontent_gen.go : out/mangen
+	cd $(SRCDIR)commands && $(CURDIR)/out/mangen
+
+out/mangen : $(SRCDIR)docs/man/mangen.go
+	@mkdir -p $(dir $@)
+	$(GOC) -o $@ $<
+
+out/genmakefile : $(SRCDIR)script/genmakefile/genmakefile.go
+	@mkdir -p $(dir $@)
+	$(GOC) -o $@ $<
+
+clean :
+	rm -rf out bin
+	rm -f $(SRCDIR)commands/mancontent_gen.go

--- a/script/genmakefile/genmakefile.go
+++ b/script/genmakefile/genmakefile.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"go/build"
+	"os"
+	"strings"
+)
+
+var packages map[string]string = make(map[string]string)
+
+func generate_target(srcdir string, pkgdir string, prefix string, ctx build.Context) string {
+	pkg, _ := ctx.ImportDir(srcdir+pkgdir, 0)
+	name := pkg.Name
+	var deps []string
+	for _, imp := range pkg.Imports {
+		if strings.HasPrefix(imp, prefix) {
+			imp = strings.TrimPrefix(imp, prefix)
+			if packages[imp] == "" {
+				packages[imp] = generate_target(srcdir, imp, prefix, ctx)
+			}
+			deps = append(deps, "$(LIBS_"+packages[imp]+")")
+		}
+	}
+	if pkgdir != "" {
+		fmt.Printf("SRCDIR_%s := $(SRCDIR)%s/\n", name, pkgdir)
+	} else {
+		fmt.Printf("SRCDIR_%s := $(SRCDIR)\n", name)
+	}
+	fmt.Printf("SRC_%s := $(addprefix $(SRCDIR_%s), %s)\n", name, name, strings.Join(pkg.GoFiles, " "))
+	fmt.Printf("DEPS_%s := %s\n", name, strings.Join(deps, " "))
+	if pkgdir != "" {
+		fmt.Printf("OBJ_%s := $(LIBDIR)/%s.o\n", name, pkgdir)
+		fmt.Printf("LIB_%s := $(LIBDIR)/%s.a\n", name, pkgdir)
+		fmt.Printf("LIBS_%s := $(LIB_%s) $(DEPS_%s)\n", name, name, name)
+		fmt.Printf("$(OBJ_%s) : $(SRC_%s) $(DEPS_%s)\n", name, name, name)
+		fmt.Printf("\t@mkdir -p $(dir $@)\n")
+		fmt.Printf("\t$(GOC) $(GOFLAGS) -c -o $@ $(SRC_%s)\n", name)
+	}
+	return name
+}
+
+func main() {
+	srcdir := os.Args[1]
+	prefix := os.Args[2]
+	ctx := build.Default
+	ctx.CgoEnabled = false
+	generate_target(srcdir, "", prefix, ctx)
+}


### PR DESCRIPTION
This pull request adds the ability to build git-lfs with gccgo simply by typing "make".  No "go" command is required.