### PR TITLE
Enforced a minimum gem version of 1.0.4 for packagecloud-ruby

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -8,9 +8,13 @@ end
 
 require "json"
 
+packagecloud_ruby_minimum_version = "1.0.4"
 begin
+  gem "packagecloud-ruby", ">=#{packagecloud_ruby_minimum_version}"
   require "packagecloud"
+  puts "Using packagecloud-ruby:#{Gem.loaded_specs["packagecloud-ruby"].version}"
 rescue LoadError
+  puts "Requires packagecloud-ruby >=#{packagecloud_ruby_minimum_version}"
   puts %(gem install packagecloud-ruby)
   exit 1
 end


### PR DESCRIPTION
Tested by:

* `sudo gem uninstall packagecloud-ruby`
* `sudo gem install packagecloud-ruby -v 1.0.2`
* `sudo gem install packagecloud-ruby`

... running `ruby script/packagecloud.rb` each time.  You get the version warning until you hit `1.0.4`, which is current.  Could make this `1.0.3`, the bare minimum, if preferred.