### PR TITLE
cmd,doc,test: teach `git lfs track --{no-touch,verbose,dry-run}

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -90,13 +90,17 @@ ArgsLoop:
 		// Since all `git-lfs track` calls are relative to the root of
 		// the repository, the leading slash is simply removed for its
 		// implicit counterpart.
-		Print("Searching for files matching pattern: %s", pattern)
+		if trackVerboseLoggingFlag {
+			Print("Searching for files matching pattern: %s", pattern)
+		}
 		gittracked, err := git.GetTrackedFiles(pattern)
 		if err != nil {
 			LoggedError(err, "Error getting git tracked files")
 			continue
 		}
-		Print("Found %d files matching pattern: %s", len(gittracked), pattern)
+		if trackVerboseLoggingFlag {
+			Print("Found %d files previously added to Git matching pattern: %s", len(gittracked), pattern)
+		}
 		now := time.Now()
 
 		var matchedBlocklist bool

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -26,7 +26,6 @@ var (
 		Run: trackCommand,
 	}
 
-	trackNoTouchFlag        bool
 	trackVerboseLoggingFlag bool
 	trackDryRunFlag         bool
 )
@@ -122,18 +121,16 @@ ArgsLoop:
 		}
 		Print("Tracking %s", pattern)
 
-		if !trackNoTouchFlag || trackDryRunFlag {
-			for _, f := range gittracked {
-				if trackVerboseLoggingFlag || trackDryRunFlag {
-					Print("Git LFS: touching %s", f)
-				}
+		for _, f := range gittracked {
+			if trackVerboseLoggingFlag || trackDryRunFlag {
+				Print("Git LFS: touching %s", f)
+			}
 
-				if !trackDryRunFlag {
-					err := os.Chtimes(f, now, now)
-					if err != nil {
-						LoggedError(err, "Error marking %q modified", f)
-						continue
-					}
+			if !trackDryRunFlag {
+				err := os.Chtimes(f, now, now)
+				if err != nil {
+					LoggedError(err, "Error marking %q modified", f)
+					continue
 				}
 			}
 		}
@@ -233,7 +230,6 @@ func blocklistItem(name string) string {
 }
 
 func init() {
-	trackCmd.Flags().BoolVarP(&trackNoTouchFlag, "no-touch", "n", false, "skip modifying files matched by the glob")
 	trackCmd.Flags().BoolVarP(&trackVerboseLoggingFlag, "verbose", "v", false, "log which files are being tracked and modified")
 	trackCmd.Flags().BoolVarP(&trackDryRunFlag, "dry-run", "d", false, "preview results of running `git lfs track`")
 

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -121,7 +121,7 @@ ArgsLoop:
 			now := time.Now()
 			for _, f := range gittracked {
 				if trackVerboseLoggingFlag {
-					Print("Git LFS Track: touching %s", f)
+					Print("Git LFS: touching %s", f)
 				}
 
 				err := os.Chtimes(f, now, now)

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -91,11 +91,13 @@ ArgsLoop:
 		// Since all `git-lfs track` calls are relative to the root of
 		// the repository, the leading slash is simply removed for its
 		// implicit counterpart.
+		Print("Searching for files matching pattern: %s", pattern)
 		gittracked, err := git.GetTrackedFiles(pattern)
 		if err != nil {
 			LoggedError(err, "Error getting git tracked files")
 			continue
 		}
+		Print("Found %d files matching pattern: %s", len(gittracked), pattern)
 		now := time.Now()
 
 		var matchedBlocklist bool

--- a/docs/man/git-lfs-track.1.ronn
+++ b/docs/man/git-lfs-track.1.ronn
@@ -21,6 +21,17 @@ the currently-tracked paths.
   If enabled, have `git lfs track` log files which it will touch. Disabled by
   default.
 
+* `--dry-run` `d`:
+  If enabled, have `git lfs track` log all actions it would normally take
+  (adding entries to .gitattributes, touching files on disk, etc) without
+  preforming any mutative operations to the disk.
+
+  `git lfs track --dry-run [files]` is equivalent to calling
+  `git lfs track --no-touch --verbose` and reverting any changes made to
+  .gitattributes.
+
+  Disabled by default.
+
 ## EXAMPLES
 
 * List the paths that Git LFS is currently tracking:

--- a/docs/man/git-lfs-track.1.ronn
+++ b/docs/man/git-lfs-track.1.ronn
@@ -3,13 +3,23 @@ git-lfs-track(1) - View or add Git LFS paths to Git attributes
 
 ## SYNOPSIS
 
-`git lfs track` [<path>...]
+`git lfs track` [options] [<path>...]
 
 ## DESCRIPTION
 
 Start tracking the given path(s) through Git LFS.  The <path> argument
 can be a pattern or a file path.  If no paths are provided, simply list
 the currently-tracked paths.
+
+## OPTIONS
+
+* `--no-touch` `-n`:
+  If enabled, prevent `git lfs track` from touching files matched by the
+  provided pattern glob. Disabled by default.
+
+* `--verbose` `-v`:
+  If enabled, have `git lfs track` log files which it will touch. Disabled by
+  default.
 
 ## EXAMPLES
 

--- a/docs/man/git-lfs-track.1.ronn
+++ b/docs/man/git-lfs-track.1.ronn
@@ -21,10 +21,10 @@ the currently-tracked paths.
   If enabled, have `git lfs track` log files which it will touch. Disabled by
   default.
 
-* `--dry-run` `d`:
+* `--dry-run` `-d`:
   If enabled, have `git lfs track` log all actions it would normally take
   (adding entries to .gitattributes, touching files on disk, etc) without
-  preforming any mutative operations to the disk.
+  performing any mutative operations to the disk.
 
   `git lfs track --dry-run [files]` is equivalent to calling
   `git lfs track --no-touch --verbose` and reverting any changes made to

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -45,24 +45,6 @@ begin_test "track"
 )
 end_test
 
-begin_test "track --no-touch"
-(
-  set -e
-
-  reponame="track_no_touch"
-  mkdir "$reponame"
-  cd "$reponame"
-  git init
-
-  touch foo.dat
-  git add foo.dat
-
-  git lfs track -v --no-touch "foo.dat" 2>&1 > track.log
-
-  [ "0" -eq "$(grep -c 'Git LFS: touching foo.dat' track.log)" ]
-)
-end_test
-
 begin_test "track --verbose"
 (
   set -e

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -57,13 +57,9 @@ begin_test "track --no-touch"
   touch foo.dat
   git add foo.dat
 
-  original_atime="$(stat -f '%a' foo.dat)"
+  git lfs track -v --no-touch "foo.dat" 2>&1 > track.log
 
-  sleep 1
-  git lfs track --no-touch "foo.dat"
-  new_atime="$(stat -f '%a' foo.dat)"
-
-  [ "$original_atime" -eq "$new_atime" ]
+  [ "0" -eq "$(grep -c 'Git LFS: touching foo.dat' track.log)" ]
 )
 end_test
 

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -45,6 +45,45 @@ begin_test "track"
 )
 end_test
 
+begin_test "track --no-touch"
+(
+  set -e
+
+  reponame="track_no_touch"
+  mkdir "$reponame"
+  cd "$reponame"
+  git init
+
+  touch foo.dat
+  git add foo.dat
+
+  original_atime="$(stat -f '%a' foo.dat)"
+
+  sleep 1
+  git lfs track --no-touch "foo.dat"
+  new_atime="$(stat -f '%a' foo.dat)"
+
+  [ "$original_atime" -eq "$new_atime" ]
+)
+end_test
+
+begin_test "track --verbose"
+(
+  set -e
+
+  reponame="track_verbose_logs"
+  mkdir "$reponame"
+  cd "$reponame"
+  git init
+
+  touch foo.dat
+  git add foo.dat
+
+  git lfs track --verbose "foo.dat" 2>&1 > track.log
+  grep "touching foo.dat" track.log
+)
+end_test
+
 begin_test "track directory"
 (
   set -e

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -80,6 +80,27 @@ begin_test "track --verbose"
 )
 end_test
 
+begin_test "track --dry-run"
+(
+  set -e
+
+  reponame="track_dry_run"
+  mkdir "$reponame"
+  cd "$reponame"
+  git init
+
+  touch foo.dat
+  git add foo.dat
+
+  git lfs track --dry-run "foo.dat" 2>&1 > track.log
+  grep "Tracking foo.dat" track.log
+  grep "Git LFS: touching foo.dat" track.log
+
+  git status --porcelain 2>&1 > status.log
+  grep "A  foo.dat" status.log
+)
+end_test
+
 begin_test "track directory"
 (
   set -e


### PR DESCRIPTION
This pull request introduces three new flags into the `git lfs track` command: `--no-touch`, `--verbose`, and `--dry-run`. It also updates the man pages and adds test for this new behavior accordingly.

- Specifying `--no-touch` will cause LFS to skip modifying the file's `atime` and `mtime`, leaving the file unmodified from the filesystem's perspective.

- Specifying `--verbose` will cause LFS to print the name of each file that it touches, so that it's more apparent what `git lfs touch` is doing when acting upon a large glob of files (see https://github.com/github/git-lfs/issues/1304).

- Specifying `--dry-run` will cause `git lfs track` to log out all of the actions it would normally preform (as given with `git lfs track --verbose`), without actually modifying files or `.gitattributes` on disk.