### PR TITLE
⏳ Retry transfers with expired actions

### DIFF
--- a/api/object.go
+++ b/api/object.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/github/git-lfs/httputil"
 )
@@ -58,6 +59,7 @@ func (o *ObjectResource) Rel(name string) (*LinkRelation, bool) {
 }
 
 type LinkRelation struct {
-	Href   string            `json:"href"`
-	Header map[string]string `json:"header,omitempty"`
+	Href      string            `json:"href"`
+	Header    map[string]string `json:"header,omitempty"`
+	ExpiresAt time.Time         `json:"expires_at,omitempty"`
 }

--- a/api/object.go
+++ b/api/object.go
@@ -58,6 +58,16 @@ func (o *ObjectResource) Rel(name string) (*LinkRelation, bool) {
 	return rel, ok
 }
 
+func (o *ObjectResource) IsExpired(now time.Time) bool {
+	for _, a := range o.Actions {
+		if a.ExpiresAt.Before(now) {
+			return true
+		}
+	}
+
+	return false
+}
+
 type LinkRelation struct {
 	Href      string            `json:"href"`
 	Header    map[string]string `json:"header,omitempty"`

--- a/api/object.go
+++ b/api/object.go
@@ -58,6 +58,11 @@ func (o *ObjectResource) Rel(name string) (*LinkRelation, bool) {
 	return rel, ok
 }
 
+// IsExpired returns true if any of the actions in this object resource have an
+// ExpiresAt field that is after the given instant "now".
+//
+// If the object contains no actions, or none of the actions it does contain
+// have non-zero ExpiresAt fields, the object is not expired.
 func (o *ObjectResource) IsExpired(now time.Time) bool {
 	for _, a := range o.Actions {
 		if !a.ExpiresAt.IsZero() && a.ExpiresAt.Before(now) {

--- a/api/object.go
+++ b/api/object.go
@@ -60,7 +60,7 @@ func (o *ObjectResource) Rel(name string) (*LinkRelation, bool) {
 
 func (o *ObjectResource) IsExpired(now time.Time) bool {
 	for _, a := range o.Actions {
-		if a.ExpiresAt.Before(now) {
+		if !a.ExpiresAt.IsZero() && a.ExpiresAt.Before(now) {
 			return true
 		}
 	}

--- a/api/object_test.go
+++ b/api/object_test.go
@@ -1,0 +1,49 @@
+package api_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/github/git-lfs/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestObjectsWithNoActionsAreNotExpired(t *testing.T) {
+	o := &api.ObjectResource{
+		Oid:     "some-oid",
+		Actions: map[string]*api.LinkRelation{},
+	}
+
+	assert.False(t, o.IsExpired(time.Now()))
+}
+
+func TestObjectsWithZeroValueTimesAreNotExpired(t *testing.T) {
+	o := &api.ObjectResource{
+		Oid: "some-oid",
+		Actions: map[string]*api.LinkRelation{
+			"upload": &api.LinkRelation{
+				Href:      "http://your-lfs-server.com",
+				ExpiresAt: time.Time{},
+			},
+		},
+	}
+
+	assert.False(t, o.IsExpired(time.Now()))
+}
+
+func TestObjectsWithExpirationDatesAreExpired(t *testing.T) {
+	now := time.Now()
+	expires := time.Now().Add(-60 * 60 * time.Second)
+
+	o := &api.ObjectResource{
+		Oid: "some-oid",
+		Actions: map[string]*api.LinkRelation{
+			"upload": &api.LinkRelation{
+				Href:      "http://your-lfs-server.com",
+				ExpiresAt: expires,
+			},
+		},
+	}
+
+	assert.True(t, o.IsExpired(now))
+}

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -194,8 +194,10 @@ func (q *TransferQueue) handleTransferResult(res transfer.TransferResult) {
 		for _, c := range q.watchers {
 			c <- oid
 		}
+
+		q.meter.FinishTransfer(res.Transfer.Name)
 	}
-	q.meter.FinishTransfer(res.Transfer.Name)
+
 	q.wait.Done()
 
 }

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -3,7 +3,6 @@ package lfs
 import (
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/github/git-lfs/api"
 	"github.com/github/git-lfs/config"
@@ -175,12 +174,6 @@ func (q *TransferQueue) ensureAdapterBegun() {
 
 }
 
-// NOTE(taylor): this function seems to be what we're looking for. It is called
-// after the transfer has been completed, see the goroutine that
-// ensureAdapterBegun spawns (L170-174).
-//
-// If the transfer completed successfully, we should check all of the action
-// expires_at fields and retry if any of them are out of date.
 func (q *TransferQueue) handleTransferResult(res transfer.TransferResult) {
 	if res.Error != nil {
 		if q.canRetry(res.Error) {
@@ -197,18 +190,6 @@ func (q *TransferQueue) handleTransferResult(res transfer.TransferResult) {
 			q.errorc <- res.Error
 		}
 	} else {
-		now := time.Now()
-		for _, action := range res.Transfer.Object.Actions {
-			if action.ExpiresAt.After(now) {
-				q.trMutex.Lock()
-				t := q.transferables[res.Transfer.Object.Oid]
-				q.trMutex.Unlock()
-
-				q.retry(t)
-				return
-			}
-		}
-
 		oid := res.Transfer.Object.Oid
 		for _, c := range q.watchers {
 			c <- oid

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -508,7 +508,6 @@ begin_test "push (retry with expired actions)"
   GIT_TRACE=1 git push origin master 2>&1 | tee push.log
 
   [ "1" -eq "$(grep -c "expired, retrying..." push.log)" ]
-  # TODO(taylor); figure out why (2 of 1 files) is outputted
-  # grep "(1 of 1 files)" push.log
+  grep "(1 of 1 files)" push.log
 )
 end_test

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -486,3 +486,29 @@ begin_test "push ambiguous branch name"
 
 )
 end_test
+
+begin_test "push (retry with expired actions)"
+(
+  set -e
+
+  reponame="push_retry_expired_action"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  printf "return-expired-action" > a.dat
+  git add .gitattributes a.dat
+
+  git commit -m "add a.dat, .gitattributes" 2>&1 | tee commit.log
+  grep "master (root-commit)" commit.log
+  grep "2 files changed" commit.log
+  grep "create mode 100644 a.dat" commit.log
+  grep "create mode 100644 .gitattributes" commit.log
+
+  GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+
+  [ "1" -eq "$(grep -c "expired, retrying..." push.log)" ]
+  # TODO(taylor); figure out why (2 of 1 files) is outputted
+  # grep "(1 of 1 files)" push.log
+)
+end_test

--- a/transfer/adapterbase.go
+++ b/transfer/adapterbase.go
@@ -1,8 +1,11 @@
 package transfer
 
 import (
+	"fmt"
 	"sync"
+	"time"
 
+	"github.com/github/git-lfs/errutil"
 	"github.com/rubyist/tracerx"
 )
 
@@ -103,8 +106,15 @@ func (a *adapterBase) worker(workerNum int) {
 			}
 		}
 		tracerx.Printf("xfer: adapter %q worker %d processing job for %q", a.Name(), workerNum, t.Object.Oid)
+
 		// Actual transfer happens here
-		err := a.transferImpl.DoTransfer(t, a.cb, authCallback)
+		var err error
+		if t.Object.IsExpired(time.Now()) {
+			tracerx.Printf("xfer: adapter %q worker %d found job for %q expired, retrying...", a.Name(), workerNum, t.Object.Oid)
+			err = errutil.NewRetriableError(fmt.Errorf("lfs/transfer: object %q has expired", t.Object.Oid))
+		} else {
+			err = a.transferImpl.DoTransfer(t, a.cb, authCallback)
+		}
 
 		if a.outChan != nil {
 			res := TransferResult{t, err}

--- a/transfer/adapterbase.go
+++ b/transfer/adapterbase.go
@@ -9,6 +9,12 @@ import (
 	"github.com/rubyist/tracerx"
 )
 
+const (
+	// objectExpirationGracePeriod is the grace period applied to objects
+	// when checking whether or not they have expired.
+	objectExpirationGracePeriod = 5 * time.Second
+)
+
 // adapterBase implements the common functionality for core adapters which
 // process transfers with N workers handling an oid each, and which wait for
 // authentication to succeed on one worker before proceeding
@@ -109,7 +115,7 @@ func (a *adapterBase) worker(workerNum int) {
 
 		// Actual transfer happens here
 		var err error
-		if t.Object.IsExpired(time.Now()) {
+		if t.Object.IsExpired(time.Now().Add(objectExpirationGracePeriod)) {
 			tracerx.Printf("xfer: adapter %q worker %d found job for %q expired, retrying...", a.Name(), workerNum, t.Object.Oid)
 			err = errutil.NewRetriableError(fmt.Errorf("lfs/transfer: object %q has expired", t.Object.Oid))
 		} else {


### PR DESCRIPTION
This pull request eagerly retries transfers that come back with expired actions, per https://github.com/github/git-lfs/issues/1345.

This is still a "work-in-progress", as I'm not 100% certain that I've implemented this in the right place. I followed the upload from `commands/command_push.go`, into the LFS code and the transfer code, into the `handleTransferResult`, which I think is where we want to be.

Just in case, I've left some `// NOTE`s throughout my code, which I would very much appreciate the validation of from any potential reviewers (/cc @sinbad).

Pending that validation, I'll go ahead and implement a change in the test server to validate that this behavior is used correctly and that requests are indeed retried. Since that component of the test server touches a good portion of our tests, I wanted to make sure that my fix is correct before going in and modifying a critical path in the test server.