### PR TITLE
script/test: propagate extra args to go test

### DIFF
--- a/script/test
+++ b/script/test
@@ -4,7 +4,7 @@
 
 script/fmt
 if [ $# -gt 0 ]; then
-    GO15VENDOREXPERIMENT=1 go test "./$1"
+    GO15VENDOREXPERIMENT=1 go test "./$@"
 else
     # The following vendor test-exclusion grep-s typically need to match the same set in
     # debian/rules variable DH_GOLANG_EXCLUDES, so update those when adding here.


### PR DESCRIPTION
As described in the test/README.md, it is possible to
pass extra args to the script/test, like for example:
  $ script/test lfs -run TestSuccessStatus -v
Those args must be propagated to the 'go test' script.

Signed-off-by: Olivier Monnier <olivier.monnier@intel.com>