### PR TITLE
Updated request.GetAuthType to handle multi-value auth headers

### DIFF
--- a/httputil/request.go
+++ b/httputil/request.go
@@ -22,11 +22,13 @@ type ClientError struct {
 }
 
 const (
-	WwwAuthenticateHeader = "Www-Authenticate"
-	LfsAuthenticateHeader = "Lfs-Authenticate"
-	BasicAuthType         = "basic"
-	NtlmAuthType          = "ntlm"
-	NegotiateAuthType     = "negotiate"
+	BasicAuthType     = "basic"
+	NtlmAuthType      = "ntlm"
+	NegotiateAuthType = "negotiate"
+)
+
+var (
+	AuthenticateHeaders = []string{"Www-Authenticate", "Lfs-Authenticate"}
 )
 
 func (e *ClientError) Error() string {
@@ -181,9 +183,8 @@ func SetAuthType(req *http.Request, res *http.Response) {
 
 func GetAuthType(res *http.Response) string {
 
-	for _, headerName := range []string{WwwAuthenticateHeader, LfsAuthenticateHeader} {
-		authHeaders := res.Header[headerName]
-		for _, auth := range authHeaders {
+	for _, headerName := range AuthenticateHeaders {
+		for _, auth := range res.Header[headerName] {
 
 			authLower := strings.ToLower(auth)
 			// When server sends Www-Authentication: Negotiate, it supports both Kerberos and NTML.

--- a/httputil/request_test.go
+++ b/httputil/request_test.go
@@ -1,0 +1,76 @@
+package httputil
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestGetAutTypeNoAuthHeaders(t *testing.T) {
+	headers := map[string][]string{}
+
+	authType := GetAuthType(httpResponseFromHeaders(headers))
+
+	assert.Equal(t, BasicAuthType, authType)
+}
+
+func TestGetAutTypewwAuthenticateBasicNtlmBearer(t *testing.T) {
+	headers := map[string][]string{
+		"WWW-Authenticate": {"Basic", "NTLM", "Bearer"},
+	}
+
+	authType := GetAuthType(httpResponseFromHeaders(headers))
+
+	assert.Equal(t, NtlmAuthType, authType)
+}
+
+func TestGetAutTypeNoWwwAuthenticateLfsAuthenticateNtlm(t *testing.T) {
+	headers := map[string][]string{
+		"LFS-Authenticate": {"Basic", "NTLM", "Bearer"},
+	}
+
+	authType := GetAuthType(httpResponseFromHeaders(headers))
+
+	assert.Equal(t, NtlmAuthType, authType)
+}
+
+func TestGetAutTypeNoWwwAuthenticateLfsAuthenticateBasicNtlm(t *testing.T) {
+	headers := map[string][]string{
+		"LFS-Authenticate": {"Basic", "Ntlm"},
+	}
+
+	authType := GetAuthType(httpResponseFromHeaders(headers))
+
+	assert.Equal(t, NtlmAuthType, authType)
+}
+
+func TestGetAutTypeWwwAuthenticateBasicNegotiate(t *testing.T) {
+	headers := map[string][]string{
+		"Www-Authenticate": {"Basic", "Negotiate"},
+	}
+
+	authType := GetAuthType(httpResponseFromHeaders(headers))
+
+	assert.Equal(t, NtlmAuthType, authType)
+}
+
+func TestGetAutTypeWwwAuthenticateBasicLfsAuthenticateNtlm(t *testing.T) {
+	headers := map[string][]string{
+		"WWW-Authenticate": {"Basic"},
+		"LFS-Authenticate": {"Ntlm"},
+	}
+
+	authType := GetAuthType(httpResponseFromHeaders(headers))
+
+	assert.Equal(t, NtlmAuthType, authType)
+}
+
+func httpResponseFromHeaders(headers map[string][]string) *http.Response {
+	res := &http.Response{Header: make(http.Header)}
+	for key, values := range headers {
+		for _, val := range values {
+			res.Header.Add(key, val)
+		}
+	}
+	return res
+}


### PR DESCRIPTION
GetAuthType method in https://github.com/github/git-lfs/blob/master/httputil/request.go#L174 only takes first WWW-Authenticate header into account. If server sends the following headers:
```
WWW-Authenticate: Bearer
WWW-Authenticate: Negotiate
WWW-Authenticate: NTLM
```
the code returns "basic", which is definitely not correct in this case.

This change fixes this issue.  With this change we will also handle Negotiate authentication.

Bug: https://github.com/github/git-lfs/issues/1377