### PR TITLE
Fix zero len test with git 2.9.1 - clean message changed

### DIFF
--- a/test/test-zero-len-file.sh
+++ b/test/test-zero-len-file.sh
@@ -50,7 +50,7 @@ begin_test "pull zero len file"
   clone_repo "$reponame" clone
   rm clone.log
 
-  git status | grep "working directory clean"
+  git status | egrep "working (directory|tree) clean"
   ls -al
 
   if [ -s "empty.dat" ]; then


### PR DESCRIPTION
Fixes #1363 

Note needs `egrep` to reliably use conditionals in my tests.