### PR TITLE
api: add Force option to unlock requests

### DIFF
--- a/api/lock_api.go
+++ b/api/lock_api.go
@@ -80,22 +80,19 @@ func (s *LockService) Search(req *LockSearchRequest) (*RequestSchema, *LockList)
 }
 
 // Unlock generates a *RequestSchema that is used to preform the "unlock" API
-// method.
-//
-// It generates a bodyless request that simply directs to POST
-// /locks/:id/unlock.
+// method, against a particular lock potentially with --force.
 //
 // This method's corresponding response type will either contain a reference to
 // the lock that was unlocked, or an error that was experienced by the server in
 // unlocking it.
-func (s *LockService) Unlock(req *UnlockRequest) (*RequestSchema, *UnlockResponse) {
+func (s *LockService) Unlock(id string, force bool) (*RequestSchema, *UnlockResponse) {
 	var resp UnlockResponse
 
 	return &RequestSchema{
 		Method:    "POST",
-		Path:      fmt.Sprintf("/locks/%s/unlock", req.Id),
+		Path:      fmt.Sprintf("/locks/%s/unlock", id),
 		Operation: UploadOperation,
-		Body:      req,
+		Body:      &UnlockRequest{id, force},
 		Into:      &resp,
 	}, &resp
 }

--- a/api/lock_api.go
+++ b/api/lock_api.go
@@ -88,13 +88,14 @@ func (s *LockService) Search(req *LockSearchRequest) (*RequestSchema, *LockList)
 // This method's corresponding response type will either contain a reference to
 // the lock that was unlocked, or an error that was experienced by the server in
 // unlocking it.
-func (s *LockService) Unlock(l *Lock) (*RequestSchema, *UnlockResponse) {
+func (s *LockService) Unlock(req *UnlockRequest) (*RequestSchema, *UnlockResponse) {
 	var resp UnlockResponse
 
 	return &RequestSchema{
 		Method:    "POST",
-		Path:      fmt.Sprintf("/locks/%s/unlock", l.Id),
+		Path:      fmt.Sprintf("/locks/%s/unlock", req.Id),
 		Operation: UploadOperation,
+		Body:      req,
 		Into:      &resp,
 	}, &resp
 }
@@ -179,6 +180,16 @@ type LockResponse struct {
 	// Err is the optional error that was encountered while trying to create
 	// the above lock.
 	Err string `json:"error,omitempty"`
+}
+
+// UnlockRequest encapsulates the data sent in an API request to remove a lock.
+type UnlockRequest struct {
+	// Id is the Id of the lock that the user wishes to unlock.
+	Id string `json:"id"`
+	// Force determines whether or not the lock should be "forcibly"
+	// unlocked; that is to say whether or not a given individual should be
+	// able to break a different individual's lock.
+	Force bool `json:"force"`
 }
 
 // UnlockResponse is the result sent back from the API when asked to remove a

--- a/api/lock_api_test.go
+++ b/api/lock_api_test.go
@@ -75,10 +75,7 @@ func TestLockSearchWithLimit(t *testing.T) {
 }
 
 func TestUnlockingALock(t *testing.T) {
-	got, body := LockService.Unlock(&api.UnlockRequest{
-		Id:    "some-lock-id",
-		Force: true,
-	})
+	got, body := LockService.Unlock("some-lock-id", true)
 
 	AssertRequestSchema(t, &api.RequestSchema{
 		Method:    "POST",

--- a/api/lock_api_test.go
+++ b/api/lock_api_test.go
@@ -74,6 +74,24 @@ func TestLockSearchWithLimit(t *testing.T) {
 	}, got)
 }
 
+func TestUnlockingALock(t *testing.T) {
+	got, body := LockService.Unlock(&api.UnlockRequest{
+		Id:    "some-lock-id",
+		Force: true,
+	})
+
+	AssertRequestSchema(t, &api.RequestSchema{
+		Method:    "POST",
+		Path:      "/locks/some-lock-id/unlock",
+		Operation: api.UploadOperation,
+		Body: &api.UnlockRequest{
+			Id:    "some-lock-id",
+			Force: true,
+		},
+		Into: body,
+	}, got)
+}
+
 func TestLockRequest(t *testing.T) {
 	schema.Validate(t, schema.LockRequestSchema, &api.LockRequest{
 		Path:               "/path/to/lock",
@@ -130,6 +148,13 @@ func TestLockResponseInvalidWithCommitAndError(t *testing.T) {
 	schema.Refute(t, schema.LockResponseSchema, &api.LockResponse{
 		Err:          "some error",
 		CommitNeeded: "deadbeef",
+	})
+}
+
+func TestUnlockRequest(t *testing.T) {
+	schema.Validate(t, schema.UnlockRequestSchema, &api.UnlockRequest{
+		Id:    "some-lock-id",
+		Force: false,
 	})
 }
 

--- a/api/schema/schemas.go
+++ b/api/schema/schemas.go
@@ -19,5 +19,6 @@ const (
 	LockListSchema       = "lock_list_schema.json"
 	LockRequestSchema    = "lock_request_schema.json"
 	LockResponseSchema   = "lock_response_schema.json"
+	UnlockRequestSchema  = "unlock_request_schema.json"
 	UnlockResponseSchema = "unlock_response_schema.json"
 )

--- a/api/schema/unlock_request_schema.json
+++ b/api/schema/unlock_request_schema.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "force": {
+            "type": "boolean"
+        }
+    },
+    "required": ["id", "force"],
+    "additionalItems": false
+}


### PR DESCRIPTION
This pull-request adds the relevant schema, tests, and type to support the ability for a client to indicate to an LFS server that it wishes to forcibly remove a particular lock.