### PR TITLE
test: use noop credential helper for auth tests

### DIFF
--- a/test/cmd/git-credential-lfsnoop.go
+++ b/test/cmd/git-credential-lfsnoop.go
@@ -1,0 +1,4 @@
+package main
+
+func main() {
+}

--- a/test/test-credentials-no-prompt.sh
+++ b/test/test-credentials-no-prompt.sh
@@ -34,8 +34,9 @@ begin_test "attempt private access without credential helper"
   git add .gitattributes
   git commit -m "initial commit"
 
-  git config --unset credential.helper
-  git config --global --unset credential.helper
+  git config --global credential.helper lfsnoop
+  git config credential.helper lfsnoop
+  git config -l
 
   GIT_TERMINAL_PROMPT=0 git push origin master 2>&1 | tee push.log
   grep "Authorization error: $GITSERVER/$reponame" push.log ||

--- a/test/test-credentials-no-prompt.sh
+++ b/test/test-credentials-no-prompt.sh
@@ -34,6 +34,7 @@ begin_test "attempt private access without credential helper"
   git add .gitattributes
   git commit -m "initial commit"
 
+  git config credential.usehttppath true
   git config --global credential.helper lfsnoop
   git config credential.helper lfsnoop
   git config -l


### PR DESCRIPTION
Some tests are failing on branches of mine because the LFS test credential helper is being overridden by the OS X system-level cred-helper. Instead of `--unset`-ing during the tests that needed it, this PR introduces a no-op credential helper, which fixes those tests.