### PR TITLE
Fix 'git lfs fetch' with a sha1 ref

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -67,12 +67,21 @@ func ResolveRef(ref string) (*Ref, error) {
 	if err != nil {
 		return nil, err
 	}
-	lines := strings.Split(outp, "\n")
-	if len(lines) <= 1 {
+	if outp == "" {
 		return nil, fmt.Errorf("Git can't resolve ref: %q", ref)
 	}
 
+	lines := strings.Split(outp, "\n")
 	fullref := &Ref{Sha: lines[0]}
+
+	if len(lines) == 1 {
+		// ref is a sha1 and has no symbolic-full-name
+		fullref.Name = lines[0] // fullref.Sha
+		fullref.Type = RefTypeOther
+		return fullref, nil
+	}
+
+	// parse the symbolic-full-name
 	fullref.Type, fullref.Name = ParseRefToTypeAndName(lines[1])
 	return fullref, nil
 }

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -71,6 +71,10 @@ func TestCurrentRefAndCurrentRemoteRef(t *testing.T) {
 	remote, err := RemoteForCurrentBranch()
 	assert.Nil(t, err)
 	assert.Equal(t, "origin", remote)
+
+	ref, err = ResolveRef(outputs[2].Sha)
+	assert.Nil(t, err)
+	assert.Equal(t, &Ref{outputs[2].Sha, RefTypeOther, outputs[2].Sha}, ref)
 }
 
 func TestRecentBranches(t *testing.T) {

--- a/test/README.md
+++ b/test/README.md
@@ -77,6 +77,9 @@ and the remote repository data in `test/remote`.
 tests when you're running the same test script multiple times without changing
 any Go code.
 
+Also ensure that your `noproxy` environment variable contains `127.0.0.1` host,
+to allow git commands to reach the local Git server `lfstest-gitserver`.
+
 ### Test Suite
 
 The `testenv.sh` script includes some global variables used in tests.  This

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -80,7 +80,14 @@ begin_test "fetch"
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
 
-  # test with commit sha1 specified
+  # test with master commit sha1 specified
+  rm -rf .git/lfs/objects
+  master_sha1=$(git rev-parse master)
+  git lfs fetch origin "$master_sha1"
+  assert_local_object "$contents_oid" 1
+  refute_local_object "$b_oid" 1
+
+  # test with newbranch commit sha1 specified
   rm -rf .git/lfs/objects
   newbranch_sha1=$(git rev-parse newbranch)
   git lfs fetch origin "$newbranch_sha1"

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -80,6 +80,13 @@ begin_test "fetch"
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
 
+  # test with commit sha1 specified
+  rm -rf .git/lfs/objects
+  newbranch_sha1=$(git rev-parse newbranch)
+  git lfs fetch origin "$newbranch_sha1"
+  assert_local_object "$contents_oid" 1
+  assert_local_object "$b_oid" 1
+
   # Test include / exclude filters supplied in gitconfig
   rm -rf .git/lfs/objects
   git config "lfs.fetchinclude" "a*"


### PR DESCRIPTION
The commit 39676192da53261efd441ccf0c67c85a341ae1a1
introduced a regression in the capability to fetch a
sha1 ref.
The command 'git lfs fetch origin <sha1>' was returning
following error: 'Invalid ref argument: [<sha1>]'.

This is due to the fact that 'git rev-parse --symbolic-full-name <ref>'
returns an empty content if the ref is a sha1.

Signed-off-by: Olivier Monnier <olivier.monnier@intel.com>