### PR TITLE
Add checkout --unstaged flag

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -20,6 +20,7 @@ var (
 		Use: "checkout",
 		Run: checkoutCommand,
 	}
+	checkoutUnstagedArg bool
 )
 
 func checkoutCommand(cmd *cobra.Command, args []string) {
@@ -43,6 +44,7 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
+	checkoutCmd.Flags().BoolVarP(&checkoutUnstagedArg, "unstaged", "u", false, "Do not add files to the index")
 	RootCmd.AddCommand(checkoutCmd)
 }
 
@@ -207,7 +209,7 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 			}
 		}
 
-		if cmd == nil {
+		if cmd == nil && !checkoutUnstagedArg {
 			// Fire up the update-index command
 			cmd = exec.Command("git", "update-index", "-q", "--refresh", "--stdin")
 			updateIdxStdin, err = cmd.StdinPipe()
@@ -221,7 +223,9 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 
 		}
 
-		updateIdxStdin.Write([]byte(cwdfilepath + "\n"))
+		if updateIdxStdin != nil {
+			updateIdxStdin.Write([]byte(cwdfilepath + "\n"))
+		}
 	}
 	close(repopathchan)
 

--- a/docs/man/git-lfs-checkout.1.ronn
+++ b/docs/man/git-lfs-checkout.1.ronn
@@ -3,7 +3,7 @@ git-lfs-checkout(1) -- Update working copy with file content if available
 
 ## SYNOPSIS
 
-`git lfs checkout` <filespec>...
+`git lfs checkout` [options] <filespec>...
 
 ## DESCRIPTION
 
@@ -17,6 +17,11 @@ pointer content with the same SHA, the real file content is written, provided
 we have it in the local store. Modified files are never overwritten.
 
 Filespecs can be provided as arguments to restrict the files which are updated.
+
+## OPTIONS
+
+* `--unstaged` `-u`:
+  Do not add files to the index, keeping them unstaged.
 
 ## EXAMPLES
 

--- a/test/test-checkout.sh
+++ b/test/test-checkout.sh
@@ -119,3 +119,34 @@ begin_test "checkout: outside git repository"
   grep "Not in a git repository" checkout.log
 )
 end_test
+
+begin_test "checkout --unstaged"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")-unstaged"
+  setup_remote_repo "$reponame"
+
+  clone_repo "$reponame" repo-unstaged
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+
+  contents="something something"
+
+  printf "$contents" > file1.dat
+  git add file1.dat
+  git add .gitattributes
+  git commit -m "add files"
+
+  # Remove the working directory
+  rm -f file1.dat
+
+  echo "checkout should replace all"
+  git lfs checkout --unstaged
+  [ "$contents" = "$(cat file1.dat)" ]
+
+  echo "large files should not be staged"
+  git diff-files
+  git diff-files | grep file1.dat
+)
+end_test


### PR DESCRIPTION
This change introduces `--unstaged` ('-u') flag to the `checkout` subcommand. Originally it is intended to skip the costly `git update-index` call in the continuous integration setup where `git lfs checkout` is the last git operation performed in the clone, and the state of the index does not matter anymore.