### PR TITLE
WIP: Stop when SetAuthType changes nothing

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -85,8 +85,11 @@ func Batch(objects []*ObjectResource, operation string, transferAdapters []strin
 		}
 
 		if errutil.IsAuthError(err) {
-			httputil.SetAuthType(req, res)
-			return Batch(objects, operation, transferAdapters)
+			authType := httputil.GetAuthType(res)
+			oldAuthType := httputil.SetAuthType(req, authType)
+			if authType != oldAuthType {
+				return Batch(objects, operation, transferAdapters)				
+			}
 		}
 
 		switch res.StatusCode {
@@ -179,7 +182,7 @@ func UploadCheck(oid string, size int64) (*ObjectResource, error) {
 
 	if err != nil {
 		if errutil.IsAuthError(err) {
-			httputil.SetAuthType(req, res)
+			httputil.SetAuthType(req, httputil.GetAuthType(res))
 			return UploadCheck(oid, size)
 		}
 


### PR DESCRIPTION
Fixes #1330. 
I'm not golang expert, feel free to spot a problem. In fact, I need help with debug message — it was in the `SetAuthType` and now it's not, because resubmitting might not happen anymore, and I did not copied it to every usage. Maybe, I should just change the message itself, so I would just indicate preference to resubmit? 