### PR TITLE
Updated request.GetAuthType to handle multi-value auth headers

### DIFF
--- a/httputil/request_test.go
+++ b/httputil/request_test.go
@@ -1,0 +1,60 @@
+package httputil
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestGetAutTypeNoAuthHeaders(t *testing.T) {
+	res := &http.Response{Header: make(http.Header)}
+
+	authType := GetAuthType(res)
+
+	assert.Equal(t, BasicAuthType, authType)
+}
+
+func TestGetAutTypewwAuthenticateBasicNtlmBearer(t *testing.T) {
+
+	res := &http.Response{Header: make(http.Header)}
+	// Intentionally using header name in the non-canonical form.
+	res.Header.Add("WWW-Authenticate", "Basic")
+	res.Header.Add("WWW-Authenticate", "NTLM")
+	res.Header.Add("WWW-Authenticate", "Bearer")
+
+	authType := GetAuthType(res)
+
+	assert.Equal(t, NtlmAuthType, authType)
+}
+
+func TestGetAutTypeNoWwwAuthenticateLfsAuthenticateNtlm(t *testing.T) {
+
+	res := &http.Response{Header: make(http.Header)}
+	res.Header.Add("LFS-Authenticate", "NTLM")
+
+	authType := GetAuthType(res)
+
+	assert.Equal(t, NtlmAuthType, authType)
+}
+
+func TestGetAutTypeNoWwwAuthenticateLfsAuthenticateBasicNtlm(t *testing.T) {
+
+	res := &http.Response{Header: make(http.Header)}
+	res.Header.Add("LFS-Authenticate", "Basic")
+	res.Header.Add("LFS-Authenticate", "NTLM")
+
+	authType := GetAuthType(res)
+
+	assert.Equal(t, NtlmAuthType, authType)
+}
+
+func TestGetAutTypeWwwAuthenticateBasicLfsAuthenticateNtlm(t *testing.T) {
+
+	res := &http.Response{Header: make(http.Header)}
+	res.Header.Add("WWW-Authenticate", "Basic")
+	res.Header.Add("LFS-Authenticate", "NTLM")
+
+	authType := GetAuthType(res)
+
+	assert.Equal(t, NtlmAuthType, authType)
+}


### PR DESCRIPTION
GetAuthType method in https://github.com/github/git-lfs/blob/master/httputil/request.go#L174 only takes first WWW-Authenticate header into account. If server sends the following headers:
```
WWW-Authenticate: Bearer
WWW-Authenticate: Negotiate
WWW-Authenticate: NTLM
```
the code returns "basic", which is definitely not correct in this case.

This change fixes this issue. 

Bug: https://github.com/github/git-lfs/issues/1377