### PR TITLE
Ignore HEAD ref when fetching with --all

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -50,7 +50,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 			Panic(err, "Invalid ref argument: %v", args[1:])
 		}
 		refs = resolvedrefs
-	} else {
+	} else if !fetchAllArg {
 		ref, err := git.CurrentRef()
 		if err != nil {
 			Panic(err, "Could not fetch")

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -400,6 +400,16 @@ begin_test "fetch-all"
     assert_local_object "${oid[$a]}" "${#content[$a]}"
   done
 
+  # Make a bare clone of the repository
+  cd ..
+  git clone --bare "$GITSERVER/$reponame" "$reponame-bare"
+  cd "$reponame-bare"
+
+  # Preform the same assertion as above, on the same data
+  git lfs fetch --all origin
+  for ((a=0 a < NUMFILES ; a++)); do
+    assert_local_object "${oid[$a]}" "${#content[$a]}"
+  done
 )
 end_test
 


### PR DESCRIPTION
Since there is no HEAD ref to resolve when a repository is cloned with the `--bare` flag, the `git lfs fetch` command learned to ignore it. Kudos to @xen2 for bringing this up in #1307.

I piggybacked the pseudo-test for bare clones onto the end of the `fetch-all` test in `test/test-fetch.sh`. I am using all of the fixture data from the test, but if we want to extract that out, I'd be more than happy to do that 😄 

Either way, this pull-request should resolve #1307!

--------------

/cc @rubyist 