### PR TITLE
teach script/integration.go about GIT_LFS_TEST_MAXPROCS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go: 1.6
 
 os:
   - linux
+  - osx
 
 env:
   global:
@@ -14,8 +15,6 @@ env:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: plain-osx
   include:
     - env: git-from-source
       os: linux
@@ -60,8 +59,6 @@ matrix:
         - >
           brew update;
           brew install git;
-    - env: plain-osx
-      os: osx
 
 before_install:
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ os:
 env:
   global:
     - GIT_LFS_TEST_DIR="$HOME/git-lfs-tests"
-    - GIT_LFS_TEST_MAXPROCS=1
     - GIT_SOURCE_REPO="https://github.com/git/git.git"
     - GIT_SOURCE_BRANCH="master"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ go: 1.6
 
 os:
   - linux
-  - osx
 
 env:
   global:
@@ -16,7 +15,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - os: osx
+    - env: plain-osx
   include:
     - env: git-from-source
       os: linux
@@ -61,6 +60,8 @@ matrix:
         - >
           brew update;
           brew install git;
+    - env: plain-osx
+      os: osx
 
 before_install:
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ os:
 env:
   global:
     - GIT_LFS_TEST_DIR="$HOME/git-lfs-tests"
+    - GIT_LFS_TEST_MAXPROCS=1
     - GIT_SOURCE_REPO="https://github.com/git/git.git"
     - GIT_SOURCE_BRANCH="master"
 

--- a/script/integration
+++ b/script/integration
@@ -41,9 +41,7 @@ fi
 
 setup
 
-parallel=${GIT_LFS_TEST_MAXPROCS:-4}
-
 echo "Running this maxprocs=$parallel"
 echo
 
-GO15VENDOREXPERIMENT=1 GIT_LFS_TEST_MAXPROCS=$parallel GIT_LFS_TEST_DIR="$GIT_LFS_TEST_DIR" SHUTDOWN_LFS="no" go run script/*.go -cmd integration "$@"
+GO15VENDOREXPERIMENT=1 GIT_LFS_TEST_MAXPROCS=$GIT_LFS_TEST_MAXPROCS GIT_LFS_TEST_DIR="$GIT_LFS_TEST_DIR" SHUTDOWN_LFS="no" go run script/*.go -cmd integration "$@"

--- a/script/integration
+++ b/script/integration
@@ -41,7 +41,4 @@ fi
 
 setup
 
-echo "Running this maxprocs=$parallel"
-echo
-
 GO15VENDOREXPERIMENT=1 GIT_LFS_TEST_MAXPROCS=$GIT_LFS_TEST_MAXPROCS GIT_LFS_TEST_DIR="$GIT_LFS_TEST_DIR" SHUTDOWN_LFS="no" go run script/*.go -cmd integration "$@"

--- a/script/integration.go
+++ b/script/integration.go
@@ -94,8 +94,6 @@ func runTest(output chan string, testname string) {
 		cmd.Process.Kill()
 		return
 	}
-
-	sendTestOutput(output, testname, buf, nil)
 }
 
 func sendTestOutput(output chan string, testname string, buf *bytes.Buffer, err error) {

--- a/script/integration.go
+++ b/script/integration.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -29,8 +30,8 @@ func mainIntegration() {
 
 	setBash()
 
-	if maxprocs < 1 {
-		maxprocs = 1
+	if max, _ := strconv.Atoi(os.Getenv("GIT_LFS_TEST_MAXPROCS")); max > 0 {
+		maxprocs = max
 	}
 
 	files := testFiles()

--- a/script/integration.go
+++ b/script/integration.go
@@ -30,11 +30,6 @@ func mainIntegration() {
 
 	setBash()
 
-	if runtime.GOOS == "darwin" {
-		// set default maxprocs to 1 because of osxkeychain issues
-		maxprocs = 1
-	}
-
 	if max, _ := strconv.Atoi(os.Getenv("GIT_LFS_TEST_MAXPROCS")); max > 0 {
 		maxprocs = max
 	}

--- a/script/integration.go
+++ b/script/integration.go
@@ -30,6 +30,11 @@ func mainIntegration() {
 
 	setBash()
 
+	if runtime.GOOS == "darwin" {
+		// set default maxprocs to 1 because of osxkeychain issues
+		maxprocs = 1
+	}
+
 	if max, _ := strconv.Atoi(os.Getenv("GIT_LFS_TEST_MAXPROCS")); max > 0 {
 		maxprocs = max
 	}

--- a/script/integration.go
+++ b/script/integration.go
@@ -39,6 +39,8 @@ func mainIntegration() {
 		maxprocs = max
 	}
 
+	fmt.Println("Running this maxprocs", maxprocs)
+
 	files := testFiles()
 
 	if len(files) == 0 {

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -71,15 +71,20 @@ func main() {
 	mux.HandleFunc("/locks", locksHandler)
 	mux.HandleFunc("/locks/", locksHandler)
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		id, ok := reqId(w)
+		if !ok {
+			return
+		}
+
 		if strings.Contains(r.URL.Path, "/info/lfs") {
-			if !skipIfBadAuth(w, r) {
-				lfsHandler(w, r)
+			if !skipIfBadAuth(w, r, id) {
+				lfsHandler(w, r, id)
 			}
 
 			return
 		}
 
-		log.Printf("git http-backend %s %s\n", r.Method, r.URL)
+		debug(id, "git http-backend %s %s", r.Method, r.URL)
 		gitHandler(w, r)
 	})
 
@@ -96,11 +101,11 @@ func main() {
 	certname := writeTestStateFile(pembytes, "LFSTEST_CERT", "lfstest-gitserver-cert")
 	defer os.RemoveAll(certname)
 
-	log.Println(server.URL)
-	log.Println(serverTLS.URL)
+	debug("init", "server url: %s", server.URL)
+	debug("init", "server tls url: %s", serverTLS.URL)
 
 	<-stopch
-	log.Println("git server done")
+	debug("init", "git server done")
 }
 
 // writeTestStateFile writes contents to either the file referenced by the
@@ -139,7 +144,7 @@ type lfsError struct {
 }
 
 // handles any requests with "{name}.server.git/info/lfs" in the path
-func lfsHandler(w http.ResponseWriter, r *http.Request) {
+func lfsHandler(w http.ResponseWriter, r *http.Request, id string) {
 	repo, err := repoFromLfsUrl(r.URL.Path)
 	if err != nil {
 		w.WriteHeader(500)
@@ -147,17 +152,17 @@ func lfsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("git lfs %s %s repo: %s\n", r.Method, r.URL, repo)
+	debug(id, "git lfs %s %s repo: %s", r.Method, r.URL, repo)
 	w.Header().Set("Content-Type", "application/vnd.git-lfs+json")
 	switch r.Method {
 	case "POST":
 		if strings.HasSuffix(r.URL.String(), "batch") {
-			lfsBatchHandler(w, r, repo)
+			lfsBatchHandler(w, r, id, repo)
 		} else {
-			lfsPostHandler(w, r, repo)
+			lfsPostHandler(w, r, id, repo)
 		}
 	case "GET":
-		lfsGetHandler(w, r, repo)
+		lfsGetHandler(w, r, id, repo)
 	default:
 		w.WriteHeader(405)
 	}
@@ -167,7 +172,7 @@ func lfsUrl(repo, oid string) string {
 	return server.URL + "/storage/" + oid + "?r=" + repo
 }
 
-func lfsPostHandler(w http.ResponseWriter, r *http.Request, repo string) {
+func lfsPostHandler(w http.ResponseWriter, r *http.Request, id, repo string) {
 	buf := &bytes.Buffer{}
 	tee := io.TeeReader(r.Body, buf)
 	obj := &lfsObject{}
@@ -175,10 +180,10 @@ func lfsPostHandler(w http.ResponseWriter, r *http.Request, repo string) {
 	io.Copy(ioutil.Discard, r.Body)
 	r.Body.Close()
 
-	log.Println("REQUEST")
-	log.Println(buf.String())
-	log.Printf("OID: %s\n", obj.Oid)
-	log.Printf("Size: %d\n", obj.Size)
+	debug(id, "REQUEST")
+	debug(id, buf.String())
+	debug(id, "OID: %s", obj.Oid)
+	debug(id, "Size: %d", obj.Size)
 
 	if err != nil {
 		log.Fatal(err)
@@ -222,21 +227,21 @@ func lfsPostHandler(w http.ResponseWriter, r *http.Request, repo string) {
 		log.Fatal(err)
 	}
 
-	log.Println("RESPONSE: 202")
-	log.Println(string(by))
+	debug(id, "RESPONSE: 202")
+	debug(id, string(by))
 
 	w.WriteHeader(202)
 	w.Write(by)
 }
 
-func lfsGetHandler(w http.ResponseWriter, r *http.Request, repo string) {
+func lfsGetHandler(w http.ResponseWriter, r *http.Request, id, repo string) {
 	parts := strings.Split(r.URL.Path, "/")
 	oid := parts[len(parts)-1]
 
 	// Support delete for testing
 	if len(parts) > 1 && parts[len(parts)-2] == "delete" {
 		largeObjects.Delete(repo, oid)
-		log.Println("DELETE:", oid)
+		debug(id, "DELETE:", oid)
 		w.WriteHeader(200)
 		return
 	}
@@ -262,14 +267,14 @@ func lfsGetHandler(w http.ResponseWriter, r *http.Request, repo string) {
 		log.Fatal(err)
 	}
 
-	log.Println("RESPONSE: 200")
-	log.Println(string(by))
+	debug(id, "RESPONSE: 200")
+	debug(id, string(by))
 
 	w.WriteHeader(200)
 	w.Write(by)
 }
 
-func lfsBatchHandler(w http.ResponseWriter, r *http.Request, repo string) {
+func lfsBatchHandler(w http.ResponseWriter, r *http.Request, id, repo string) {
 	if repo == "batchunsupported" {
 		w.WriteHeader(404)
 		return
@@ -309,8 +314,8 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, repo string) {
 	io.Copy(ioutil.Discard, r.Body)
 	r.Body.Close()
 
-	log.Println("REQUEST")
-	log.Println(buf.String())
+	debug(id, "REQUEST")
+	debug(id, buf.String())
 
 	if err != nil {
 		log.Fatal(err)
@@ -402,8 +407,8 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, repo string) {
 		log.Fatal(err)
 	}
 
-	log.Println("RESPONSE: 200")
-	log.Println(string(by))
+	debug(id, "RESPONSE: 200")
+	debug(id, string(by))
 
 	w.WriteHeader(200)
 	w.Write(by)
@@ -441,6 +446,11 @@ var tusStorageAttempts = 0
 
 // handles any /storage/{oid} requests
 func storageHandler(w http.ResponseWriter, r *http.Request) {
+	id, ok := reqId(w)
+	if !ok {
+		return
+	}
+
 	repo := r.URL.Query().Get("r")
 	parts := strings.Split(r.URL.Path, "/")
 	oid := parts[len(parts)-1]
@@ -448,7 +458,7 @@ func storageHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("storage %s %s repo: %s\n", r.Method, oid, repo)
+	debug(id, "storage %s %s repo: %s", r.Method, oid, repo)
 	switch r.Method {
 	case "PUT":
 		switch oidHandlers[oid] {
@@ -478,7 +488,7 @@ func storageHandler(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			if !valid {
-				log.Fatal("Chunked transfer encoding expected")
+				debug(id, "Chunked transfer encoding expected")
 			}
 		}
 
@@ -543,7 +553,7 @@ func storageHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(404)
 	case "HEAD":
 		// tus.io
-		if !validateTusHeaders(r) {
+		if !validateTusHeaders(r, id) {
 			w.WriteHeader(400)
 			return
 		}
@@ -557,7 +567,7 @@ func storageHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 	case "PATCH":
 		// tus.io
-		if !validateTusHeaders(r) {
+		if !validateTusHeaders(r, id) {
 			w.WriteHeader(400)
 			return
 		}
@@ -588,7 +598,7 @@ func storageHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			largeObjects.DeleteIncomplete(repo, oid)
-			log.Printf("Resuming upload of %v at byte %d", oid, offset)
+			debug(id, "Resuming upload of %v at byte %d", oid, offset)
 		}
 
 		// As a test, we intentionally break the upload from byte 0 by only
@@ -613,7 +623,7 @@ func storageHandler(w http.ResponseWriter, r *http.Request) {
 		if copyErr != nil {
 			b := buf.Bytes()
 			if len(b) > 0 {
-				log.Printf("Incomplete upload of %v, %d bytes", oid, len(b))
+				debug(id, "Incomplete upload of %v, %d bytes", oid, len(b))
 				largeObjects.SetIncomplete(repo, oid, b)
 			}
 			w.WriteHeader(500)
@@ -636,13 +646,12 @@ func storageHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func validateTusHeaders(r *http.Request) bool {
+func validateTusHeaders(r *http.Request, id string) bool {
 	if len(r.Header.Get("Tus-Resumable")) == 0 {
-		log.Fatal("Missing Tus-Resumable header in request")
+		debug(id, "Missing Tus-Resumable header in request")
 		return false
 	}
 	return true
-
 }
 
 func gitHandler(w http.ResponseWriter, r *http.Request) {
@@ -690,6 +699,11 @@ func gitHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func redirect307Handler(w http.ResponseWriter, r *http.Request) {
+	id, ok := reqId(w)
+	if !ok {
+		return
+	}
+
 	// Send a redirect to info/lfs
 	// Make it either absolute or relative depending on subpath
 	parts := strings.Split(r.URL.Path, "/")
@@ -700,7 +714,7 @@ func redirect307Handler(w http.ResponseWriter, r *http.Request) {
 	} else if parts[2] == "abs" {
 		redirectTo = server.URL + "/" + strings.Join(parts[3:], "/")
 	} else {
-		log.Fatal(fmt.Errorf("Invalid URL for redirect: %v", r.URL))
+		debug(id, "Invalid URL for redirect: %v", r.URL)
 		w.WriteHeader(404)
 		return
 	}
@@ -1077,7 +1091,7 @@ func extractAuth(auth string) (string, string, error) {
 	return "", "", nil
 }
 
-func skipIfBadAuth(w http.ResponseWriter, r *http.Request) bool {
+func skipIfBadAuth(w http.ResponseWriter, r *http.Request, id string) bool {
 	auth := r.Header.Get("Authorization")
 	if auth == "" {
 		w.WriteHeader(401)
@@ -1087,7 +1101,7 @@ func skipIfBadAuth(w http.ResponseWriter, r *http.Request) bool {
 	user, pass, err := extractAuth(auth)
 	if err != nil {
 		w.WriteHeader(403)
-		log.Printf("Error decoding auth: %s\n", err)
+		debug(id, "Error decoding auth: %s", err)
 		return true
 	}
 
@@ -1102,11 +1116,11 @@ func skipIfBadAuth(w http.ResponseWriter, r *http.Request) bool {
 		if strings.HasPrefix(r.URL.Path, "/"+pass) {
 			return false
 		}
-		log.Printf("auth attempt against: %q", r.URL.Path)
+		debug(id, "auth attempt against: %q", r.URL.Path)
 	}
 
 	w.WriteHeader(403)
-	log.Printf("Bad auth: %q\n", auth)
+	debug(id, "Bad auth: %q", auth)
 	return true
 }
 
@@ -1117,4 +1131,23 @@ func init() {
 		h.Write([]byte(content))
 		oidHandlers[hex.EncodeToString(h.Sum(nil))] = content
 	}
+}
+
+func debug(reqid, msg string, args ...interface{}) {
+	fullargs := make([]interface{}, len(args)+1)
+	fullargs[0] = reqid
+	for i, a := range args {
+		fullargs[i+1] = a
+	}
+	log.Printf("[%s] "+msg+"\n", fullargs...)
+}
+
+func reqId(w http.ResponseWriter) (string, bool) {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	if err != nil {
+		http.Error(w, "error generating id: "+err.Error(), 500)
+		return "", false
+	}
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:]), true
 }

--- a/test/test-credentials-no-prompt.sh
+++ b/test/test-credentials-no-prompt.sh
@@ -34,7 +34,6 @@ begin_test "attempt private access without credential helper"
   git add .gitattributes
   git commit -m "initial commit"
 
-  git config credential.usehttppath true
   git config --global credential.helper lfsnoop
   git config credential.helper lfsnoop
   git config -l

--- a/test/test-credentials-no-prompt.sh
+++ b/test/test-credentials-no-prompt.sh
@@ -4,13 +4,6 @@
 
 # these tests rely on GIT_TERMINAL_PROMPT to test properly
 ensure_git_version_isnt $VERSION_LOWER "2.3.0"
-# if there is a system cred helper we can't run this test
-# can't disable without changing state outside test & probably don't have permission
-# this is common on OS X with certain versions of Git installed, default cred helper
-if [[ "$(git config --system credential.helper)" -ne "" ]]; then
-  echo "skip: $0 (system cred helper we can't disable)"
-  exit
-fi
 
 # if there is a system cred helper we can't run this test
 # can't disable without changing state outside test & probably don't have permission
@@ -38,7 +31,7 @@ begin_test "attempt private access without credential helper"
   git config credential.helper lfsnoop
   git config -l
 
-  GIT_TERMINAL_PROMPT=0 git push origin master 2>&1 | tee push.log
+  git push origin master 2>&1 | tee push.log
   grep "Authorization error: $GITSERVER/$reponame" push.log ||
     grep "Git credentials for $GITSERVER/$reponame not found" push.log
 )

--- a/test/test-credentials.sh
+++ b/test/test-credentials.sh
@@ -2,6 +2,8 @@
 
 . "test/testlib.sh"
 
+ensure_git_version_isnt $VERSION_LOWER "2.3.0"
+
 begin_test "credentials without useHttpPath, with bad path password"
 (
   set -e

--- a/test/test-credentials.sh
+++ b/test/test-credentials.sh
@@ -12,6 +12,7 @@ begin_test "credentials without useHttpPath, with bad path password"
   printf "path:wrong" > "$CREDSDIR/127.0.0.1--$reponame"
 
   clone_repo "$reponame" without-path
+  git config credential.useHttpPath false
   git checkout -b without-path
 
   git lfs track "*.dat" 2>&1 | tee track.log
@@ -40,7 +41,6 @@ begin_test "credentials with useHttpPath, with wrong password"
   printf "path:wrong" > "$CREDSDIR/127.0.0.1--$reponame"
 
   clone_repo "$reponame" with-path-wrong-pass
-  git config credential.useHttpPath true
   git checkout -b with-path-wrong-pass
 
   git lfs track "*.dat" 2>&1 | tee track.log
@@ -69,7 +69,6 @@ begin_test "credentials with useHttpPath, with correct password"
   printf "path:$reponame" > "$CREDSDIR/127.0.0.1--$reponame"
 
   clone_repo "$reponame" with-path-correct-pass
-  git config credential.useHttpPath true
   git checkout -b with-path-correct-pass
 
   git lfs track "*.dat" 2>&1 | tee track.log
@@ -102,6 +101,21 @@ begin_test "git credential"
   git init
 
   echo "protocol=http
+host=credential-test.com
+path=some/path" | GIT_TERMINAL_PROMPT=0 git credential fill > cred.log
+  cat cred.log
+
+  expected="protocol=http
+host=credential-test.com
+path=some/path
+username=git
+password=path"
+
+  [ "$expected" = "$(cat cred.log)" ]
+
+  git config credential.useHttpPath false
+
+  echo "protocol=http
 host=credential-test.com" | GIT_TERMINAL_PROMPT=0 git credential fill > cred.log
   cat cred.log
 
@@ -120,21 +134,6 @@ path=some/path" | GIT_TERMINAL_PROMPT=0 git credential fill > cred.log
 host=credential-test.com
 username=git
 password=server"
-
-  [ "$expected" = "$(cat cred.log)" ]
-
-  git config credential.useHttpPath true
-
-  echo "protocol=http
-host=credential-test.com
-path=some/path" | GIT_TERMINAL_PROMPT=0 git credential fill > cred.log
-  cat cred.log
-
-  expected="protocol=http
-host=credential-test.com
-path=some/path
-username=git
-password=path"
 
   [ "$expected" = "$(cat cred.log)" ]
 )

--- a/test/testenv.sh
+++ b/test/testenv.sh
@@ -60,7 +60,7 @@ if [ -z "$GIT_LFS_TEST_DIR" ]; then
     GIT_LFS_TEST_DIR=$(resolve_symlink $GIT_LFS_TEST_DIR)
     # cleanup either after single test or at end of integration (except on fail)
     RM_GIT_LFS_TEST_DIR=yes
-fi 
+fi
 # create a temporary work space
 TMPDIR=$GIT_LFS_TEST_DIR
 
@@ -102,6 +102,7 @@ LFS_CERT_FILE="$REMOTEDIR/cert"
 TESTHOME="$REMOTEDIR/home"
 
 GIT_CONFIG_NOSYSTEM=1
+GIT_TERMINAL_PROMPT=0
 
 export CREDSDIR
 

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -302,6 +302,7 @@ setup() {
   HOME="$TESTHOME"
   mkdir "$HOME"
   git lfs install
+  git config --global credential.usehttppath true
   git config --global credential.helper lfstest
   git config --global user.name "Git LFS Tests"
   git config --global user.email "git-lfs@example.com"


### PR DESCRIPTION
Found an intermittent test issue running `script/cibuild` on mac. While investigating, I noticed that `GIT_LFS_TEST_MAXPROCS` isn't even used now. The intermittent issue goes away when `GIT_LFS_TEST_MAXPROCS=1` too.