### PR TITLE
commands/test: make lock commands opt-in using GITLFSLOCKSENABLED=1

### DIFF
--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -109,7 +109,7 @@ func lockPath(file string) (string, error) {
 func init() {
 	lockCmd.Flags().StringVarP(&lockRemote, "remote", "r", config.Config.CurrentRemote, lockRemoteHelp)
 
-	if isCommandEnabled("locks") {
+	if isCommandEnabled(config.Config, "locks") {
 		RootCmd.AddCommand(lockCmd)
 	}
 }

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -109,5 +109,7 @@ func lockPath(file string) (string, error) {
 func init() {
 	lockCmd.Flags().StringVarP(&lockRemote, "remote", "r", config.Config.CurrentRemote, lockRemoteHelp)
 
-	RootCmd.AddCommand(lockCmd)
+	if isCommandEnabled("locks") {
+		RootCmd.AddCommand(lockCmd)
+	}
 }

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -63,7 +63,9 @@ func init() {
 	locksCmd.Flags().StringVarP(&locksCmdFlags.Id, "id", "i", "", "filter locks results matching a particular ID")
 	locksCmd.Flags().IntVarP(&locksCmdFlags.Limit, "limit", "l", 0, "optional limit for number of results to return")
 
-	RootCmd.AddCommand(locksCmd)
+	if isCommandEnabled("locks") {
+		RootCmd.AddCommand(locksCmd)
+	}
 }
 
 // locksFlags wraps up and holds all of the flags that can be given to the

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -63,7 +63,7 @@ func init() {
 	locksCmd.Flags().StringVarP(&locksCmdFlags.Id, "id", "i", "", "filter locks results matching a particular ID")
 	locksCmd.Flags().IntVarP(&locksCmdFlags.Limit, "limit", "l", 0, "optional limit for number of results to return")
 
-	if isCommandEnabled("locks") {
+	if isCommandEnabled(config.Config, "locks") {
 		RootCmd.AddCommand(locksCmd)
 	}
 }

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -103,5 +103,8 @@ func init() {
 	unlockCmd.Flags().StringVarP(&unlockCmdFlags.Id, "id", "i", "", "unlock a lock by its ID")
 	unlockCmd.Flags().BoolVarP(&unlockCmdFlags.Force, "force", "f", false, "forcibly break another user's lock(s)")
 
-	RootCmd.AddCommand(unlockCmd)
+	if isCommandEnabled(config.Config, "locks") {
+		RootCmd.AddCommand(unlockCmd)
+	}
+
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -251,6 +252,19 @@ func help(cmd *cobra.Command, args []string) {
 func usage(cmd *cobra.Command) error {
 	printHelp(cmd.Name())
 	return nil
+}
+
+// isCommandEnabled returns whether the environment variable GITLFS<cmd>ENABLED
+// is equal to 1, returning false by default if the enviornment variable is not
+// specified.
+//
+// This function call should only guard commands that do not yet have stable
+// APIs or solid server implementations.
+func isCommandEnabled(cmd string) bool {
+	env := os.Getenv(fmt.Sprintf("GITLFS%sENABLED", strings.ToUpper(cmd)))
+	v, _ := strconv.Atoi(env)
+
+	return v == 1
 }
 
 func init() {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -254,17 +253,15 @@ func usage(cmd *cobra.Command) error {
 	return nil
 }
 
-// isCommandEnabled returns whether the environment variable GITLFS<cmd>ENABLED
-// is equal to 1, returning false by default if the enviornment variable is not
-// specified.
+// isCommandEnabled returns whether the environment variable GITLFS<CMD>ENABLED
+// is "truthy" according to config.GetenvBool (see
+// github.com/github/git-lfs/config#Configuration.GetenvBool), returning false
+// by default if the enviornment variable is not specified.
 //
 // This function call should only guard commands that do not yet have stable
 // APIs or solid server implementations.
-func isCommandEnabled(cmd string) bool {
-	env := os.Getenv(fmt.Sprintf("GITLFS%sENABLED", strings.ToUpper(cmd)))
-	v, _ := strconv.Atoi(env)
-
-	return v == 1
+func isCommandEnabled(cfg *config.Configuration, cmd string) bool {
+	return cfg.GetenvBool(fmt.Sprintf("GITLFS%sENABLED", strings.ToUpper(cmd)), false)
 }
 
 func init() {

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -27,3 +27,28 @@ func TestDetermineIncludeExcludePathsReturnsDefaultsWhenAbsent(t *testing.T) {
 	assert.Equal(t, []string{"/default/include"}, i)
 	assert.Equal(t, []string{"/default/exclude"}, e)
 }
+
+func TestCommandEnabledFromEnvironmentVariables(t *testing.T) {
+	cfg := config.NewConfig()
+	err := cfg.Setenv("GITLFSLOCKSENABLED", "1")
+
+	assert.Nil(t, err)
+	assert.True(t, isCommandEnabled(cfg, "locks"))
+}
+
+func TestCommandEnabledDisabledByDefault(t *testing.T) {
+	cfg := config.NewConfig()
+
+	// Since config.Configuration.Setenv makes a call to os.Setenv, we have
+	// to make sure that the LFSLOCKSENABLED enviornment variable is not
+	// present in the configuration object during the lifecycle of this
+	// test.
+	//
+	// This behavior can cause race conditions with the above test when
+	// running in parallel, so this should be investigated further in the
+	// future.
+	err := cfg.Setenv("GITLFSLOCKSENABLED", "")
+
+	assert.Nil(t, err)
+	assert.False(t, isCommandEnabled(cfg, "locks"))
+}

--- a/test/test-lock.sh
+++ b/test/test-lock.sh
@@ -8,7 +8,7 @@ begin_test "creating a lock"
 
   setup_remote_repo_with_file "lock_create_simple" "a.dat"
 
-  git lfs lock "a.dat" | tee lock.log
+  GITLFSLOCKSENABLED=1 git lfs lock "a.dat" | tee lock.log
   grep "'a.dat' was locked" lock.log
 
   id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
@@ -22,13 +22,13 @@ begin_test "locking a previously locked file"
 
   setup_remote_repo_with_file "lock_create_previously_created" "b.dat"
 
-  git lfs lock "b.dat" | tee lock.log
+  GITLFSLOCKSENABLED=1 git lfs lock "b.dat" | tee lock.log
   grep "'b.dat' was locked" lock.log
 
   id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
   assert_server_lock $id
 
-  grep "lock already created" <(git lfs lock "b.dat" 2>&1)
+  grep "lock already created" <(GITLFSLOCKSENABLED=1 git lfs lock "b.dat" 2>&1)
 )
 end_test
 
@@ -55,7 +55,7 @@ begin_test "locking a directory"
   git push origin master 2>&1 | tee push.log
   grep "master -> master" push.log
 
-  git lfs lock ./dir/ 2>&1 | tee lock.log
+  GITLFSLOCKSENABLED=1 git lfs lock ./dir/ 2>&1 | tee lock.log
   grep "cannot lock directory" lock.log
 )
 end_test

--- a/test/test-locks.sh
+++ b/test/test-locks.sh
@@ -8,12 +8,12 @@ begin_test "list a single lock"
 
   setup_remote_repo_with_file "locks_list_single" "f.dat"
 
-  git lfs lock "f.dat" | tee lock.log
+  GITLFSLOCKSENABLED=1 git lfs lock "f.dat" | tee lock.log
 
   id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
   assert_server_lock $id
 
-  git lfs locks --path "f.dat" | tee locks.log
+  GITLFSLOCKSENABLED=1 git lfs locks --path "f.dat" | tee locks.log
   grep "1 lock(s) matched query" locks.log
   grep "f.dat" locks.log
 )
@@ -42,13 +42,13 @@ begin_test "list locks with a limit"
   git push origin master 2>&1 | tee push.log
   grep "master -> master" push.log
 
-  git lfs lock "g_1.dat" | tee lock.log
+  GITLFSLOCKSENABLED=1 git lfs lock "g_1.dat" | tee lock.log
   assert_server_lock "$(grep -oh "\((.*)\)" lock.log | tr -d "()")"
 
-  git lfs lock "g_2.dat" | tee lock.log
+  GITLFSLOCKSENABLED=1 git lfs lock "g_2.dat" | tee lock.log
   assert_server_lock "$(grep -oh "\((.*)\)" lock.log | tr -d "()")"
 
-  git lfs locks --limit 1 | tee locks.log
+  GITLFSLOCKSENABLED=1 git lfs locks --limit 1 | tee locks.log
   grep "1 lock(s) matched query" locks.log
 )
 end_test
@@ -79,12 +79,12 @@ begin_test "list locks with pagination"
   grep "master -> master" push.log
 
   for i in $(seq 1 5); do
-    git lfs lock "h_$i.dat" | tee lock.log
+    GITLFSLOCKSENABLED=1 git lfs lock "h_$i.dat" | tee lock.log
     assert_server_lock "$(grep -oh "\((.*)\)" lock.log | tr -d "()")"
   done
 
   # The server will return, at most, three locks at a time
-  git lfs locks --limit 4 | tee locks.log
+  GITLFSLOCKSENABLED=1 git lfs locks --limit 4 | tee locks.log
   grep "4 lock(s) matched query" locks.log
 )
 end_test

--- a/test/test-unlock.sh
+++ b/test/test-unlock.sh
@@ -8,12 +8,12 @@ begin_test "unlocking a lock by path"
 
   setup_remote_repo_with_file "unlock_by_path" "c.dat"
 
-  git lfs lock "c.dat" | tee lock.log
+  GITLFSLOCKSENABLED=1 git lfs lock "c.dat" | tee lock.log
 
   id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
   assert_server_lock $id
 
-  git lfs unlock "c.dat" 2>&1 | tee unlock.log
+  GITLFSLOCKSENABLED=1 git lfs unlock "c.dat" 2>&1 | tee unlock.log
   refute_server_lock $id
 )
 end_test
@@ -24,12 +24,12 @@ begin_test "unlocking a lock by id"
 
   setup_remote_repo_with_file "unlock_by_id" "d.dat"
 
-  git lfs lock "d.dat" | tee lock.log
+  GITLFSLOCKSENABLED=1 git lfs lock "d.dat" | tee lock.log
 
   id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
   assert_server_lock $id
 
-  git lfs unlock --id="$id" 2>&1 | tee unlock.log
+  GITLFSLOCKSENABLED=1 git lfs unlock --id="$id" 2>&1 | tee unlock.log
   refute_server_lock $id
 )
 end_test
@@ -40,12 +40,12 @@ begin_test "unlocking a lock without sufficient info"
 
   setup_remote_repo_with_file "unlock_ambiguous" "e.dat"
 
-  git lfs lock "e.dat" | tee lock.log
+  GITLFSLOCKSENABLED=1 git lfs lock "e.dat" | tee lock.log
 
   id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
   assert_server_lock $id
 
-  git lfs unlock 2>&1 | tee unlock.log
+  GITLFSLOCKSENABLED=1 git lfs unlock 2>&1 | tee unlock.log
   grep "Usage: git lfs unlock" unlock.log
   assert_server_lock $id
 )


### PR DESCRIPTION
To prepare for the upcoming release of Git LFS v1.3, the `git-lfs lock` and
`git-lfs locks` commands are now hidden behind a enviornment variable
`GITLFSLOCKSENABLED`. Since most (all?) implementations of LFS do not yet
support this new locking API, it makes sense to allow users to experiment with
the command while at the same time, not making it a "full" part of the release.

If users wish to run any `git-lfs lock{,s}` command, they may do so according
to the following:

```
$ GITLFSLOCKSEANBLED=1 git lfs lock <flags> [args]
$ GITLFSLOCKSEANBLED=1 git lfs locks <flags> [args]
```

This commit, when applied, adds two new things:

1. The `isCommandEnabled(cmd string) bool` func in the commands package. This
   new func checks the OS's enviornment variables and determines whether or not
   a command is "enabled".

2. Updates the `lock` and `locks` tests to use the
   GITLFSLOCKSENABLED=1 flag such that they are able to run.

Since the `isCommandEnabled` func defaults to "false", it should only guard
commands which are deemed "experimental", as noted in the godoc.

-------

/cc @technoweenie @rubyist @sinbad @larsxschneider 