### PR TITLE
Implement support for GIT_SSH_COMMAND

### DIFF
--- a/auth/ssh.go
+++ b/auth/ssh.go
@@ -70,6 +70,12 @@ func sshGetExeAndArgs(endpoint config.Endpoint) (exe string, baseargs []string) 
 	isTortoise := false
 
 	ssh := config.Config.Getenv("GIT_SSH")
+	cmdArgs := strings.Fields(config.Config.Getenv("GIT_SSH_COMMAND"))
+	if len(cmdArgs) > 0 {
+		ssh = cmdArgs[0]
+		cmdArgs = cmdArgs[1:]
+	}
+
 	if ssh == "" {
 		ssh = "ssh"
 	} else {
@@ -82,7 +88,11 @@ func sshGetExeAndArgs(endpoint config.Endpoint) (exe string, baseargs []string) 
 		isTortoise = strings.EqualFold(basessh, "tortoiseplink")
 	}
 
-	args := make([]string, 0, 4)
+	args := make([]string, 0, 4+len(cmdArgs))
+	if len(cmdArgs) > 0 {
+		args = append(args, cmdArgs...)
+	}
+
 	if isTortoise {
 		// TortoisePlink requires the -batch argument to behave like ssh/plink
 		args = append(args, "-batch")

--- a/auth/ssh_test.go
+++ b/auth/ssh_test.go
@@ -11,6 +11,8 @@ import (
 func TestSSHGetExeAndArgsSsh(t *testing.T) {
 	endpoint := config.Config.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
+	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	config.Config.Setenv("GIT_SSH_COMMAND", "")
 	oldGITSSH := config.Config.Getenv("GIT_SSH")
 	config.Config.Setenv("GIT_SSH", "")
 	exe, args := sshGetExeAndArgs(endpoint)
@@ -18,12 +20,15 @@ func TestSSHGetExeAndArgsSsh(t *testing.T) {
 	assert.Equal(t, []string{"user@foo.com"}, args)
 
 	config.Config.Setenv("GIT_SSH", oldGITSSH)
+	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsSshCustomPort(t *testing.T) {
 	endpoint := config.Config.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
+	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	config.Config.Setenv("GIT_SSH_COMMAND", "")
 	oldGITSSH := config.Config.Getenv("GIT_SSH")
 	config.Config.Setenv("GIT_SSH", "")
 	exe, args := sshGetExeAndArgs(endpoint)
@@ -31,11 +36,14 @@ func TestSSHGetExeAndArgsSshCustomPort(t *testing.T) {
 	assert.Equal(t, []string{"-p", "8888", "user@foo.com"}, args)
 
 	config.Config.Setenv("GIT_SSH", oldGITSSH)
+	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsPlink(t *testing.T) {
 	endpoint := config.Config.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
+	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	config.Config.Setenv("GIT_SSH_COMMAND", "")
 	oldGITSSH := config.Config.Getenv("GIT_SSH")
 	// this will run on non-Windows platforms too but no biggie
 	plink := filepath.Join("Users", "joebloggs", "bin", "plink.exe")
@@ -45,12 +53,15 @@ func TestSSHGetExeAndArgsPlink(t *testing.T) {
 	assert.Equal(t, []string{"user@foo.com"}, args)
 
 	config.Config.Setenv("GIT_SSH", oldGITSSH)
+	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsPlinkCustomPort(t *testing.T) {
 	endpoint := config.Config.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
+	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	config.Config.Setenv("GIT_SSH_COMMAND", "")
 	oldGITSSH := config.Config.Getenv("GIT_SSH")
 	// this will run on non-Windows platforms too but no biggie
 	plink := filepath.Join("Users", "joebloggs", "bin", "plink")
@@ -60,11 +71,14 @@ func TestSSHGetExeAndArgsPlinkCustomPort(t *testing.T) {
 	assert.Equal(t, []string{"-P", "8888", "user@foo.com"}, args)
 
 	config.Config.Setenv("GIT_SSH", oldGITSSH)
+	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsTortoisePlink(t *testing.T) {
 	endpoint := config.Config.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
+	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	config.Config.Setenv("GIT_SSH_COMMAND", "")
 	oldGITSSH := config.Config.Getenv("GIT_SSH")
 	// this will run on non-Windows platforms too but no biggie
 	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink.exe")
@@ -74,12 +88,15 @@ func TestSSHGetExeAndArgsTortoisePlink(t *testing.T) {
 	assert.Equal(t, []string{"-batch", "user@foo.com"}, args)
 
 	config.Config.Setenv("GIT_SSH", oldGITSSH)
+	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsTortoisePlinkCustomPort(t *testing.T) {
 	endpoint := config.Config.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
+	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	config.Config.Setenv("GIT_SSH_COMMAND", "")
 	oldGITSSH := config.Config.Getenv("GIT_SSH")
 	// this will run on non-Windows platforms too but no biggie
 	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink")
@@ -89,4 +106,103 @@ func TestSSHGetExeAndArgsTortoisePlinkCustomPort(t *testing.T) {
 	assert.Equal(t, []string{"-batch", "-P", "8888", "user@foo.com"}, args)
 
 	config.Config.Setenv("GIT_SSH", oldGITSSH)
+	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+}
+
+func TestSSHGetExeAndArgsSshCommandPrecedence(t *testing.T) {
+	endpoint := config.Config.Endpoint("download")
+	endpoint.SshUserAndHost = "user@foo.com"
+	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	config.Config.Setenv("GIT_SSH_COMMAND", "sshcmd")
+	oldGITSSH := config.Config.Getenv("GIT_SSH")
+	config.Config.Setenv("GIT_SSH", "bad")
+	exe, args := sshGetExeAndArgs(endpoint)
+	assert.Equal(t, "sshcmd", exe)
+	assert.Equal(t, []string{"user@foo.com"}, args)
+
+	config.Config.Setenv("GIT_SSH", oldGITSSH)
+	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+}
+
+func TestSSHGetExeAndArgsSshCommandArgs(t *testing.T) {
+	endpoint := config.Config.Endpoint("download")
+	endpoint.SshUserAndHost = "user@foo.com"
+	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	config.Config.Setenv("GIT_SSH_COMMAND", "sshcmd --args 1")
+	exe, args := sshGetExeAndArgs(endpoint)
+	assert.Equal(t, "sshcmd", exe)
+	assert.Equal(t, []string{"--args", "1", "user@foo.com"}, args)
+
+	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+}
+
+func TestSSHGetExeAndArgsSshCommandCustomPort(t *testing.T) {
+	endpoint := config.Config.Endpoint("download")
+	endpoint.SshUserAndHost = "user@foo.com"
+	endpoint.SshPort = "8888"
+	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	config.Config.Setenv("GIT_SSH_COMMAND", "sshcmd")
+	exe, args := sshGetExeAndArgs(endpoint)
+	assert.Equal(t, "sshcmd", exe)
+	assert.Equal(t, []string{"-p", "8888", "user@foo.com"}, args)
+
+	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+}
+
+func TestSSHGetExeAndArgsPlinkCommand(t *testing.T) {
+	endpoint := config.Config.Endpoint("download")
+	endpoint.SshUserAndHost = "user@foo.com"
+	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	// this will run on non-Windows platforms too but no biggie
+	plink := filepath.Join("Users", "joebloggs", "bin", "plink.exe")
+	config.Config.Setenv("GIT_SSH_COMMAND", plink)
+	exe, args := sshGetExeAndArgs(endpoint)
+	assert.Equal(t, plink, exe)
+	assert.Equal(t, []string{"user@foo.com"}, args)
+
+	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+}
+
+func TestSSHGetExeAndArgsPlinkCommandCustomPort(t *testing.T) {
+	endpoint := config.Config.Endpoint("download")
+	endpoint.SshUserAndHost = "user@foo.com"
+	endpoint.SshPort = "8888"
+	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	// this will run on non-Windows platforms too but no biggie
+	plink := filepath.Join("Users", "joebloggs", "bin", "plink")
+	config.Config.Setenv("GIT_SSH_COMMAND", plink)
+	exe, args := sshGetExeAndArgs(endpoint)
+	assert.Equal(t, plink, exe)
+	assert.Equal(t, []string{"-P", "8888", "user@foo.com"}, args)
+
+	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+}
+
+func TestSSHGetExeAndArgsTortoisePlinkCommand(t *testing.T) {
+	endpoint := config.Config.Endpoint("download")
+	endpoint.SshUserAndHost = "user@foo.com"
+	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	// this will run on non-Windows platforms too but no biggie
+	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink.exe")
+	config.Config.Setenv("GIT_SSH_COMMAND", plink)
+	exe, args := sshGetExeAndArgs(endpoint)
+	assert.Equal(t, plink, exe)
+	assert.Equal(t, []string{"-batch", "user@foo.com"}, args)
+
+	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+}
+
+func TestSSHGetExeAndArgsTortoisePlinkCommandCustomPort(t *testing.T) {
+	endpoint := config.Config.Endpoint("download")
+	endpoint.SshUserAndHost = "user@foo.com"
+	endpoint.SshPort = "8888"
+	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	// this will run on non-Windows platforms too but no biggie
+	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink")
+	config.Config.Setenv("GIT_SSH_COMMAND", plink)
+	exe, args := sshGetExeAndArgs(endpoint)
+	assert.Equal(t, plink, exe)
+	assert.Equal(t, []string{"-batch", "-P", "8888", "user@foo.com"}, args)
+
+	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }


### PR DESCRIPTION
Per the spec, `GIT_SSH_COMMAND` takes precedence over `GIT_SSH`.

Fixes #1142