### PR TITLE
cmd/clone: add include/exclude via flags and config

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -19,7 +19,9 @@ var (
 		Run: cloneCommand,
 	}
 
-	cloneFlags git.CloneFlags
+	cloneFlags      git.CloneFlags
+	cloneIncludeArg string
+	cloneExcludeArg string
 )
 
 func cloneCommand(cmd *cobra.Command, args []string) {
@@ -71,11 +73,12 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 		config.Config.CurrentRemote = "origin"
 	}
 
+	include, exclude := determineIncludeExcludePaths(config.Config, cloneIncludeArg, cloneExcludeArg)
 	if cloneFlags.NoCheckout || cloneFlags.Bare {
 		// If --no-checkout or --bare then we shouldn't check out, just fetch instead
-		fetchRef("HEAD", nil, nil)
+		fetchRef("HEAD", include, exclude)
 	} else {
-		pull(nil, nil)
+		pull(include, exclude)
 	}
 
 }
@@ -106,5 +109,9 @@ func init() {
 	cloneCmd.Flags().BoolVarP(&cloneFlags.Verbose, "verbose", "", false, "See 'git clone --help'")
 	cloneCmd.Flags().BoolVarP(&cloneFlags.Ipv4, "ipv4", "", false, "See 'git clone --help'")
 	cloneCmd.Flags().BoolVarP(&cloneFlags.Ipv6, "ipv6", "", false, "See 'git clone --help'")
+
+	cloneCmd.Flags().StringVarP(&cloneIncludeArg, "include", "I", "", "Include a list of paths")
+	cloneCmd.Flags().StringVarP(&cloneExcludeArg, "exclude", "X", "", "Exclude a list of paths")
+
 	RootCmd.AddCommand(cloneCmd)
 }

--- a/docs/man/git-lfs-clone.1.ronn
+++ b/docs/man/git-lfs-clone.1.ronn
@@ -19,6 +19,23 @@ downloads performed by 'git lfs pull'.
 
 All options supported by 'git clone'
 
+* `-I` <paths> `--include=`<paths>:
+  See [INCLUDE AND EXCLUDE]
+
+* `-X` <paths> `--exclude=`<paths>:
+  See [INCLUDE AND EXCLUDE]
+
+## INCLUDE AND EXCLUDE
+
+You can configure Git LFS to only fetch objects to satisfy references in certain
+paths of the repo, and/or to exclude certain paths of the repo, to reduce the
+time you spend downloading things you do not use.
+
+In lfsconfig, set lfs.fetchinclude and lfs.fetchexclude to comma-separated lists
+of paths to include/exclude in the fetch (wildcard matching as per gitignore).
+Only paths which are matched by fetchinclude and not matched by fetchexclude
+will have objects fetched for them.
+
 ## SEE ALSO
 
 git-clone(1), git-lfs-pull(1).


### PR DESCRIPTION
This pull-request adds the ability to specify include/exclude flags to the `git lfs clone` command via `-I` and `-X`, and the repository-level `.lfsconfig` file, a-la `git lfs fetch`, etc.

Other things to note: I put the `clone{Include,Exclude}Arg string` flag outside of the `git.CloneFlags` type, since the new flags are LFS-specific, and not related to Git. If we'd rather have those flags roped into the `git.CloneFlags` type (but not passed to the `git clone` invocation), I'm cool with that, too.

Most importantly, thanks for the review! 👋 