### PR TITLE
Return a fully remote ref to reduce chances of ref clashes

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -116,7 +116,8 @@ func RemoteForCurrentBranch() (string, error) {
 	return remote, nil
 }
 
-// RemoteRefForCurrentBranch returns the full remote ref (remote/remotebranch) that the current branch is tracking
+// RemoteRefForCurrentBranch returns the full remote ref (refs/remotes/{remote}/{remotebranch})
+// that the current branch is tracking.
 func RemoteRefNameForCurrentBranch() (string, error) {
 	ref, err := CurrentRef()
 	if err != nil {
@@ -134,7 +135,7 @@ func RemoteRefNameForCurrentBranch() (string, error) {
 
 	remotebranch := RemoteBranchForLocalBranch(ref.Name)
 
-	return remote + "/" + remotebranch, nil
+	return fmt.Sprintf("refs/remotes/%s/%s", remote, remotebranch), nil
 }
 
 // RemoteForBranch returns the remote name that a given local branch is tracking (blank if none)

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -66,7 +66,7 @@ func TestCurrentRefAndCurrentRemoteRef(t *testing.T) {
 
 	refname, err := RemoteRefNameForCurrentBranch()
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "origin/someremotebranch", refname)
+	assert.Equal(t, "refs/remotes/origin/someremotebranch", refname)
 
 	remote, err := RemoteForCurrentBranch()
 	assert.Equal(t, nil, err)


### PR DESCRIPTION
Returning simply `{remote}/{branch}` doesn't help if someone creates a local branch `refs/heads/master/{remote}/{branch}`. This `RemoteRefNameForCurrentBranch()` function is only used for `ResolveRef()`. `git rev-parse` can definitely handle full refs.