### PR TITLE
script: add changelog script

### DIFF
--- a/script/changelog
+++ b/script/changelog
@@ -34,16 +34,32 @@ misc=""
 for rev in $(git rev-list --merges $range); do
   git show $rev
 
-  echo ""
-  echo "Categorize this change: [f,b,m,s] ?"
+  processed=0
+  while [ $processed -eq 0 ]; do
+    echo "Categorize this change: [f,b,m,s,?] ?"
+    read -n 1 opt
+    echo ""
 
-  read -n 1 opt
+    case $opt in
+      [fbms])
+        processed=1
+        ;;
+      ?)
+        echo "f - mark this merge as a feature"
+        echo "b - mark this merge as a bugfix"
+        echo "m - make this merge as a misc. change"
+        echo "s - skip this merge, excluding it from the changelog"
+        echo "? - display this help message"
+        ;;
+      *)
+        echo "Unknown option: $opt, try again."
+        ;;
+    esac
+  done
 
-  if [ "$opt" = "s" ]; then
-    continue
+  if [ $opt != "s" ]; then
+    summary="$(commit_summary $rev)"
   fi
-
-  summary="$(commit_summary $rev)"
 
   case $opt in
     f)
@@ -55,9 +71,6 @@ for rev in $(git rev-list --merges $range); do
     m)
       misc="$(printf "%s\n%s\n" "$misc" "$summary")"
       ;;
-    *)
-      echo "Usage: [f,b,m,s]"
-      exit 1
   esac
 done
 

--- a/script/changelog
+++ b/script/changelog
@@ -11,7 +11,7 @@ commit_summary() {
   id="$(echo $prjson | jq -r -e ".number")"
   author="$(echo $prjson | jq -r -e ".user.login")"
 
-  echo "- $title #$id (@$author)"
+  echo "* $title #$id (@$author)"
 }
 
 range=$1

--- a/script/changelog
+++ b/script/changelog
@@ -11,6 +11,12 @@ commit_summary() {
   id="$(echo $prjson | jq -r -e ".number")"
   author="$(echo $prjson | jq -r -e ".user.login")"
 
+  # If the title begins with "Backport", then strip everything until the actual
+  # pull-request title.
+  if grep -q "Backport" <(echo $title); then
+    title="$(echo $title | sed 's/^[^:]*: //g')"
+  fi
+
   echo "* $title #$id (@$author)"
 }
 

--- a/script/changelog
+++ b/script/changelog
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Interactively generates a changelog over a range of commits:
+
+commit_summary() {
+  local hash=$1
+
+  pr=$(git show $hash | grep -o "#\([0-9]*\)" | cut -c 2-)
+  prjson="$(curl -n https://api.github.com/repos/github/git-lfs/pulls/$pr 2>/dev/null)"
+  title="$(echo $prjson | jq -r -e ".title")"
+  id="$(echo $prjson | jq -r -e ".number")"
+  author="$(echo $prjson | jq -r -e ".user.login")"
+
+  echo "- $title #$id (@$author)"
+}
+
+range=$1
+
+if [ "$range" = "" ]; then
+  echo "Usage: $0 [options] base..next"
+  exit 1
+fi
+
+features=""
+bugs=""
+misc=""
+
+for rev in $(git rev-list --merges $range); do
+  git show $rev
+
+  echo ""
+  echo "Categorize this change: [f,b,m,s] ?"
+
+  read -n 1 opt
+
+  if [ "$opt" = "s" ]; then
+    continue
+  fi
+
+  summary="$(commit_summary $rev)"
+
+  case $opt in
+    f)
+      features="$(printf "%s\n%s\n" "$features" "$summary")"
+      ;;
+    b)
+      bugs="$(printf "%s\n%s\n" "$bugs" "$summary")"
+      ;;
+    m)
+      misc="$(printf "%s\n%s\n" "$misc" "$summary")"
+      ;;
+    *)
+      echo "Usage: [f,b,m,s]"
+      exit 1
+  esac
+done
+
+echo "" >&2
+
+cat <<- EOF
+# Features$features
+
+# Bugs$bugs
+
+# Misc$misc
+EOF

--- a/script/changelog
+++ b/script/changelog
@@ -58,9 +58,12 @@ done
 echo "" >&2
 
 cat <<- EOF
-# Features$features
+### Features
+$features
 
-# Bugs$bugs
+### Bugs
+$bugs
 
-# Misc$misc
+### Misc
+$misc
 EOF


### PR DESCRIPTION
This pull-request introduces the `script/changelog` script, which enables callers to generate changelog summaries like we currently use within the releases page.

It accepts a range over which each merge commit is examined, categorized, and appended to a list. The categorization step works very similarly to `git add -i`, and allows you to slot each pull-request into a features, bugs, or misc category.

My bash is a little ugly, but this should work for now :smile:

------------

As an example, this is a changelog that I generated for the v1.2.1 release:

```
# Features
- Allow additional fields on request & response schema #1276 (@sinbad)
- Add missing config details to `env` command #1217 (@sinbad)
- Allow smudge filter to return 0 on download failure #1213 (@sinbad)
- Add `git lfs update --manual` option & promote it on hook install fail #1182 (@sinbad)
- Applied same -ldflags -X name value -> name=value fix as in a62e510f. #1193 (@javabrett)
- Pass `git lfs clone` flags through to `git clone` correctly, respect some options #1160 (@sinbad)

# Bugs
- Fix installer error on win32. #1198 (@teo-tsirpanis)
- fix concurrent map read and map write #1179 (@technoweenie)
- Fix problems with user prompts in `git lfs clone` #1185 (@sinbad)
- Fix failure to return non-zero exit code when lfs install/update fails to install hooks #1178 (@sinbad)
- Fixed #719 missing /usr/share/man/man5/git-lfs-config.5.gz . #1149 (@javabrett)

# Misc
- Backport #1273 for v1.2.x: ignore all osx ci failures #1280 (@ttaylorr)
- embed the open code of conduct since the link is bad now #1206 (@technoweenie)
- add instructions to install from MacPorts #1186 (@skymoo)
- Add xenial repo #1170 (@graingert)
- add homebrew update to release process #1154 (@larsxschneider)
```