### PR TITLE
Backport #1273 for v1.2.x: ignore all osx ci failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - os: osx
-      go: 1.6
   include:
     - env: git-latest
       os: linux


### PR DESCRIPTION
This backports #1273.