### PR TITLE
Safety check to `comands.requireStdin`

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -120,9 +120,17 @@ func PipeCommand(name string, args ...string) error {
 }
 
 func requireStdin(msg string) {
-	stat, _ := os.Stdin.Stat()
-	if stat == nil || (stat.Mode()&os.ModeCharDevice) != 0 {
-		Error("Cannot read from STDIN. %s", msg)
+	var out string
+
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		out = fmt.Sprintf("Cannot read from STDIN. %s (%s)", msg, err)
+	} else if (stat.Mode() & os.ModeCharDevice) != 0 {
+		out = fmt.Sprintf("Cannot read from STDIN. %s", msg)
+	}
+
+	if len(out) > 0 {
+		Error(out)
 		os.Exit(1)
 	}
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -121,7 +121,7 @@ func PipeCommand(name string, args ...string) error {
 
 func requireStdin(msg string) {
 	stat, _ := os.Stdin.Stat()
-	if (stat.Mode() & os.ModeCharDevice) != 0 {
+	if stat == nil || (stat.Mode()&os.ModeCharDevice) != 0 {
 		Error("Cannot read from STDIN. %s", msg)
 		os.Exit(1)
 	}


### PR DESCRIPTION
This pull-request introduces an additional safety check around the `requireStdin` function of the `commands` package as seen [here](https://github.com/github/git-lfs/blob/79bedebb2536485317ed5470d4e6d72cdc92d0c4/commands/commands.go#L116).

As reported in https://github.com/github/git-lfs/issues/1347, the function was panicking when trying to call Mode on a nil `os.FileInfo`. Since `os.File.Stat` is guaranteed to return a non-nil value so long as no error is present, a sanity check was added to catch and log these errors. If no error was present, the bitmask is applied and checked as normal.

An aside: I added the error logging in my second commit, whereas it was previously simply discarding the error as before. If we want to continue to discard the blanked error from `os.Stdin.Stat()`, then we can simply not apply the second commit contained in this PR.