### PR TITLE
travis-ci: require successful tests against upcoming Git core release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,12 @@ env:
   global:
     - GIT_LFS_TEST_DIR="$HOME/git-lfs-tests"
     - GIT_SOURCE_REPO="https://github.com/git/git.git"
-    - GIT_SOURCE_BRANCH="next"
+    - GIT_SOURCE_BRANCH="master"
 
 matrix:
   fast_finish: true
   allow_failures:
     - os: osx
-    - env: git-from-source
   include:
     - env: git-from-source
       os: linux


### PR DESCRIPTION
The Git-core 'master' branch tracks the commits that should go into the next release (see https://github.com/git/git/blob/master/Documentation/gitworkflows.txt). 

Run Git-LFS tests against a build of the Git-core 'master' branch and require a successful pass.