### PR TITLE
test/zero-len: update test for git v2.9.1

### DIFF
--- a/test/test-zero-len-file.sh
+++ b/test/test-zero-len-file.sh
@@ -50,8 +50,7 @@ begin_test "pull zero len file"
   clone_repo "$reponame" clone
   rm clone.log
 
-  git status 2>&1 | tee status.log
-  grep "working (directory|tree) clean" status.log
+  git status | grep -E "working (directory|tree) clean"
   ls -al
 
   if [ -s "empty.dat" ]; then

--- a/test/test-zero-len-file.sh
+++ b/test/test-zero-len-file.sh
@@ -50,7 +50,8 @@ begin_test "pull zero len file"
   clone_repo "$reponame" clone
   rm clone.log
 
-  git status | grep "working directory clean"
+  git status 2>&1 | tee status.log
+  grep "working (directory|tree) clean" status.log
   ls -al
 
   if [ -s "empty.dat" ]; then


### PR DESCRIPTION
With the new release of Git, version 2.9.1, our "pull zero len file" test is
broken. @larsxschneider was the first to point this out in github/git-lfs#1363.

The cause of this problem is that `git-status` changed to print "working tree
clean", instead of "working directory clean" when running in a clean working
tree. Though this is more correct, it still broke our tests :-).

This commit changes the `grep` assertion to match the new behavior of
`git-status`.

The relevant change from git/git is here: git/git@2a0e6cd.

Closes: github/git-lfs#1363.

------------

/cc @larsxschneider @technoweenie @rubyist @sinbad 