### PR TITLE
ignore all osx ci failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - os: osx
-      go: 1.6
   include:
     - env: git-latest
       os: linux


### PR DESCRIPTION
Seems that all 3 of our osx builds have different failures associated with them. 

* https://travis-ci.org/github/git-lfs/jobs/134590303
* https://travis-ci.org/github/git-lfs/jobs/134590297
* https://travis-ci.org/github/git-lfs/jobs/134590299

These 3 seem like test related issues on travis, and not lfs bugs, so they're now ignored.