### PR TITLE
update test suite so it runs outside of a git repo

### DIFF
--- a/git/git_test.go
+++ b/git/git_test.go
@@ -3,8 +3,10 @@ package git_test // to avoid import cycles
 import (
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -277,7 +279,12 @@ func TestVersionCompare(t *testing.T) {
 func TestGitAndRootDirs(t *testing.T) {
 	git, root, err := GitAndRootDirs()
 	if err != nil {
-		t.Fatal(err)
+		errmsg := err.Error()
+		if strings.Contains(errmsg, "Not a git repository") {
+			t.Skip("Not a git repository")
+		} else {
+			t.Fatal(errmsg)
+		}
 	}
 
 	assert.Equal(t, git, filepath.Join(root, ".git"))
@@ -382,6 +389,9 @@ func TestGetTrackedFiles(t *testing.T) {
 func TestLocalRefs(t *testing.T) {
 	refs, err := LocalRefs()
 	if err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			t.Skip("Not a git repository")
+		}
 		t.Fatal(err)
 	}
 

--- a/lfs/upload_test.go
+++ b/lfs/upload_test.go
@@ -106,7 +106,7 @@ func TestExistingUpload(t *testing.T) {
 	defer Config.ResetConfig()
 	Config.SetConfig("lfs.url", server.URL+"/media")
 
-	oidPath, _ := LocalMediaPath("988881adc9fc3655077dc2d4d757d480b5ea0e11")
+	oidPath := uploadMediaPath(t, "988881adc9fc3655077dc2d4d757d480b5ea0e11")
 	if err := ioutil.WriteFile(oidPath, []byte("test"), 0744); err != nil {
 		t.Fatal(err)
 	}
@@ -233,7 +233,7 @@ func TestUploadWithRedirect(t *testing.T) {
 	defer Config.ResetConfig()
 	Config.SetConfig("lfs.url", server.URL+"/redirect")
 
-	oidPath, _ := LocalMediaPath("988881adc9fc3655077dc2d4d757d480b5ea0e11")
+	oidPath := uploadMediaPath(t, "988881adc9fc3655077dc2d4d757d480b5ea0e11")
 	if err := ioutil.WriteFile(oidPath, []byte("test"), 0744); err != nil {
 		t.Fatal(err)
 	}
@@ -410,7 +410,7 @@ func TestSuccessfulUploadWithVerify(t *testing.T) {
 	defer Config.ResetConfig()
 	Config.SetConfig("lfs.url", server.URL+"/media")
 
-	oidPath, _ := LocalMediaPath("988881adc9fc3655077dc2d4d757d480b5ea0e11")
+	oidPath := uploadMediaPath(t, "988881adc9fc3655077dc2d4d757d480b5ea0e11")
 	if err := ioutil.WriteFile(oidPath, []byte("test"), 0744); err != nil {
 		t.Fatal(err)
 	}
@@ -574,7 +574,7 @@ func TestSuccessfulUploadWithoutVerify(t *testing.T) {
 	defer Config.ResetConfig()
 	Config.SetConfig("lfs.url", server.URL+"/media")
 
-	oidPath, _ := LocalMediaPath("988881adc9fc3655077dc2d4d757d480b5ea0e11")
+	oidPath := uploadMediaPath(t, "988881adc9fc3655077dc2d4d757d480b5ea0e11")
 	if err := ioutil.WriteFile(oidPath, []byte("test"), 0744); err != nil {
 		t.Fatal(err)
 	}
@@ -622,7 +622,7 @@ func TestUploadApiError(t *testing.T) {
 	defer Config.ResetConfig()
 	Config.SetConfig("lfs.url", server.URL+"/media")
 
-	oidPath, _ := LocalMediaPath("988881adc9fc3655077dc2d4d757d480b5ea0e11")
+	oidPath := uploadMediaPath(t, "988881adc9fc3655077dc2d4d757d480b5ea0e11")
 	if err := ioutil.WriteFile(oidPath, []byte("test"), 0744); err != nil {
 		t.Fatal(err)
 	}
@@ -734,7 +734,7 @@ func TestUploadStorageError(t *testing.T) {
 	defer Config.ResetConfig()
 	Config.SetConfig("lfs.url", server.URL+"/media")
 
-	oidPath, _ := LocalMediaPath("988881adc9fc3655077dc2d4d757d480b5ea0e11")
+	oidPath := uploadMediaPath(t, "988881adc9fc3655077dc2d4d757d480b5ea0e11")
 	if err := ioutil.WriteFile(oidPath, []byte("test"), 0744); err != nil {
 		t.Fatal(err)
 	}
@@ -886,7 +886,7 @@ func TestUploadVerifyError(t *testing.T) {
 	defer Config.ResetConfig()
 	Config.SetConfig("lfs.url", server.URL+"/media")
 
-	oidPath, _ := LocalMediaPath("988881adc9fc3655077dc2d4d757d480b5ea0e11")
+	oidPath := uploadMediaPath(t, "988881adc9fc3655077dc2d4d757d480b5ea0e11")
 	if err := ioutil.WriteFile(oidPath, []byte("test"), 0744); err != nil {
 		t.Fatal(err)
 	}
@@ -922,4 +922,12 @@ func TestUploadVerifyError(t *testing.T) {
 	if !verifyCalled {
 		t.Errorf("verify not called")
 	}
+}
+
+func uploadMediaPath(t *testing.T, oid string) string {
+	if objects == nil {
+		t.Skip("Not in a git repository")
+	}
+	oidPath, _ := LocalMediaPath(oid)
+	return oidPath
 }


### PR DESCRIPTION
Fixes #1202 by skipping any tests that fail:

```bash
$ GO15VENDOREXPERIMENT=0 go test ./lfs ./git -v
=== RUN   TestExistingUpload
--- SKIP: TestExistingUpload (0.00s)
	upload_test.go:929: Not in a git repository
=== RUN   TestUploadWithRedirect
--- SKIP: TestUploadWithRedirect (0.00s)
	upload_test.go:929: Not in a git repository
=== RUN   TestSuccessfulUploadWithVerify
--- SKIP: TestSuccessfulUploadWithVerify (0.00s)
	upload_test.go:929: Not in a git repository
=== RUN   TestSuccessfulUploadWithoutVerify
--- SKIP: TestSuccessfulUploadWithoutVerify (0.00s)
	upload_test.go:929: Not in a git repository
=== RUN   TestUploadApiError
--- SKIP: TestUploadApiError (0.00s)
	upload_test.go:929: Not in a git repository
=== RUN   TestUploadStorageError
--- SKIP: TestUploadStorageError (0.00s)
	upload_test.go:929: Not in a git repository
=== RUN   TestUploadVerifyError
--- SKIP: TestUploadVerifyError (0.00s)
	upload_test.go:929: Not in a git repository
```

I'm not crazy about it, but it at least unblocks #1201. The upload tests are all using the legacy LFS API, so I don't think it's worth our time to update them. The newer LFS Batch API is tested primarily through the integration test suite.

Maybe in #1201's implementation, `script/cibuild` can run tests against a repo-less source directory when given a special ENV var, so it can be added to the suite of Travis tests in `.travis.yml`. This would catch future regressions.

/cc @javabrett @sinbad