### PR TITLE
Disable gojsonschema test, causes failures when firewalls block it

### DIFF
--- a/script/test
+++ b/script/test
@@ -9,6 +9,7 @@ else
     GO15VENDOREXPERIMENT=1 go test \
       $(GO15VENDOREXPERIMENT=1 go list ./... \
           | grep -v "github.com/olekukonko/ts" \
+          | grep -v "github.com/xeipuuv/gojsonschema" \
           | grep -v "github.com/technoweenie/go-contentaddressable" \
       )
 fi


### PR DESCRIPTION
My firewall kept alerting me to this test accepting network connections and when I denied it or didn't click fast enough it would often cause test failures. I'm not sure if this is related to the random test failures we're seeing on OS X sometimes, it's possible. I've turned it off.

/cc @technoweenie @ttaylorr 