### PR TITLE
Enhanced transfers: part 3 (resumable downloads)

### DIFF
--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -345,14 +345,6 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, repo string) {
 			o.Err = &lfsError{Code: 422, Message: "welp"}
 		case "status-batch-500":
 			o.Err = &lfsError{Code: 500, Message: "welp"}
-		case "status-batch-resume-206", "batch-resume-fail-fallback":
-			for _, t := range objs.Transfers {
-				if t == "http-range" {
-					transferChoice = "http-range"
-					break
-				}
-			}
-			fallthrough
 		default: // regular 200 response
 			if addAction {
 				o.Actions = map[string]lfsLink{

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -450,7 +450,7 @@ func storageHandler(w http.ResponseWriter, r *http.Request) {
 					if match != nil && len(match) > 1 {
 						statusCode = 206
 						resumeAt, _ = strconv.ParseInt(match[1], 10, 32)
-						w.Header().Set("Content-Range", fmt.Sprintf("bytes=%d-%d", resumeAt, len(by)))
+						w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", resumeAt, len(by), resumeAt-int64(len(by))))
 					}
 				} else {
 					byteLimit = 10

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -44,6 +45,7 @@ var (
 		"status-batch-403", "status-batch-404", "status-batch-410", "status-batch-422", "status-batch-500",
 		"status-storage-403", "status-storage-404", "status-storage-410", "status-storage-422", "status-storage-500",
 		"status-legacy-404", "status-legacy-410", "status-legacy-422", "status-legacy-403", "status-legacy-500",
+		"status-batch-resume-206",
 	}
 )
 
@@ -284,8 +286,13 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, repo string) {
 	}
 
 	type batchReq struct {
+		Transfers []string    `json:"transfers"`
 		Operation string      `json:"operation"`
 		Objects   []lfsObject `json:"objects"`
+	}
+	type batchResp struct {
+		Transfer string      `json:"transfer,omitempty"`
+		Objects  []lfsObject `json:"objects"`
 	}
 
 	buf := &bytes.Buffer{}
@@ -304,6 +311,7 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, repo string) {
 
 	res := []lfsObject{}
 	testingChunked := testingChunkedTransferEncoding(r)
+	var transferChoice string
 	for _, obj := range objs.Objects {
 		action := objs.Operation
 
@@ -337,6 +345,14 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, repo string) {
 			o.Err = &lfsError{Code: 422, Message: "welp"}
 		case "status-batch-500":
 			o.Err = &lfsError{Code: 500, Message: "welp"}
+		case "status-batch-resume-206":
+			for _, t := range objs.Transfers {
+				if t == "http-range" {
+					transferChoice = "http-range"
+					break
+				}
+			}
+			fallthrough
 		default: // regular 200 response
 			if addAction {
 				o.Actions = map[string]lfsLink{
@@ -355,7 +371,7 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, repo string) {
 		res = append(res, o)
 	}
 
-	ores := map[string][]lfsObject{"objects": res}
+	ores := batchResp{Transfer: transferChoice, Objects: res}
 
 	by, err := json.Marshal(ores)
 	if err != nil {
@@ -427,9 +443,32 @@ func storageHandler(w http.ResponseWriter, r *http.Request) {
 	case "GET":
 		parts := strings.Split(r.URL.Path, "/")
 		oid := parts[len(parts)-1]
+		statusCode := 200
+		byteLimit := 0
+		resumeAt := int64(0)
 
 		if by, ok := largeObjects.Get(repo, oid); ok {
-			w.Write(by)
+			if len(by) == len("status-batch-resume-206") && string(by) == "status-batch-resume-206" {
+				// Resume if header includes range, otherwise deliberately interrupt
+				if rangeHdr := r.Header.Get("Range"); rangeHdr != "" {
+					regex := regexp.MustCompile(`bytes=(\d+)\-.*`)
+					match := regex.FindStringSubmatch(rangeHdr)
+					if match != nil && len(match) > 1 {
+						statusCode = 206
+						resumeAt, _ = strconv.ParseInt(match[1], 10, 32)
+					}
+				} else {
+					byteLimit = 10
+				}
+			}
+			w.WriteHeader(statusCode)
+			if byteLimit > 0 {
+				w.Write(by[0:byteLimit])
+			} else if resumeAt > 0 {
+				w.Write(by[resumeAt:])
+			} else {
+				w.Write(by)
+			}
 			return
 		}
 

--- a/test/test-resume-http-range.sh
+++ b/test/test-resume-http-range.sh
@@ -43,3 +43,46 @@ begin_test "resume-http-range"
 )
 end_test
 
+begin_test "resume-http-range-fallback"
+(
+  set -e
+
+  reponame="resume-http-range-fallback"
+  setup_remote_repo "$reponame"
+
+  clone_repo "$reponame" $reponame
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \*.dat" track.log
+
+  # this string announces to server that we want it to abort the download part
+  # way and tell us it supports http-range, but reject the Range: header and
+  # fall back on re-downloading instead
+  contents="batch-resume-fail-fallback"
+  contents_oid=$(calc_oid "$contents")
+
+  printf "$contents" > a.dat
+  git add a.dat
+  git add .gitattributes
+  git commit -m "add a.dat" 2>&1 | tee commit.log
+  git push origin master 
+
+  assert_server_object "$reponame" "$contents_oid"
+
+  # delete local copy then fetch it back
+  # server will abort the transfer mid way (so will error) when not resuming
+  # then we can restart it
+  rm -rf .git/lfs/objects
+  git lfs fetch 2>&1 | tee fetchinterrupted.log
+  refute_local_object "$contents_oid"
+
+  # now fetch again, this should try to resume but server should reject the Range
+  # header, which should cause client to re-download
+  GIT_TRACE=1 git lfs fetch 2>&1 | tee fetchresumefallback.log
+  grep "http-range: server rejected resume" fetchresumefallback.log
+  # re-download should still have worked
+  assert_local_object "$contents_oid" "${#contents}"
+
+)
+end_test
+

--- a/test/test-resume-http-range.sh
+++ b/test/test-resume-http-range.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "resume-http-range"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")"
+  setup_remote_repo "$reponame"
+
+  clone_repo "$reponame" $reponame
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \*.dat" track.log
+
+  # this string announces to server that we want http-range support and to
+  # interrupt the transfer when started from 0 to cause resume
+  contents="status-batch-resume-206"
+  contents_oid=$(calc_oid "$contents")
+
+  printf "$contents" > a.dat
+  git add a.dat
+  git add .gitattributes
+  git commit -m "add a.dat" 2>&1 | tee commit.log
+  git push origin master 
+
+  assert_server_object "$reponame" "$contents_oid"
+
+  # delete local copy then fetch it back
+  # server will abort the transfer mid way (so will error) when not resuming
+  # then we can restart it
+  rm -rf .git/lfs/objects
+  git lfs fetch 2>&1 | tee fetchinterrupted.log
+  refute_local_object "$contents_oid"
+
+  # now fetch again, this should try to resume and server should send remainder
+  # this time (it does not cut short when Range is requested)
+  GIT_TRACE=1 git lfs fetch 2>&1 | tee fetchresume.log
+  grep "http-range: server accepted resume" fetchresume.log
+  assert_local_object "$contents_oid" "${#contents}"
+
+)
+end_test
+

--- a/test/test-resume-http-range.sh
+++ b/test/test-resume-http-range.sh
@@ -14,8 +14,8 @@ begin_test "resume-http-range"
   git lfs track "*.dat" 2>&1 | tee track.log
   grep "Tracking \*.dat" track.log
 
-  # this string announces to server that we want http-range support and to
-  # interrupt the transfer when started from 0 to cause resume
+  # this string announces to server that we want a test that
+  # interrupts the transfer when started from 0 to cause resume
   contents="status-batch-resume-206"
   contents_oid=$(calc_oid "$contents")
 
@@ -37,7 +37,7 @@ begin_test "resume-http-range"
   # now fetch again, this should try to resume and server should send remainder
   # this time (it does not cut short when Range is requested)
   GIT_TRACE=1 git lfs fetch 2>&1 | tee fetchresume.log
-  grep "http-range: server accepted resume" fetchresume.log
+  grep "xfer: server accepted resume" fetchresume.log
   assert_local_object "$contents_oid" "${#contents}"
 
 )
@@ -56,8 +56,7 @@ begin_test "resume-http-range-fallback"
   grep "Tracking \*.dat" track.log
 
   # this string announces to server that we want it to abort the download part
-  # way and tell us it supports http-range, but reject the Range: header and
-  # fall back on re-downloading instead
+  # way, but reject the Range: header and fall back on re-downloading instead
   contents="batch-resume-fail-fallback"
   contents_oid=$(calc_oid "$contents")
 
@@ -79,7 +78,7 @@ begin_test "resume-http-range-fallback"
   # now fetch again, this should try to resume but server should reject the Range
   # header, which should cause client to re-download
   GIT_TRACE=1 git lfs fetch 2>&1 | tee fetchresumefallback.log
-  grep "http-range: server rejected resume" fetchresumefallback.log
+  grep "xfer: server rejected resume" fetchresumefallback.log
   # re-download should still have worked
   assert_local_object "$contents_oid" "${#contents}"
 

--- a/tools/iotools.go
+++ b/tools/iotools.go
@@ -51,6 +51,11 @@ func CopyWithCallback(writer io.Writer, reader io.Reader, totalSize int64, cb pr
 	return io.Copy(writer, cbReader)
 }
 
+// Get a new Hash instance of the type used to hash LFS content
+func NewLfsContentHash() hash.Hash {
+	return sha256.New()
+}
+
 // HashingReader wraps a reader and calculates the hash of the data as it is read
 type HashingReader struct {
 	reader io.Reader
@@ -58,7 +63,11 @@ type HashingReader struct {
 }
 
 func NewHashingReader(r io.Reader) *HashingReader {
-	return &HashingReader{r, sha256.New()}
+	return &HashingReader{r, NewLfsContentHash()}
+}
+
+func NewHashingReaderPreloadHash(r io.Reader, hash hash.Hash) *HashingReader {
+	return &HashingReader{r, hash}
 }
 
 func (r *HashingReader) Hash() string {

--- a/transfer/adapterbase.go
+++ b/transfer/adapterbase.go
@@ -1,0 +1,124 @@
+package transfer
+
+import (
+	"sync"
+
+	"github.com/rubyist/tracerx"
+)
+
+// adapterBase implements the common functionality for core adapters which
+// process transfers with N workers handling an oid each, and which wait for
+// authentication to succeed on one worker before proceeding
+type adapterBase struct {
+	name         string
+	direction    Direction
+	transferImpl transferImplementation
+	jobChan      chan *Transfer
+	cb           TransferProgressCallback
+	outChan      chan TransferResult
+	// WaitGroup to sync the completion of all workers
+	workerWait sync.WaitGroup
+	// WaitGroup to serialise the first transfer response to perform login if needed
+	authWait sync.WaitGroup
+}
+
+// transferImplementation must be implemented to provide the actual upload/download
+// implementation for all core transfer approaches that use adapterBase for
+// convenience. This function will be called on multiple goroutines so it
+// must be either stateless or thread safe. However it will never be called
+// for the same oid in parallel.
+// If authOkFunc is not nil, implementations must call it as early as possible
+// when authentication succeeded, before the whole file content is transferred
+type transferImplementation interface {
+	DoTransfer(t *Transfer, cb TransferProgressCallback, authOkFunc func()) error
+}
+
+func newAdapterBase(name string, dir Direction, ti transferImplementation) *adapterBase {
+	return &adapterBase{name: name, direction: dir, transferImpl: ti}
+}
+
+func (a *adapterBase) Name() string {
+	return a.name
+}
+
+func (a *adapterBase) Direction() Direction {
+	return a.direction
+}
+
+func (a *adapterBase) Begin(maxConcurrency int, cb TransferProgressCallback, completion chan TransferResult) error {
+	a.cb = cb
+	a.outChan = completion
+	a.jobChan = make(chan *Transfer, 100)
+
+	tracerx.Printf("xfer: adapter %q Begin() with %d workers", a.Name(), maxConcurrency)
+
+	a.workerWait.Add(maxConcurrency)
+	a.authWait.Add(1)
+	for i := 0; i < maxConcurrency; i++ {
+		go a.worker(i)
+	}
+	tracerx.Printf("xfer: adapter %q started", a.Name())
+	return nil
+}
+
+func (a *adapterBase) Add(t *Transfer) {
+	tracerx.Printf("xfer: adapter %q Add() for %q", a.Name(), t.Object.Oid)
+	a.jobChan <- t
+}
+
+func (a *adapterBase) End() {
+	tracerx.Printf("xfer: adapter %q End()", a.Name())
+	close(a.jobChan)
+	// wait for all transfers to complete
+	a.workerWait.Wait()
+	if a.outChan != nil {
+		close(a.outChan)
+	}
+	tracerx.Printf("xfer: adapter %q stopped", a.Name())
+}
+
+// worker function, many of these run per adapter
+func (a *adapterBase) worker(workerNum int) {
+
+	tracerx.Printf("xfer: adapter %q worker %d starting", a.Name(), workerNum)
+	waitForAuth := workerNum > 0
+	signalAuthOnResponse := workerNum == 0
+
+	// First worker is the only one allowed to start immediately
+	// The rest wait until successful response from 1st worker to
+	// make sure only 1 login prompt is presented if necessary
+	// Deliberately outside jobChan processing so we know worker 0 will process 1st item
+	if waitForAuth {
+		tracerx.Printf("xfer: adapter %q worker %d waiting for Auth", a.Name(), workerNum)
+		a.authWait.Wait()
+		tracerx.Printf("xfer: adapter %q worker %d auth signal received", a.Name(), workerNum)
+	}
+
+	for t := range a.jobChan {
+		var authCallback func()
+		if signalAuthOnResponse {
+			authCallback = func() {
+				a.authWait.Done()
+			}
+		}
+		tracerx.Printf("xfer: adapter %q worker %d processing job for %q", a.Name(), workerNum, t.Object.Oid)
+		// Actual transfer happens here
+		err := a.transferImpl.DoTransfer(t, a.cb, authCallback)
+
+		if a.outChan != nil {
+			res := TransferResult{t, err}
+			a.outChan <- res
+		}
+
+		// Only need to signal for auth once
+		signalAuthOnResponse = false
+
+		tracerx.Printf("xfer: adapter %q worker %d finished job for %q", a.Name(), workerNum, t.Object.Oid)
+	}
+	// This will only happen if no jobs were submitted; just wake up all workers to finish
+	if signalAuthOnResponse {
+		a.authWait.Done()
+	}
+	tracerx.Printf("xfer: adapter %q worker %d stopping", a.Name(), workerNum)
+	a.workerWait.Done()
+}

--- a/transfer/adapterbase.go
+++ b/transfer/adapterbase.go
@@ -99,6 +99,7 @@ func (a *adapterBase) worker(workerNum int) {
 		if signalAuthOnResponse {
 			authCallback = func() {
 				a.authWait.Done()
+				signalAuthOnResponse = false
 			}
 		}
 		tracerx.Printf("xfer: adapter %q worker %d processing job for %q", a.Name(), workerNum, t.Object.Oid)
@@ -109,9 +110,6 @@ func (a *adapterBase) worker(workerNum int) {
 			res := TransferResult{t, err}
 			a.outChan <- res
 		}
-
-		// Only need to signal for auth once
-		signalAuthOnResponse = false
 
 		tracerx.Printf("xfer: adapter %q worker %d finished job for %q", a.Name(), workerNum, t.Object.Oid)
 	}

--- a/transfer/basic_download.go
+++ b/transfer/basic_download.go
@@ -101,7 +101,7 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb TransferProgressCallback
 			return fmt.Errorf("Cannot restart %v from %d without a file & hash", t.Object.Oid, fromByte)
 		}
 		// We could just use a start byte, but since we know the length be specific
-		req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", fromByte, t.Object.Size))
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", fromByte, t.Object.Size-1))
 	}
 
 	res, err := httputil.DoHttpRequest(req, true)

--- a/transfer/basic_download.go
+++ b/transfer/basic_download.go
@@ -147,17 +147,19 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb TransferProgressCallback
 		if rangeRequestOk {
 			tracerx.Printf("xfer: server accepted resume download request: %q from byte %d", t.Object.Oid, fromByte)
 			// Advance progress callback; must split into max int sizes though
-			const maxInt = int(^uint(0) >> 1)
-			for read := int64(0); read < fromByte; {
-				remainder := fromByte - read
-				if remainder > int64(maxInt) {
-					read += int64(maxInt)
-					cb(t.Name, t.Object.Size, read, maxInt)
-				} else {
-					read += remainder
-					cb(t.Name, t.Object.Size, read, int(remainder))
-				}
+			if cb != nil {
+				const maxInt = int(^uint(0) >> 1)
+				for read := int64(0); read < fromByte; {
+					remainder := fromByte - read
+					if remainder > int64(maxInt) {
+						read += int64(maxInt)
+						cb(t.Name, t.Object.Size, read, maxInt)
+					} else {
+						read += remainder
+						cb(t.Name, t.Object.Size, read, int(remainder))
+					}
 
+				}
 			}
 		} else {
 			// Abort resume, perform regular download

--- a/transfer/basic_download.go
+++ b/transfer/basic_download.go
@@ -126,7 +126,7 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb TransferProgressCallback
 		if res.StatusCode == 206 {
 			// Probably a successful range request, check Content-Range
 			if rangeHdr := res.Header.Get("Content-Range"); rangeHdr != "" {
-				regex := regexp.MustCompile(`bytes=(\d+)\-.*`)
+				regex := regexp.MustCompile(`bytes (\d+)\-.*`)
 				match := regex.FindStringSubmatch(rangeHdr)
 				if match != nil && len(match) > 1 {
 					contentStart, _ := strconv.ParseInt(match[1], 10, 32)

--- a/transfer/basic_download.go
+++ b/transfer/basic_download.go
@@ -129,7 +129,7 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb TransferProgressCallback
 				regex := regexp.MustCompile(`bytes (\d+)\-.*`)
 				match := regex.FindStringSubmatch(rangeHdr)
 				if match != nil && len(match) > 1 {
-					contentStart, _ := strconv.ParseInt(match[1], 10, 32)
+					contentStart, _ := strconv.ParseInt(match[1], 10, 64)
 					if contentStart == fromByte {
 						rangeRequestOk = true
 					} else {

--- a/transfer/basic_upload.go
+++ b/transfer/basic_upload.go
@@ -1,7 +1,6 @@
 package transfer
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,106 +12,29 @@ import (
 	"github.com/github/git-lfs/errutil"
 	"github.com/github/git-lfs/httputil"
 	"github.com/github/git-lfs/progress"
-	"github.com/github/git-lfs/tools"
 )
 
 const (
 	BasicAdapterName = "basic"
 )
 
-// Base implementation of basic all-or-nothing HTTP upload / download adapter
-type basicAdapter struct {
+// Adapter for basic uploads (non resumable)
+type basicUploadAdapter struct {
 	*adapterBase
 }
 
-func (a *basicAdapter) ClearTempStorage() error {
+func (a *basicUploadAdapter) ClearTempStorage() error {
 	// Should be empty already but also remove dir
 	return os.RemoveAll(a.tempDir())
 }
 
-func (a *basicAdapter) tempDir() string {
+func (a *basicUploadAdapter) tempDir() string {
 	// Must be dedicated to this adapter as deleted by ClearTempStorage
 	d := filepath.Join(os.TempDir(), "git-lfs-basic-temp")
 	if err := os.MkdirAll(d, 0755); err != nil {
 		return os.TempDir()
 	}
 	return d
-}
-
-// Adapter for basic downloads
-type basicDownloadAdapter struct {
-	*basicAdapter
-}
-
-func (a *basicDownloadAdapter) DoTransfer(t *Transfer, cb TransferProgressCallback, authOkFunc func()) error {
-	rel, ok := t.Object.Rel("download")
-	if !ok {
-		return errors.New("Object not found on the server.")
-	}
-
-	req, err := httputil.NewHttpRequest("GET", rel.Href, rel.Header)
-	if err != nil {
-		return err
-	}
-
-	res, err := httputil.DoHttpRequest(req, true)
-	if err != nil {
-		return errutil.NewRetriableError(err)
-	}
-	httputil.LogTransfer("lfs.data.download", res)
-	defer res.Body.Close()
-
-	// Signal auth OK on success response, before starting download to free up
-	// other workers immediately
-	if authOkFunc != nil {
-		authOkFunc()
-	}
-
-	// Now do transfer of content
-	f, err := ioutil.TempFile(a.tempDir(), t.Object.Oid+"-")
-	if err != nil {
-		return fmt.Errorf("cannot create temp file: %v", err)
-	}
-
-	defer func() {
-		if err != nil {
-			// Don't leave the temp file lying around on error.
-			_ = os.Remove(f.Name()) // yes, ignore the error, not much we can do about it.
-		}
-	}()
-
-	hasher := tools.NewHashingReader(res.Body)
-
-	// ensure we always close f. Note that this does not conflict with  the
-	// close below, as close is idempotent.
-	defer f.Close()
-	tempfilename := f.Name()
-	// Wrap callback to give name context
-	ccb := func(totalSize int64, readSoFar int64, readSinceLast int) error {
-		if cb != nil {
-			return cb(t.Name, totalSize, readSoFar, readSinceLast)
-		}
-		return nil
-	}
-	written, err := tools.CopyWithCallback(f, hasher, res.ContentLength, ccb)
-	if err != nil {
-		return fmt.Errorf("cannot write data to tempfile %q: %v", tempfilename, err)
-	}
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("can't close tempfile %q: %v", tempfilename, err)
-	}
-
-	if actual := hasher.Hash(); actual != t.Object.Oid {
-		return fmt.Errorf("Expected OID %s, got %s after %d bytes written", t.Object.Oid, actual, written)
-	}
-
-	return tools.RenameFileCopyPermissions(tempfilename, t.Path)
-
-}
-
-// Adapter for basic uploads
-type basicUploadAdapter struct {
-	*basicAdapter
 }
 
 func (a *basicUploadAdapter) DoTransfer(t *Transfer, cb TransferProgressCallback, authOkFunc func()) error {
@@ -209,26 +131,18 @@ func newStartCallbackReader(r io.Reader, cb func(*startCallbackReader)) *startCa
 	return &startCallbackReader{r, cb, false}
 }
 
-func newBasicAdapter(name string, dir Direction) *basicAdapter {
-	return &basicAdapter{newAdapterBase(name, dir, nil)}
-}
-
 func init() {
 	newfunc := func(name string, dir Direction) TransferAdapter {
 		switch dir {
-		case Download:
-			bd := &basicDownloadAdapter{newBasicAdapter(name, dir)}
-			// self implements impl
-			bd.transferImpl = bd
-			return bd
 		case Upload:
-			bu := &basicUploadAdapter{newBasicAdapter(name, dir)}
+			bu := &basicUploadAdapter{newAdapterBase(name, dir, nil)}
 			// self implements impl
 			bu.transferImpl = bu
 			return bu
+		case Download:
+			panic("Should never ask this func for basic download")
 		}
 		return nil
 	}
 	RegisterNewTransferAdapterFunc(BasicAdapterName, Upload, newfunc)
-	RegisterNewTransferAdapterFunc(BasicAdapterName, Download, newfunc)
 }

--- a/transfer/http_range.go
+++ b/transfer/http_range.go
@@ -1,0 +1,199 @@
+package transfer
+
+import (
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/github/git-lfs/errutil"
+	"github.com/github/git-lfs/httputil"
+	"github.com/github/git-lfs/tools"
+)
+
+const (
+	HttpRangeAdapterName = "http-range"
+)
+
+// Download adapter that can resume downloads using HTTP Range headers
+type httpRangeAdapter struct {
+	*adapterBase
+}
+
+func (a *httpRangeAdapter) ClearTempStorage() error {
+	return os.RemoveAll(a.tempDir())
+}
+
+func (a *httpRangeAdapter) tempDir() string {
+	// Must be dedicated to this adapter as deleted by ClearTempStorage
+	d := filepath.Join(os.TempDir(), "git-lfs-http-range-temp")
+	if err := os.MkdirAll(d, 0755); err != nil {
+		return os.TempDir()
+	}
+	return d
+}
+
+func (a *httpRangeAdapter) DoTransfer(t *Transfer, cb TransferProgressCallback, authOkFunc func()) error {
+
+	f, fromByte, hashSoFar, err := a.checkResumeDownload(t)
+	if err != nil {
+		return err
+	}
+	return a.download(t, cb, authOkFunc, f, fromByte, hashSoFar)
+}
+
+// Checks to see if a download can be resumed, and if so returns a non-nil locked file, byte start and hash
+func (a *httpRangeAdapter) checkResumeDownload(t *Transfer) (outFile *os.File, fromByte int64, hashSoFar hash.Hash, e error) {
+	// lock the file by opening it for read/write, rather than checking Stat() etc
+	// which could be subject to race conditions by other processes
+	f, err := os.OpenFile(a.downloadFilename(t), os.O_RDWR, 0644)
+
+	if err != nil {
+		// Create a new file instead, must not already exist or error (permissions / race condition)
+		newfile, err := os.OpenFile(a.downloadFilename(t), os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0644)
+		return newfile, 0, nil, err
+	}
+
+	// Successfully opened an existing file at this point
+	// Read any existing data into hash then return file handle at end
+	hash := tools.NewLfsContentHash()
+	n, err := io.Copy(hash, f)
+	if err != nil {
+		f.Close()
+		return nil, 0, nil, err
+	}
+	return f, n, hash, nil
+
+}
+
+// Create or open a download file for resuming
+func (a *httpRangeAdapter) downloadFilename(t *Transfer) string {
+	// Not a temp file since we will be resuming it
+	return filepath.Join(a.tempDir(), t.Object.Oid+".tmp")
+}
+
+// download starts or resumes and download. Always closes dlFile if non-nil
+func (a *httpRangeAdapter) download(t *Transfer, cb TransferProgressCallback, authOkFunc func(), dlFile *os.File, fromByte int64, hash hash.Hash) error {
+
+	if dlFile != nil {
+		// ensure we always close dlFile. Note that this does not conflict with the
+		// early close below, as close is idempotent.
+		defer dlFile.Close()
+	}
+
+	rel, ok := t.Object.Rel("download")
+	if !ok {
+		return errors.New("Object not found on the server.")
+	}
+
+	req, err := httputil.NewHttpRequest("GET", rel.Href, rel.Header)
+	if err != nil {
+		return err
+	}
+
+	if fromByte > 0 {
+		if dlFile == nil || hash == nil {
+			return fmt.Errorf("Cannot restart %v from %d without a file & hash", t.Object.Oid, fromByte)
+		}
+		// We could just use a start byte, but since we know the length be specific
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", fromByte, t.Object.Size))
+	}
+
+	res, err := httputil.DoHttpRequest(req, true)
+	if err != nil {
+		return errutil.NewRetriableError(err)
+	}
+	httputil.LogTransfer("lfs.data.download", res)
+	defer res.Body.Close()
+
+	// Range request must return 206 to confirm
+	if fromByte > 0 {
+		if res.StatusCode == 206 {
+			// Successful range request
+			// Advance progress callback; must split into max int sizes though
+			const maxInt = int(^uint(0) >> 1)
+			for read := int64(0); read < fromByte; {
+				remainder := fromByte - read
+				if remainder > int64(maxInt) {
+					read += int64(maxInt)
+					cb(t.Name, t.Object.Size, read, maxInt)
+				} else {
+					read += remainder
+					cb(t.Name, t.Object.Size, read, int(remainder))
+				}
+
+			}
+		} else {
+			// Abort resume, perform regular download
+			dlFile.Close()
+			os.Remove(dlFile.Name())
+			return a.download(t, cb, authOkFunc, nil, 0, nil)
+		}
+	}
+
+	// Signal auth OK on success response, before starting download to free up
+	// other workers immediately
+	if authOkFunc != nil {
+		authOkFunc()
+	}
+
+	var hasher *tools.HashingReader
+	if fromByte > 0 && hash != nil {
+		// pre-load hashing reader with previous content
+		hasher = tools.NewHashingReaderPreloadHash(res.Body, hash)
+	} else {
+		hasher = tools.NewHashingReader(res.Body)
+	}
+
+	if dlFile == nil {
+		// New file start
+		dlFile, err := os.OpenFile(a.downloadFilename(t), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return err
+		}
+		defer dlFile.Close()
+	}
+	dlfilename := dlFile.Name()
+	// Wrap callback to give name context
+	ccb := func(totalSize int64, readSoFar int64, readSinceLast int) error {
+		if cb != nil {
+			return cb(t.Name, totalSize, readSoFar+fromByte, readSinceLast)
+		}
+		return nil
+	}
+	written, err := tools.CopyWithCallback(dlFile, hasher, res.ContentLength, ccb)
+	if err != nil {
+		return fmt.Errorf("cannot write data to tempfile %q: %v", dlfilename, err)
+	}
+	if err := dlFile.Close(); err != nil {
+		return fmt.Errorf("can't close tempfile %q: %v", dlfilename, err)
+	}
+
+	if actual := hasher.Hash(); actual != t.Object.Oid {
+		return fmt.Errorf("Expected OID %s, got %s after %d bytes written", t.Object.Oid, actual, written)
+	}
+
+	// Notice that on failure we do not delete the partially downloaded file.
+	// Instead we will resume next time
+
+	return tools.RenameFileCopyPermissions(dlfilename, t.Path)
+
+}
+
+func init() {
+	newfunc := func(name string, dir Direction) TransferAdapter {
+		switch dir {
+		case Download:
+			hd := &httpRangeAdapter{newAdapterBase(name, dir, nil)}
+			// self implements impl
+			hd.transferImpl = hd
+			return hd
+		case Upload:
+			panic("Should never ask a HTTP Range adapter to upload")
+		}
+		return nil
+	}
+	RegisterNewTransferAdapterFunc(HttpRangeAdapterName, Download, newfunc)
+}

--- a/transfer/http_range.go
+++ b/transfer/http_range.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/github/git-lfs/localstorage"
+
 	"github.com/rubyist/tracerx"
 
 	"github.com/github/git-lfs/errutil"
@@ -30,7 +32,9 @@ func (a *httpRangeAdapter) ClearTempStorage() error {
 
 func (a *httpRangeAdapter) tempDir() string {
 	// Must be dedicated to this adapter as deleted by ClearTempStorage
-	d := filepath.Join(os.TempDir(), "git-lfs-http-range-temp")
+	// Also make local to this repo not global, and separate to localstorage temp,
+	// which gets cleared at the end of every invocation
+	d := filepath.Join(localstorage.Objects().RootDir, "incomplete")
 	if err := os.MkdirAll(d, 0755); err != nil {
 		return os.TempDir()
 	}


### PR DESCRIPTION
This PR implements resumable downloads for all storage hosts which support HTTP Range/Content-Range exchanges. Since it seamlessly falls back to re-downloading the entire file if the server doesn't support a range request, it doesn't hurt to always ask to resume and to proceed depending on what the server responds with (often these servers will just return 200 instead of 206 and send the entire file, which this caters for).