### PR TITLE
Improve progress reporting when files skipped

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -289,6 +289,8 @@ func fetchAndReportToChan(pointers []*lfs.WrappedPointer, include, exclude []str
 			tracerx.Printf("fetch %v [%v]", p.Name, p.Oid)
 			q.Add(lfs.NewDownloadable(p))
 		} else {
+			// Ensure progress matches
+			q.Skip(p.Size)
 			if !passFilter {
 				tracerx.Printf("Skipping %v [%v], include/exclude filters applied", p.Name, p.Oid)
 			} else {

--- a/progress/meter.go
+++ b/progress/meter.go
@@ -23,7 +23,7 @@ type ProgressMeter struct {
 	currentBytes      int64
 	skippedBytes      int64
 	started           int32
-	estimatedFiles    int
+	estimatedFiles    int32
 	startTime         time.Time
 	finished          chan interface{}
 	logger            *progressLogger
@@ -46,7 +46,7 @@ func NewProgressMeter(estFiles int, estBytes int64, dryRun bool, logPath string)
 		fileIndex:      make(map[string]int64),
 		fileIndexMutex: &sync.Mutex{},
 		finished:       make(chan interface{}),
-		estimatedFiles: estFiles,
+		estimatedFiles: int32(estFiles),
 		estimatedBytes: estBytes,
 		dryRun:         dryRun,
 	}
@@ -72,6 +72,10 @@ func (p *ProgressMeter) Add(name string) {
 func (p *ProgressMeter) Skip(size int64) {
 	atomic.AddInt64(&p.skippedFiles, 1)
 	atomic.AddInt64(&p.skippedBytes, size)
+	// Reduce bytes and files so progress easier to parse
+	atomic.AddInt32(&p.estimatedFiles, -1)
+	atomic.AddInt64(&p.estimatedBytes, -size)
+
 }
 
 // TransferBytes increments the number of bytes transferred

--- a/progress/meter.go
+++ b/progress/meter.go
@@ -125,7 +125,7 @@ func (p *ProgressMeter) writer() {
 }
 
 func (p *ProgressMeter) update() {
-	if p.dryRun || p.estimatedFiles == 0 {
+	if p.dryRun || (p.estimatedFiles == 0 && p.skippedFiles == 0) {
 		return
 	}
 

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -100,7 +100,7 @@ begin_test "pre-push 307 redirects"
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/redirect307/rel/$reponame.git/info/lfs" 2>&1 |
     tee push.log
-  grep "(0 of 1 files, 1 skipped)" push.log
+  grep "(0 of 0 files, 1 skipped)" push.log
 
   assert_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4
 
@@ -116,7 +116,7 @@ begin_test "pre-push 307 redirects"
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/redirect307/abs/$reponame.git/info/lfs" 2>&1 |
     tee push.log
-  grep "(0 of 1 files, 1 skipped)" push.log
+  grep "(0 of 0 files, 1 skipped)" push.log
 )
 end_test
 

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -42,7 +42,7 @@ begin_test "push"
   rm -rf .git/refs/remotes
 
   git lfs push origin push-b 2>&1 | tee push.log
-  grep "(1 of 2 files, 1 skipped)" push.log
+  grep "(1 of 1 files, 1 skipped)" push.log
 )
 end_test
 
@@ -162,7 +162,7 @@ begin_test "push --all (no ref args)"
   [ $(grep -c "push" push.log) -eq 6 ]
 
   git push --all origin 2>&1 | tee push.log
-  grep "(2 of 3 files, 1 skipped)" push.log
+  grep "(2 of 2 files, 1 skipped)" push.log
   grep "(3 of 3 files)" push.log
   [ $(grep -c "files)" push.log) -eq 1 ]
   [ $(grep -c "skipped)" push.log) -eq 1 ]
@@ -343,7 +343,7 @@ begin_test "push object id(s)"
   git lfs push --object-id origin \
     4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
     2>&1 | tee push.log
-  grep "(0 of 1 files, 1 skipped)" push.log
+  grep "(0 of 0 files, 1 skipped)" push.log
 
   echo "push b" > b.dat
   git add b.dat
@@ -353,7 +353,7 @@ begin_test "push object id(s)"
     4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
     82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 \
     2>&1 | tee push.log
-  grep "(0 of 2 files, 2 skipped)" push.log
+  grep "(0 of 0 files, 2 skipped)" push.log
 )
 end_test
 


### PR DESCRIPTION
When a file is skipped because it already exists locally, the progress reporting was wonky and on completion would look something like this from `git lfs fetch`:

```
Git LFS: (1 of 13 files) 17.33 MB / 18.34 MB
```
That looks like it didn't finish! Actually the 1 file it downloaded is 17.33 MB and the other 12 were skipped and made up the remainder.

This PR improves this 2 ways:

- Marks files as skipped during `fetch` so the progress tells the user that files & bytes were skipped
- Reduces the estimated files & bytes when skipping so the totals match up when finished (while still showing the number of files and bytes *actually* transferred

The result after this PR is something like this instead:

```
Git LFS: (1 of 1 files, 12 skipped) 17.33 MB / 17.33 MB, 1.02 MB skipped
```