### PR TITLE
use `git rev-list --stdin` instead of passing each remote ref

### DIFF
--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -265,11 +265,11 @@ func ScanIndex() ([]*WrappedPointer, error) {
 
 }
 
-// Get additional arguments needed to limit 'git rev-list' to just the changes in revTo
-// that are also not on remoteName.
+// Get additional arguments needed to limit 'git rev-list' to just the changes
+// in revTo that are also not on remoteName.
 //
-// Returns a slice of string args, and false if --stdin is not needed.
-// Returns a slice of string commit args and true if --stdin is needed.
+// Returns a slice of string command arguments, and a slice of string git
+// commits to pass to `git rev-list` via STDIN.
 func revListArgsRefVsRemote(refTo, remoteName string) ([]string, []string) {
 	// We need to check that the locally cached versions of remote refs are still
 	// present on the remote before we use them as a 'from' point. If the

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -304,7 +304,7 @@ func revListArgsRefVsRemote(refTo, remoteName string) ([]string, bool) {
 				commits = append(commits, "^"+cachedRef.Sha)
 			}
 		}
-		return commits
+		return commits, true
 	} else {
 		// Safe to use cached
 		return []string{refTo, "--not", "--remotes=" + remoteName}, false

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -267,6 +267,9 @@ func ScanIndex() ([]*WrappedPointer, error) {
 
 // Get additional arguments needed to limit 'git rev-list' to just the changes in revTo
 // that are also not on remoteName.
+//
+// Returns a slice of string args, and false if --stdin is not needed.
+// Returns a slice of string commit args and true if --stdin is needed.
 func revListArgsRefVsRemote(refTo, remoteName string) ([]string, bool) {
 	// We need to check that the locally cached versions of remote refs are still
 	// present on the remote before we use them as a 'from' point. If the
@@ -297,7 +300,7 @@ func revListArgsRefVsRemote(refTo, remoteName string) ([]string, bool) {
 
 	if len(missingRefs) > 0 {
 		// Use only the non-missing refs as 'from' points
-		commits := make([]string, 1, len(cachedRemoteRefs) + 1)
+		commits := make([]string, 1, len(cachedRemoteRefs)+1)
 		commits[0] = refTo
 		for _, cachedRef := range cachedRemoteRefs {
 			if !missingRefs.Contains(cachedRef.Name) {


### PR DESCRIPTION
Fixes https://github.com/github/git-lfs/issues/1318 by using `--stdin`. Hat tip to @alex-davidson for the idea. It doesn't work with the `--not` flag, so it now passes SHAs in with a `^` prefix.