### PR TITLE
Backport #1257 for v1.2.x: Config include exclude

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -70,7 +70,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		success = fetchAll()
 
 	} else { // !all
-		includePaths, excludePaths := determineIncludeExcludePaths(config.Config, fetchIncludeArg, fetchExcludeArg)
+		includePaths, excludePaths := determineIncludeExcludePaths(lfs.Config, fetchIncludeArg, fetchExcludeArg)
 
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored
 		for _, ref := range refs {

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -70,7 +70,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		success = fetchAll()
 
 	} else { // !all
-		includePaths, excludePaths := determineIncludeExcludePaths(fetchIncludeArg, fetchExcludeArg)
+		includePaths, excludePaths := determineIncludeExcludePaths(config.Config, fetchIncludeArg, fetchExcludeArg)
 
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored
 		for _, ref := range refs {

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -35,7 +35,7 @@ func pullCommand(cmd *cobra.Command, args []string) {
 		lfs.Config.CurrentRemote = defaultRemote
 	}
 
-	pull(determineIncludeExcludePaths(config.Config, pullIncludeArg, pullExcludeArg))
+	pull(determineIncludeExcludePaths(lfs.Config, pullIncludeArg, pullExcludeArg))
 
 }
 

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -35,7 +35,7 @@ func pullCommand(cmd *cobra.Command, args []string) {
 		lfs.Config.CurrentRemote = defaultRemote
 	}
 
-	pull(determineIncludeExcludePaths(pullIncludeArg, pullExcludeArg))
+	pull(determineIncludeExcludePaths(config.Config, pullIncludeArg, pullExcludeArg))
 
 }
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/tools"
@@ -211,7 +210,7 @@ type ErrorWithStack interface {
 	Stack() []byte
 }
 
-func determineIncludeExcludePaths(config *config.Configuration, includeArg, excludeArg string) (include, exclude []string) {
+func determineIncludeExcludePaths(config *lfs.Configuration, includeArg, excludeArg string) (include, exclude []string) {
 	return tools.CleanPathsDefault(includeArg, ",", config.FetchIncludePaths()),
 		tools.CleanPathsDefault(excludeArg, ",", config.FetchExcludePaths())
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -11,14 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
-<<<<<<< HEAD
-	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
-=======
 	"github.com/github/git-lfs/tools"
-	"github.com/spf13/cobra"
->>>>>>> 5bed973... Merge pull request #1257 from ttaylorr/config-include-exclude
+
+	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
 )
 
 // Populate man pages
@@ -213,34 +211,9 @@ type ErrorWithStack interface {
 	Stack() []byte
 }
 
-<<<<<<< HEAD
-// determineIncludeExcludePaths is a common function to take the string arguments
-// for include/exclude and derive slices either from these options or from the
-// common global config
-func determineIncludeExcludePaths(includeArg, excludeArg string) (include, exclude []string) {
-	var includePaths, excludePaths []string
-	if len(includeArg) > 0 {
-		for _, inc := range strings.Split(includeArg, ",") {
-			inc = strings.TrimSpace(inc)
-			includePaths = append(includePaths, inc)
-		}
-	} else {
-		includePaths = lfs.Config.FetchIncludePaths()
-	}
-	if len(excludeArg) > 0 {
-		for _, ex := range strings.Split(excludeArg, ",") {
-			ex = strings.TrimSpace(ex)
-			excludePaths = append(excludePaths, ex)
-		}
-	} else {
-		excludePaths = lfs.Config.FetchExcludePaths()
-	}
-	return includePaths, excludePaths
-=======
 func determineIncludeExcludePaths(config *config.Configuration, includeArg, excludeArg string) (include, exclude []string) {
 	return tools.CleanPathsDefault(includeArg, ",", config.FetchIncludePaths()),
 		tools.CleanPathsDefault(excludeArg, ",", config.FetchExcludePaths())
->>>>>>> 5bed973... Merge pull request #1257 from ttaylorr/config-include-exclude
 }
 
 func printHelp(commandName string) {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -13,7 +13,12 @@ import (
 
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
+<<<<<<< HEAD
 	"github.com/github/git-lfs/vendor/_nuts/github.com/spf13/cobra"
+=======
+	"github.com/github/git-lfs/tools"
+	"github.com/spf13/cobra"
+>>>>>>> 5bed973... Merge pull request #1257 from ttaylorr/config-include-exclude
 )
 
 // Populate man pages
@@ -208,6 +213,7 @@ type ErrorWithStack interface {
 	Stack() []byte
 }
 
+<<<<<<< HEAD
 // determineIncludeExcludePaths is a common function to take the string arguments
 // for include/exclude and derive slices either from these options or from the
 // common global config
@@ -230,6 +236,11 @@ func determineIncludeExcludePaths(includeArg, excludeArg string) (include, exclu
 		excludePaths = lfs.Config.FetchExcludePaths()
 	}
 	return includePaths, excludePaths
+=======
+func determineIncludeExcludePaths(config *config.Configuration, includeArg, excludeArg string) (include, exclude []string) {
+	return tools.CleanPathsDefault(includeArg, ",", config.FetchIncludePaths()),
+		tools.CleanPathsDefault(excludeArg, ",", config.FetchExcludePaths())
+>>>>>>> 5bed973... Merge pull request #1257 from ttaylorr/config-include-exclude
 }
 
 func printHelp(commandName string) {

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -3,12 +3,12 @@ package commands
 import (
 	"testing"
 
-	"github.com/github/git-lfs/config"
-	"github.com/stretchr/testify/assert"
+	"github.com/github/git-lfs/lfs"
+	"github.com/github/git-lfs/vendor/_nuts/github.com/technoweenie/assert"
 )
 
 var (
-	cfg = config.NewFromValues(map[string]string{
+	cfg = lfs.NewFromValues(map[string]string{
 		"lfs.fetchinclude": "/default/include",
 		"lfs.fetchexclude": "/default/exclude",
 	})

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -1,0 +1,29 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/github/git-lfs/config"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	cfg = config.NewFromValues(map[string]string{
+		"lfs.fetchinclude": "/default/include",
+		"lfs.fetchexclude": "/default/exclude",
+	})
+)
+
+func TestDetermineIncludeExcludePathsReturnsCleanedPaths(t *testing.T) {
+	i, e := determineIncludeExcludePaths(cfg, "/some/include", "/some/exclude")
+
+	assert.Equal(t, []string{"/some/include"}, i)
+	assert.Equal(t, []string{"/some/exclude"}, e)
+}
+
+func TestDetermineIncludeExcludePathsReturnsDefaultsWhenAbsent(t *testing.T) {
+	i, e := determineIncludeExcludePaths(cfg, "", "")
+
+	assert.Equal(t, []string{"/default/include"}, i)
+	assert.Equal(t, []string{"/default/exclude"}, e)
+}

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -11,14 +11,11 @@ import (
 	"sync"
 
 	"github.com/github/git-lfs/git"
-<<<<<<< HEAD:lfs/config.go
+	"github.com/github/git-lfs/tools"
+
 	"github.com/github/git-lfs/vendor/_nuts/github.com/ThomsonReutersEikon/go-ntlm/ntlm"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/bgentry/go-netrc/netrc"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/rubyist/tracerx"
-=======
-	"github.com/github/git-lfs/tools"
-	"github.com/rubyist/tracerx"
->>>>>>> 5bed973... Merge pull request #1257 from ttaylorr/config-include-exclude:config/config.go
 )
 
 var (

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -1,6 +1,7 @@
 package lfs
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"os"
@@ -10,9 +11,14 @@ import (
 	"sync"
 
 	"github.com/github/git-lfs/git"
+<<<<<<< HEAD:lfs/config.go
 	"github.com/github/git-lfs/vendor/_nuts/github.com/ThomsonReutersEikon/go-ntlm/ntlm"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/bgentry/go-netrc/netrc"
 	"github.com/github/git-lfs/vendor/_nuts/github.com/rubyist/tracerx"
+=======
+	"github.com/github/git-lfs/tools"
+	"github.com/rubyist/tracerx"
+>>>>>>> 5bed973... Merge pull request #1257 from ttaylorr/config-include-exclude:config/config.go
 )
 
 var (
@@ -76,6 +82,29 @@ func NewConfig() *Configuration {
 	c.isDebuggingHttp = c.GetenvBool("LFS_DEBUG_HTTP", false)
 	c.isLoggingStats = c.GetenvBool("GIT_LOG_STATS", false)
 	return c
+}
+
+// NewFromValues returns a new *config.Configuration instance as if it had
+// been read from the .gitconfig specified by "gitconfig" parameter.
+//
+// NOTE: this method should only be called during testing.
+func NewFromValues(gitconfig map[string]string) *Configuration {
+	config := &Configuration{
+		gitConfig: make(map[string]string, 0),
+	}
+
+	buf := bytes.NewBuffer([]byte{})
+	for k, v := range gitconfig {
+		fmt.Fprintf(buf, "%s=%s\n", k, v)
+	}
+
+	config.readGitConfig(
+		string(buf.Bytes()),
+		map[string]bool{},
+		false,
+	)
+
+	return config
 }
 
 func (c *Configuration) Getenv(key string) string {
@@ -271,6 +300,7 @@ func (c *Configuration) FetchIncludePaths() []string {
 	c.loadGitConfig()
 	return c.fetchIncludePaths
 }
+
 func (c *Configuration) FetchExcludePaths() []string {
 	c.loadGitConfig()
 	return c.fetchExcludePaths
@@ -558,15 +588,12 @@ func (c *Configuration) readGitConfig(output string, uniqRemotes map[string]bool
 
 		c.gitConfig[key] = value
 
-		if len(keyParts) == 2 && keyParts[0] == "lfs" && keyParts[1] == "fetchinclude" {
-			for _, inc := range strings.Split(value, ",") {
-				inc = strings.TrimSpace(inc)
-				c.fetchIncludePaths = append(c.fetchIncludePaths, inc)
-			}
-		} else if len(keyParts) == 2 && keyParts[0] == "lfs" && keyParts[1] == "fetchexclude" {
-			for _, ex := range strings.Split(value, ",") {
-				ex = strings.TrimSpace(ex)
-				c.fetchExcludePaths = append(c.fetchExcludePaths, ex)
+		if len(keyParts) == 2 && keyParts[0] == "lfs" {
+			switch keyParts[1] {
+			case "fetchinclude":
+				c.fetchIncludePaths = tools.CleanPaths(value, ",")
+			case "fetchexclude":
+				c.fetchExcludePaths = tools.CleanPaths(value, ",")
 			}
 		}
 	}

--- a/lfs/config_test.go
+++ b/lfs/config_test.go
@@ -530,3 +530,13 @@ func (c *Configuration) ResetConfig() {
 	}
 	c.loading.Unlock()
 }
+
+func TestFetchIncludeExcludesAreCleaned(t *testing.T) {
+	config := NewFromValues(map[string]string{
+		"lfs.fetchinclude": "/path/to/clean/",
+		"lfs.fetchexclude": "/other/path/to/clean/",
+	})
+
+	assert.Equal(t, []string{"/path/to/clean"}, config.FetchIncludePaths())
+	assert.Equal(t, []string{"/other/path/to/clean"}, config.FetchExcludePaths())
+}

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -1,0 +1,87 @@
+// Package tools contains other helper functions too small to justify their own package
+// NOTE: Subject to change, do not rely on this package from outside git-lfs source
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FileOrDirExists determines if a file/dir exists, returns IsDir() results too.
+func FileOrDirExists(path string) (exists bool, isDir bool) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false, false
+	} else {
+		return true, fi.IsDir()
+	}
+}
+
+// FileExists determines if a file (NOT dir) exists.
+func FileExists(path string) bool {
+	ret, isDir := FileOrDirExists(path)
+	return ret && !isDir
+}
+
+// DirExists determines if a dir (NOT file) exists.
+func DirExists(path string) bool {
+	ret, isDir := FileOrDirExists(path)
+	return ret && isDir
+}
+
+// FileExistsOfSize determines if a file exists and is of a specific size.
+func FileExistsOfSize(path string, sz int64) bool {
+	fi, err := os.Stat(path)
+
+	if err != nil {
+		return false
+	}
+
+	return !fi.IsDir() && fi.Size() == sz
+}
+
+// ResolveSymlinks ensures that if the path supplied is a symlink, it is
+// resolved to the actual concrete path
+func ResolveSymlinks(path string) string {
+	if len(path) == 0 {
+		return path
+	}
+
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return path
+}
+
+// CleanPaths splits the given `paths` argument by the delimiter argument, and
+// then "cleans" that path according to the filepath.Clean function (see
+// https://golang.org/pkg/file/filepath#Clean).
+func CleanPaths(paths, delim string) (cleaned []string) {
+	// If paths is an empty string, splitting it will yield [""], which will
+	// become the filepath ".". To avoid this, bail out if trimmed paths
+	// argument is empty.
+	if paths = strings.TrimSpace(paths); len(paths) == 0 {
+		return
+	}
+
+	for _, part := range strings.Split(paths, delim) {
+		part = strings.TrimSpace(part)
+
+		cleaned = append(cleaned, filepath.Clean(part))
+	}
+
+	return cleaned
+}
+
+// CleanPathsDefault cleans the paths contained in the given `paths` argument
+// delimited by the `delim`, argument. If an empty set is returned from that
+// split, then the fallback argument is returned instead.
+func CleanPathsDefault(paths, delim string, fallback []string) []string {
+	cleaned := CleanPaths(paths, delim)
+	if len(cleaned) == 0 {
+		return fallback
+	}
+
+	return cleaned
+}

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -3,56 +3,9 @@
 package tools
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 )
-
-// FileOrDirExists determines if a file/dir exists, returns IsDir() results too.
-func FileOrDirExists(path string) (exists bool, isDir bool) {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return false, false
-	} else {
-		return true, fi.IsDir()
-	}
-}
-
-// FileExists determines if a file (NOT dir) exists.
-func FileExists(path string) bool {
-	ret, isDir := FileOrDirExists(path)
-	return ret && !isDir
-}
-
-// DirExists determines if a dir (NOT file) exists.
-func DirExists(path string) bool {
-	ret, isDir := FileOrDirExists(path)
-	return ret && isDir
-}
-
-// FileExistsOfSize determines if a file exists and is of a specific size.
-func FileExistsOfSize(path string, sz int64) bool {
-	fi, err := os.Stat(path)
-
-	if err != nil {
-		return false
-	}
-
-	return !fi.IsDir() && fi.Size() == sz
-}
-
-// ResolveSymlinks ensures that if the path supplied is a symlink, it is
-// resolved to the actual concrete path
-func ResolveSymlinks(path string) string {
-	if len(path) == 0 {
-		return path
-	}
-
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
-		return resolved
-	}
-	return path
-}
 
 // CleanPaths splits the given `paths` argument by the delimiter argument, and
 // then "cleans" that path according to the filepath.Clean function (see

--- a/tools/filetools_test.go
+++ b/tools/filetools_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/github/git-lfs/tools"
-	"github.com/stretchr/testify/assert"
+	"github.com/github/git-lfs/vendor/_nuts/github.com/technoweenie/assert"
 )
 
 func TestCleanPathsCleansPaths(t *testing.T) {
@@ -16,7 +16,7 @@ func TestCleanPathsCleansPaths(t *testing.T) {
 func TestCleanPathsReturnsNoResultsWhenGivenNoPaths(t *testing.T) {
 	cleaned := tools.CleanPaths("", ",")
 
-	assert.Empty(t, cleaned)
+	assert.Equal(t, 0, len(cleaned))
 }
 
 func TestCleanPathsDefaultReturnsInputWhenResultsPresent(t *testing.T) {

--- a/tools/filetools_test.go
+++ b/tools/filetools_test.go
@@ -1,0 +1,32 @@
+package tools_test
+
+import (
+	"testing"
+
+	"github.com/github/git-lfs/tools"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCleanPathsCleansPaths(t *testing.T) {
+	cleaned := tools.CleanPaths("/foo/bar/,/foo/bar/baz", ",")
+
+	assert.Equal(t, []string{"/foo/bar", "/foo/bar/baz"}, cleaned)
+}
+
+func TestCleanPathsReturnsNoResultsWhenGivenNoPaths(t *testing.T) {
+	cleaned := tools.CleanPaths("", ",")
+
+	assert.Empty(t, cleaned)
+}
+
+func TestCleanPathsDefaultReturnsInputWhenResultsPresent(t *testing.T) {
+	cleaned := tools.CleanPathsDefault("/foo/bar/", ",", []string{"/default"})
+
+	assert.Equal(t, []string{"/foo/bar"}, cleaned)
+}
+
+func TestCleanPathsDefaultReturnsDefaultWhenResultsAbsent(t *testing.T) {
+	cleaned := tools.CleanPathsDefault("", ",", []string{"/default"})
+
+	assert.Equal(t, []string{"/default"}, cleaned)
+}


### PR DESCRIPTION
This backports #1257.

Conflicting files:
- commands/commands.go
- lfs/config.go
- tools/filetools.go