### PR TITLE
In git 2.9+, run "git lfs pull" in submodules after "git lfs clone"

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -92,7 +92,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 
 func postCloneSubmodules(args []string) error {
 	// In git 2.9+ the filter option will have been passed through to submodules
-	// So we need to lfs pull inside each, if the original clone command
+	// So we need to lfs pull inside each
 	if !git.Config.IsGitVersionAtLeast("2.9.0") {
 		// In earlier versions submodules would have used smudge filter
 		return nil


### PR DESCRIPTION
Fixes #1172

git 2.9+ preserves the config settings which disable the LFS filters in submodules so any LFS files will be pointers. This makes it more optimal (previous versions will suppress these settings so the smudge filter will be used in submodules) but we must run "git lfs pull" to update the submodule working copies.

/cc @larsxschneider 