### PR TITLE
Backport #1267 for v1.2.x: test: use noop credential helper for auth tests

### DIFF
--- a/test/cmd/git-credential-lfsnoop.go
+++ b/test/cmd/git-credential-lfsnoop.go
@@ -1,0 +1,4 @@
+package main
+
+func main() {
+}

--- a/test/test-credentials-no-prompt.sh
+++ b/test/test-credentials-no-prompt.sh
@@ -34,8 +34,10 @@ begin_test "attempt private access without credential helper"
   git add .gitattributes
   git commit -m "initial commit"
 
-  git config --unset credential.helper
-  git config --global --unset credential.helper
+  git config credential.usehttppath true
+  git config --global credential.helper lfsnoop
+  git config credential.helper lfsnoop
+  git config -l
 
   GIT_TERMINAL_PROMPT=0 git push origin master 2>&1 | tee push.log
   grep "Authorization error: $GITSERVER/$reponame" push.log ||


### PR DESCRIPTION
This backports #1267.

Conflicting files: