### PR TITLE
Revert "Add checkout --unstaged flag"

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -20,7 +20,6 @@ var (
 		Use: "checkout",
 		Run: checkoutCommand,
 	}
-	checkoutUnstagedArg bool
 )
 
 func checkoutCommand(cmd *cobra.Command, args []string) {
@@ -44,7 +43,6 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	checkoutCmd.Flags().BoolVarP(&checkoutUnstagedArg, "unstaged", "u", false, "Do not add files to the index")
 	RootCmd.AddCommand(checkoutCmd)
 }
 
@@ -209,7 +207,7 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 			}
 		}
 
-		if cmd == nil && !checkoutUnstagedArg {
+		if cmd == nil {
 			// Fire up the update-index command
 			cmd = exec.Command("git", "update-index", "-q", "--refresh", "--stdin")
 			updateIdxStdin, err = cmd.StdinPipe()
@@ -223,9 +221,7 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 
 		}
 
-		if updateIdxStdin != nil {
-			updateIdxStdin.Write([]byte(cwdfilepath + "\n"))
-		}
+		updateIdxStdin.Write([]byte(cwdfilepath + "\n"))
 	}
 	close(repopathchan)
 

--- a/docs/man/git-lfs-checkout.1.ronn
+++ b/docs/man/git-lfs-checkout.1.ronn
@@ -3,7 +3,7 @@ git-lfs-checkout(1) -- Update working copy with file content if available
 
 ## SYNOPSIS
 
-`git lfs checkout` [options] <filespec>...
+`git lfs checkout` <filespec>...
 
 ## DESCRIPTION
 
@@ -17,11 +17,6 @@ pointer content with the same SHA, the real file content is written, provided
 we have it in the local store. Modified files are never overwritten.
 
 Filespecs can be provided as arguments to restrict the files which are updated.
-
-## OPTIONS
-
-* `--unstaged` `-u`:
-  Do not add files to the index, keeping them unstaged.
 
 ## EXAMPLES
 

--- a/test/test-checkout.sh
+++ b/test/test-checkout.sh
@@ -119,34 +119,3 @@ begin_test "checkout: outside git repository"
   grep "Not in a git repository" checkout.log
 )
 end_test
-
-begin_test "checkout --unstaged"
-(
-  set -e
-
-  reponame="$(basename "$0" ".sh")-unstaged"
-  setup_remote_repo "$reponame"
-
-  clone_repo "$reponame" repo-unstaged
-
-  git lfs track "*.dat" 2>&1 | tee track.log
-
-  contents="something something"
-
-  printf "$contents" > file1.dat
-  git add file1.dat
-  git add .gitattributes
-  git commit -m "add files"
-
-  # Remove the working directory
-  rm -f file1.dat
-
-  echo "checkout should replace all"
-  git lfs checkout --unstaged
-  [ "$contents" = "$(cat file1.dat)" ]
-
-  echo "large files should not be staged"
-  git diff-files
-  git diff-files | grep file1.dat
-)
-end_test


### PR DESCRIPTION
Fixes #1334
Reverts github/git-lfs#1262

Reverting for possible re-submission later. The reasons are:

1. Failures in the test are causing other subsequent PRs to fail. The reason is that skipping the `update-index` is unreliable at creating a clean git state, because the index cache may be out of date if the timestamp of files changes during checkout. Depending on the exact timing, the version of git, and the file system, precision issues can result in a non-clean status without `update-index`.

1. I think the flag `--unstaged` is misleading and the documentation "Do not add files to the index, keeping them unstaged." is incorrect. `checkout` never added anything to the index, it only made sure the index cache was not out of date.

If the intention is to save the expense of calling `update-index` then perhaps this feature can come back later in the form of a `--no-update-index` flag or something, with a more accurate description of what it does; including mentioning that although it's faster, it might prevent the state returning to clean correctly in some cases.