### PR TITLE
get git tests passing when run outside of repository

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -184,9 +184,13 @@ func LocalRefs() ([]*Ref, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to call git show-ref: %v", err)
 	}
-	cmd.Start()
 
 	var refs []*Ref
+
+	if err := cmd.Start(); err != nil {
+		return refs, err
+	}
+
 	scanner := bufio.NewScanner(outp)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())


### PR DESCRIPTION
This uses `NewRepo()` so that these 2 tests run identically from a git clone and from a plain source dump. Should fix #1202 

/cc @sinbad @javabrett 