### PR TITLE
Allow additional fields on request & response schema

### DIFF
--- a/docs/api/http-v1-batch-request-schema.json
+++ b/docs/api/http-v1-batch-request-schema.json
@@ -23,6 +23,5 @@
       }
     }
   },
-  "required": ["objects", "operation"],
-  "additionalProperties": false
+  "required": ["objects", "operation"]
 }

--- a/docs/api/http-v1-batch-response-schema.json
+++ b/docs/api/http-v1-batch-response-schema.json
@@ -72,6 +72,5 @@
       "type": "string"
     },
   },
-  "required": ["objects"],
-  "additionalProperties": false
+  "required": ["objects"]
 }


### PR DESCRIPTION
This is to allow us to extend the API with optional fields in future versions without breaking the schema.

We should notify server implementations to update their schema if they're using it to validate requests since we need to add optional fields for the transfer features in v1.3 even if they don't implement those features.