### PR TITLE
Backport #1271 for v1.2.x: gitignore: ignore lfstest-* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ docker/*.key
 
 src
 commands/mancontent_gen.go
+
+lfstest-*


### PR DESCRIPTION
This backports #1271.