### PR TITLE
travis-ci: add a build job to test against upcoming versions of Git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,25 @@ os:
 env:
   global:
     - GIT_LFS_TEST_DIR="$HOME/git-lfs-tests"
+    - GIT_SOURCE_REPO="https://github.com/git/git.git"
+    - GIT_SOURCE_BRANCH="next"
 
 matrix:
   fast_finish: true
   allow_failures:
     - os: osx
+    - env: git-from-source
   include:
+    - env: git-from-source
+      os: linux
+      before_script:
+        - >
+          git clone $GIT_SOURCE_REPO git-source;
+          cd git-source;
+          git checkout $GIT_SOURCE_BRANCH;
+          make --jobs=2;
+          make install;
+          cd ..;
     - env: git-latest
       os: linux
       addons:


### PR DESCRIPTION
The Git source version is defined by the variables GIT_SOURCE_REPO and
GIT_SOURCE_BRANCH (which can also be a Git hash). The Git source is
checked out, compiled, and installed on the Travis CI Linux machine.
Afterwards all Git-LFS tests are executed against the this Git version.

This setup helps to test features that depend on changes in the
development branches of Git and Git-LFS.