### PR TITLE
use proxy from git config 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -85,6 +85,7 @@ func NewConfig() *Configuration {
 func NewFromValues(gitconfig map[string]string) *Configuration {
 	config := &Configuration{
 		gitConfig: make(map[string]string, 0),
+		envVars:   make(map[string]string, 0),
 	}
 
 	buf := bytes.NewBuffer([]byte{})

--- a/httputil/http.go
+++ b/httputil/http.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -144,21 +143,6 @@ func NewHttpClient(c *config.Configuration, host string) *HttpClient {
 	httpClients[host] = client
 
 	return client
-}
-
-func ProxyFromGitConfigOrEnvironment(c *config.Configuration) func(req *http.Request) (*url.URL, error) {
-	return func(req *http.Request) (*url.URL, error) {
-		proxyURL, err := http.ProxyFromEnvironment(req)
-		if proxyURL != nil || err != nil {
-			return proxyURL, err
-		}
-
-		if proxy, ok := c.GitConfig("http.proxy"); ok {
-			return url.Parse(proxy)
-		}
-
-		return nil, nil
-	}
 }
 
 func CheckRedirect(req *http.Request, via []*http.Request) error {

--- a/httputil/http.go
+++ b/httputil/http.go
@@ -149,8 +149,7 @@ func NewHttpClient(c *config.Configuration, host string) *HttpClient {
 func ProxyFromGitConfigOrEnvironment(c *config.Configuration) func(req *http.Request) (*url.URL, error) {
 	return func(req *http.Request) (*url.URL, error) {
 		proxyURL, err := http.ProxyFromEnvironment(req)
-		fmt.Printf("YO: %v\n", proxyURL)
-		if proxyURL != nil {
+		if proxyURL != nil || err != nil {
 			return proxyURL, err
 		}
 

--- a/httputil/proxy.go
+++ b/httputil/proxy.go
@@ -1,0 +1,139 @@
+package httputil
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"fmt"
+
+	"github.com/github/git-lfs/config"
+)
+
+func ProxyFromGitConfigOrEnvironment(c *config.Configuration) func(req *http.Request) (*url.URL, error) {
+	https_proxy := c.Getenv("HTTPS_PROXY")
+	if len(https_proxy) == 0 {
+		https_proxy = c.Getenv("https_proxy")
+	}
+
+	http_proxy := c.Getenv("HTTP_PROXY")
+	if len(http_proxy) == 0 {
+		http_proxy = c.Getenv("http_proxy")
+	}
+
+	if len(http_proxy) == 0 {
+		http_proxy, _ = c.GitConfig("http.proxy")
+	}
+
+	no_proxy := c.Getenv("NO_PROXY")
+	if len(no_proxy) == 0 {
+		no_proxy = c.Getenv("no_proxy")
+	}
+
+	return func(req *http.Request) (*url.URL, error) {
+		var proxy string
+		if req.URL.Scheme == "https" {
+			proxy = https_proxy
+		}
+
+		if len(proxy) == 0 {
+			proxy = http_proxy
+		}
+
+		if len(proxy) == 0 {
+			return nil, nil
+		}
+
+		if !useProxy(no_proxy, canonicalAddr(req.URL)) {
+			return nil, nil
+		}
+
+		proxyURL, err := url.Parse(proxy)
+		if err != nil || !strings.HasPrefix(proxyURL.Scheme, "http") {
+			// proxy was bogus. Try prepending "http://" to it and
+			// see if that parses correctly. If not, we fall
+			// through and complain about the original one.
+			if proxyURL, err := url.Parse("http://" + proxy); err == nil {
+				return proxyURL, nil
+			}
+		}
+		if err != nil {
+			return nil, fmt.Errorf("invalid proxy address: %q: %v", proxy, err)
+		}
+		return proxyURL, nil
+	}
+}
+
+// canonicalAddr returns url.Host but always with a ":port" suffix
+func canonicalAddr(url *url.URL) string {
+	addr := url.Host
+	if !hasPort(addr) {
+		return addr + ":" + portMap[url.Scheme]
+	}
+	return addr
+}
+
+// useProxy reports whether requests to addr should use a proxy,
+// according to the NO_PROXY or no_proxy environment variable.
+// addr is always a canonicalAddr with a host and port.
+func useProxy(no_proxy, addr string) bool {
+	if len(addr) == 0 {
+		return true
+	}
+
+	if no_proxy == "*" {
+		return false
+	}
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	if host == "localhost" {
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.IsLoopback() {
+			return false
+		}
+	}
+
+	addr = strings.ToLower(strings.TrimSpace(addr))
+	if hasPort(addr) {
+		addr = addr[:strings.LastIndex(addr, ":")]
+	}
+
+	for _, p := range strings.Split(no_proxy, ",") {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if len(p) == 0 {
+			continue
+		}
+		if hasPort(p) {
+			p = p[:strings.LastIndex(p, ":")]
+		}
+		if addr == p {
+			return false
+		}
+		if p[0] == '.' && (strings.HasSuffix(addr, p) || addr == p[1:]) {
+			// no_proxy ".foo.com" matches "bar.foo.com" or "foo.com"
+			return false
+		}
+		if p[0] != '.' && strings.HasSuffix(addr, p) && addr[len(addr)-len(p)-1] == '.' {
+			// no_proxy "foo.com" matches "bar.foo.com"
+			return false
+		}
+	}
+	return true
+}
+
+// Given a string of the form "host", "host:port", or "[ipv6::address]:port",
+// return true if the string includes a port.
+func hasPort(s string) bool { return strings.LastIndex(s, ":") > strings.LastIndex(s, "]") }
+
+var (
+	portMap = map[string]string{
+		"http":  "80",
+		"https": "443",
+	}
+)

--- a/httputil/proxy.go
+++ b/httputil/proxy.go
@@ -13,18 +13,26 @@ import (
 
 // Logic is copied, with small changes, from "net/http".ProxyFromEnvironment in the go std lib.
 func ProxyFromGitConfigOrEnvironment(c *config.Configuration) func(req *http.Request) (*url.URL, error) {
-	https_proxy := c.Getenv("HTTPS_PROXY")
+	var https_proxy string
+	http_proxy, _ := c.GitConfig("http.proxy")
+	if strings.HasPrefix(http_proxy, "https://") {
+		https_proxy = http_proxy
+	}
+
+	if len(https_proxy) == 0 {
+		https_proxy = c.Getenv("HTTPS_PROXY")
+	}
+
 	if len(https_proxy) == 0 {
 		https_proxy = c.Getenv("https_proxy")
 	}
 
-	http_proxy := c.Getenv("HTTP_PROXY")
 	if len(http_proxy) == 0 {
-		http_proxy = c.Getenv("http_proxy")
+		http_proxy = c.Getenv("HTTP_PROXY")
 	}
 
 	if len(http_proxy) == 0 {
-		http_proxy, _ = c.GitConfig("http.proxy")
+		http_proxy = c.Getenv("http_proxy")
 	}
 
 	no_proxy := c.Getenv("NO_PROXY")

--- a/httputil/proxy.go
+++ b/httputil/proxy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/github/git-lfs/config"
 )
 
+// Logic is copied, with small changes, from "net/http".ProxyFromEnvironment in the go std lib.
 func ProxyFromGitConfigOrEnvironment(c *config.Configuration) func(req *http.Request) (*url.URL, error) {
 	https_proxy := c.Getenv("HTTPS_PROXY")
 	if len(https_proxy) == 0 {
@@ -66,6 +67,7 @@ func ProxyFromGitConfigOrEnvironment(c *config.Configuration) func(req *http.Req
 }
 
 // canonicalAddr returns url.Host but always with a ":port" suffix
+// Copied from "net/http".ProxyFromEnvironment in the go std lib.
 func canonicalAddr(url *url.URL) string {
 	addr := url.Host
 	if !hasPort(addr) {
@@ -77,6 +79,7 @@ func canonicalAddr(url *url.URL) string {
 // useProxy reports whether requests to addr should use a proxy,
 // according to the NO_PROXY or no_proxy environment variable.
 // addr is always a canonicalAddr with a host and port.
+// Copied from "net/http".ProxyFromEnvironment in the go std lib.
 func useProxy(no_proxy, addr string) bool {
 	if len(addr) == 0 {
 		return true
@@ -129,6 +132,7 @@ func useProxy(no_proxy, addr string) bool {
 
 // Given a string of the form "host", "host:port", or "[ipv6::address]:port",
 // return true if the string includes a port.
+// Copied from "net/http".ProxyFromEnvironment in the go std lib.
 func hasPort(s string) bool { return strings.LastIndex(s, ":") > strings.LastIndex(s, "]") }
 
 var (

--- a/httputil/proxy_test.go
+++ b/httputil/proxy_test.go
@@ -24,7 +24,7 @@ func TestProxyFromEnvironment(t *testing.T) {
 	proxyURL, err := ProxyFromGitConfigOrEnvironment(cfg)(req)
 
 	assert.Equal(t, "proxy-from-env:8080", proxyURL.Host)
-	assert.Equal(t, nil, err)
+	assert.Nil(t, err)
 }
 
 func TestProxyFromGitConfig(t *testing.T) {
@@ -40,7 +40,7 @@ func TestProxyFromGitConfig(t *testing.T) {
 	proxyURL, err := ProxyFromGitConfigOrEnvironment(cfg)(req)
 
 	assert.Equal(t, "proxy-from-git-config:8080", proxyURL.Host)
-	assert.Equal(t, nil, err)
+	assert.Nil(t, err)
 }
 
 func TestProxyIsNil(t *testing.T) {

--- a/httputil/proxy_test.go
+++ b/httputil/proxy_test.go
@@ -1,11 +1,10 @@
-package lfs
+package httputil
 
 import (
 	"net/http"
 	"testing"
 
 	"github.com/github/git-lfs/config"
-	"github.com/github/git-lfs/httputil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,7 +21,7 @@ func TestProxyFromEnvironment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	proxyURL, err := httputil.ProxyFromGitConfigOrEnvironment(cfg)(req)
+	proxyURL, err := ProxyFromGitConfigOrEnvironment(cfg)(req)
 
 	assert.Equal(t, "proxy-from-env:8080", proxyURL.Host)
 	assert.Equal(t, nil, err)
@@ -38,7 +37,7 @@ func TestProxyFromGitConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	proxyURL, err := httputil.ProxyFromGitConfigOrEnvironment(cfg)(req)
+	proxyURL, err := ProxyFromGitConfigOrEnvironment(cfg)(req)
 
 	assert.Equal(t, "proxy-from-git-config:8080", proxyURL.Host)
 	assert.Equal(t, nil, err)
@@ -52,7 +51,7 @@ func TestProxyIsNil(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	proxyURL, err := httputil.ProxyFromGitConfigOrEnvironment(cfg)(req)
+	proxyURL, err := ProxyFromGitConfigOrEnvironment(cfg)(req)
 
 	assert.Nil(t, proxyURL)
 	assert.Nil(t, err)
@@ -71,7 +70,7 @@ func TestProxyNoProxy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	proxyUrl, err := httputil.ProxyFromGitConfigOrEnvironment(cfg)(req)
+	proxyUrl, err := ProxyFromGitConfigOrEnvironment(cfg)(req)
 
 	assert.Nil(t, proxyUrl)
 	assert.Nil(t, err)

--- a/lfs/proxy_test.go
+++ b/lfs/proxy_test.go
@@ -2,7 +2,6 @@ package lfs
 
 import (
 	"net/http"
-	"net/url"
 	"testing"
 
 	"github.com/github/git-lfs/config"
@@ -18,14 +17,9 @@ func TestProxyFromEnvironment(t *testing.T) {
 		"HTTPS_PROXY": "https://proxy-from-env:8080",
 	})
 
-	u, err := url.Parse("https://some-host.com:123/foo/bar")
+	req, err := http.NewRequest("GET", "https://some-host.com:123/foo/bar", nil)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	req := &http.Request{
-		URL:    u,
-		Header: http.Header{},
 	}
 
 	proxyURL, err := httputil.ProxyFromGitConfigOrEnvironment(cfg)(req)
@@ -39,14 +33,9 @@ func TestProxyFromGitConfig(t *testing.T) {
 		"http.proxy": "https://proxy-from-git-config:8080",
 	})
 
-	u, err := url.Parse("http://some-host.com:123/foo/bar")
+	req, err := http.NewRequest("GET", "http://some-host.com:123/foo/bar", nil)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	req := &http.Request{
-		URL:    u,
-		Header: http.Header{},
 	}
 
 	proxyURL, err := httputil.ProxyFromGitConfigOrEnvironment(cfg)(req)
@@ -57,13 +46,10 @@ func TestProxyFromGitConfig(t *testing.T) {
 
 func TestProxyIsNil(t *testing.T) {
 	cfg := config.NewConfig()
-	u, err := url.Parse("http://some-host.com:123/foo/bar")
+
+	req, err := http.NewRequest("GET", "http://some-host.com:123/foo/bar", nil)
 	if err != nil {
 		t.Fatal(err)
-	}
-	req := &http.Request{
-		URL:    u,
-		Header: http.Header{},
 	}
 
 	proxyURL, err := httputil.ProxyFromGitConfigOrEnvironment(cfg)(req)

--- a/lfs/proxy_test.go
+++ b/lfs/proxy_test.go
@@ -57,3 +57,22 @@ func TestProxyIsNil(t *testing.T) {
 	assert.Nil(t, proxyURL)
 	assert.Nil(t, err)
 }
+
+func TestProxyNoProxy(t *testing.T) {
+	cfg := config.NewFromValues(map[string]string{
+		"http.proxy": "https://proxy-from-git-config:8080",
+	})
+	cfg.SetAllEnv(map[string]string{
+		"NO_PROXY": "some-host",
+	})
+
+	req, err := http.NewRequest("GET", "https://some-host:8080", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxyUrl, err := httputil.ProxyFromGitConfigOrEnvironment(cfg)(req)
+
+	assert.Nil(t, proxyUrl)
+	assert.Nil(t, err)
+}

--- a/lfs/proxy_test.go
+++ b/lfs/proxy_test.go
@@ -10,6 +10,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestProxyFromEnvironment(t *testing.T) {
+	cfg := config.NewFromValues(map[string]string{
+		"http.proxy": "https://proxy-from-git-config:8080",
+	})
+	cfg.SetAllEnv(map[string]string{
+		"HTTPS_PROXY": "https://proxy-from-env:8080",
+	})
+
+	u, err := url.Parse("https://some-host.com:123/foo/bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := &http.Request{
+		URL:    u,
+		Header: http.Header{},
+	}
+
+	proxyURL, err := httputil.ProxyFromGitConfigOrEnvironment(cfg)(req)
+
+	assert.Equal(t, "proxy-from-env:8080", proxyURL.Host)
+	assert.Equal(t, nil, err)
+}
+
 func TestProxyFromGitConfig(t *testing.T) {
 	cfg := config.NewFromValues(map[string]string{
 		"http.proxy": "https://proxy-from-git-config:8080",

--- a/lfs/proxy_test.go
+++ b/lfs/proxy_test.go
@@ -3,40 +3,36 @@ package lfs
 import (
 	"net/http"
 	"net/url"
-	// "os"
 	"testing"
 
-	"github.com/github/git-lfs/vendor/_nuts/github.com/technoweenie/assert"
+	"github.com/github/git-lfs/config"
+	"github.com/github/git-lfs/httputil"
+	"github.com/stretchr/testify/assert"
 )
 
-// --- FAIL: TestProxyFromEnv (0.00s)
-// panic: runtime error: invalid memory address or nil pointer dereference [recovered]
-// panic: runtime error: invalid memory address or nil pointer dereference
-//
-// func TestProxyFromEnv(t *testing.T) {
-// 	os.Setenv("HTTPS_PROXY", "https://proxy-from-env:8080")
-//
-// 	u, err := url.Parse("http://some-host.com:123/foo/bar")
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	req := &http.Request{
-// 		URL:    u,
-// 		Header: http.Header{},
-// 	}
-// 	proxyURL, err := proxyFromGitConfigOrEnvironment(req)
-//
-// 	assert.Equal(t, "proxy-from-env:8080", proxyURL.Host)
-// 	assert.Equal(t, nil, err)
-// }
-
 func TestProxyFromGitConfig(t *testing.T) {
-	oldGitConfig := Config.gitConfig
-	defer func() {
-		Config.gitConfig = oldGitConfig
-	}()
-	Config.gitConfig = map[string]string{"http.proxy": "https://proxy-from-git-config:8080"}
+	cfg := config.NewFromValues(map[string]string{
+		"http.proxy": "https://proxy-from-git-config:8080",
+	})
 
+	u, err := url.Parse("http://some-host.com:123/foo/bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := &http.Request{
+		URL:    u,
+		Header: http.Header{},
+	}
+
+	proxyURL, err := httputil.ProxyFromGitConfigOrEnvironment(cfg)(req)
+
+	assert.Equal(t, "proxy-from-git-config:8080", proxyURL.Host)
+	assert.Equal(t, nil, err)
+}
+
+func TestProxyIsNil(t *testing.T) {
+	cfg := config.NewConfig()
 	u, err := url.Parse("http://some-host.com:123/foo/bar")
 	if err != nil {
 		t.Fatal(err)
@@ -45,27 +41,9 @@ func TestProxyFromGitConfig(t *testing.T) {
 		URL:    u,
 		Header: http.Header{},
 	}
-	proxyURL, err := proxyFromGitConfigOrEnvironment(req)
 
-	assert.Equal(t, "proxy-from-git-config:8080", proxyURL.Host)
-	assert.Equal(t, nil, err)
+	proxyURL, err := httputil.ProxyFromGitConfigOrEnvironment(cfg)(req)
+
+	assert.Nil(t, proxyURL)
+	assert.Nil(t, err)
 }
-
-// --- FAIL: TestProxyIsNil (0.00s)
-// panic: runtime error: invalid memory address or nil pointer dereference [recovered]
-// panic: runtime error: invalid memory address or nil pointer dereference
-//
-// func TestProxyIsNil(t *testing.T) {
-// 	u, err := url.Parse("http://some-host.com:123/foo/bar")
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	req := &http.Request{
-// 		URL:    u,
-// 		Header: http.Header{},
-// 	}
-// 	proxyURL, err := proxyFromGitConfigOrEnvironment(req)
-//
-// 	assert.Equal(t, nil, proxyURL.Host)
-// 	assert.Equal(t, nil, err)
-// }


### PR DESCRIPTION
This updates #1173 with the latest master. Since that PR, a lot of subpackages have been split out, and we've switched assertion libraries. 

@jonmagic @LizzHale: I also changed the main `ProxyFromGitConfigOrEnvironment()` function from #1173 for these reasons:

1. `proxyFromGitConfigOrEnvironment()` is coupled to the global `Config` value. I updated the function to accept only a `*config.Configuration` argument, and return a `func(*http.Request) (*url.URL, error)`. That cleaned up the test setup for `TestProxyFromGitConfig` a bit.
2. It returns a valid url OR error from `http.ProxyFromEnvironment` now. I didn't want to drop a potential error if users have a bad HTTPS_PROXY value, but a good git `http.proxy` value.
3. The end of the function returns `nil` now, explicitly.

Unfortunately, I couldn't test the environment, because of [how `http.ProxyFromEnvironment` is implemented](https://golang.org/src/net/http/transport.go?s=7918:7975#L202). It reads from the env the _first_ time that function is called. Calling `os.Setenv` doesn't affect it.

However, I'm thinking about pulling all that code into Git LFS. There are a few internal functions that would be useful for proxy values specified in the git config, such as `NO_PROXY` handling.