### PR TITLE
Use commands.Config instead of config.Config

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -21,7 +21,8 @@ import (
 // This is for simplicity, legacy route is not most optimal (serial)
 // TODO LEGACY API: remove when legacy API removed
 func BatchOrLegacy(objects []*ObjectResource, operation string, transferAdapters []string) (objs []*ObjectResource, transferAdapter string, e error) {
-	if !config.Config.BatchTransfer() {
+	cfg := config.Config
+	if !cfg.BatchTransfer() {
 		objs, err := Legacy(objects, operation)
 		return objs, "", err
 	}
@@ -54,6 +55,8 @@ func Batch(objects []*ObjectResource, operation string, transferAdapters []strin
 		return nil, "", nil
 	}
 
+	cfg := config.Config
+
 	o := &batchRequest{Operation: operation, Objects: objects, TransferAdapterNames: transferAdapters}
 	by, err := json.Marshal(o)
 	if err != nil {
@@ -85,7 +88,7 @@ func Batch(objects []*ObjectResource, operation string, transferAdapters []strin
 		}
 
 		if errutil.IsAuthError(err) {
-			httputil.SetAuthType(req, res)
+			httputil.SetAuthType(cfg, req, res)
 			return Batch(objects, operation, transferAdapters)
 		}
 
@@ -98,7 +101,7 @@ func Batch(objects []*ObjectResource, operation string, transferAdapters []strin
 		tracerx.Printf("api error: %s", err)
 		return nil, "", errutil.Error(err)
 	}
-	httputil.LogTransfer("lfs.batch", res)
+	httputil.LogTransfer(cfg, "lfs.batch", res)
 
 	if res.StatusCode != 200 {
 		return nil, "", errutil.Error(fmt.Errorf("Invalid status for %s: %d", httputil.TraceHttpReq(req), res.StatusCode))
@@ -141,7 +144,9 @@ func DownloadCheck(oid string) (*ObjectResource, error) {
 	if err != nil {
 		return nil, err
 	}
-	httputil.LogTransfer("lfs.download", res)
+
+	cfg := config.Config
+	httputil.LogTransfer(cfg, "lfs.download", res)
 
 	_, err = obj.NewRequest("download", "GET")
 	if err != nil {
@@ -153,7 +158,7 @@ func DownloadCheck(oid string) (*ObjectResource, error) {
 
 // TODO LEGACY API: remove when legacy API removed
 func UploadCheck(oid string, size int64) (*ObjectResource, error) {
-
+	cfg := config.Config
 	reqObj := &ObjectResource{
 		Oid:  oid,
 		Size: size,
@@ -179,13 +184,13 @@ func UploadCheck(oid string, size int64) (*ObjectResource, error) {
 
 	if err != nil {
 		if errutil.IsAuthError(err) {
-			httputil.SetAuthType(req, res)
+			httputil.SetAuthType(cfg, req, res)
 			return UploadCheck(oid, size)
 		}
 
 		return nil, errutil.NewRetriableError(err)
 	}
-	httputil.LogTransfer("lfs.upload", res)
+	httputil.LogTransfer(cfg, "lfs.upload", res)
 
 	if res.StatusCode == 200 {
 		return nil, nil

--- a/api/download_test.go
+++ b/api/download_test.go
@@ -353,7 +353,7 @@ var (
 )
 
 func init() {
-	TestCredentialsFunc = func(input auth.Creds, subCommand string) (auth.Creds, error) {
+	TestCredentialsFunc = func(cfg *config.Configuration, input auth.Creds, subCommand string) (auth.Creds, error) {
 		output := make(auth.Creds)
 		for key, value := range input {
 			output[key] = value

--- a/api/http_lifecycle.go
+++ b/api/http_lifecycle.go
@@ -78,7 +78,7 @@ func (l *HttpLifecycle) Build(schema *RequestSchema) (*http.Request, error) {
 		return nil, err
 	}
 
-	if _, err = auth.GetCreds(req); err != nil {
+	if _, err = auth.GetCreds(config.Config, req); err != nil {
 		return nil, err
 	}
 

--- a/api/http_lifecycle.go
+++ b/api/http_lifecycle.go
@@ -102,7 +102,7 @@ func (l *HttpLifecycle) Build(schema *RequestSchema) (*http.Request, error) {
 // Otherwise, the api.Response is returned, along with no error, signaling that
 // the request completed successfully.
 func (l *HttpLifecycle) Execute(req *http.Request, into interface{}) (Response, error) {
-	resp, err := httputil.DoHttpRequestWithRedirects(req, []*http.Request{}, true)
+	resp, err := httputil.DoHttpRequestWithRedirects(config.Config, req, []*http.Request{}, true)
 	if err != nil {
 		return nil, err
 	}

--- a/api/v1.go
+++ b/api/v1.go
@@ -88,9 +88,9 @@ func NewRequest(method, oid string) (*http.Request, error) {
 			operation = "upload"
 		}
 	}
-	endpoint := config.Config.Endpoint(operation)
 
-	res, err := auth.SshAuthenticate(endpoint, operation, oid)
+	cfg := config.Config
+	res, endpoint, err := auth.SshAuthenticate(cfg, operation, oid)
 	if err != nil {
 		tracerx.Printf("ssh: attempted with %s.  Error: %s",
 			endpoint.SshUserAndHost, err.Error(),
@@ -117,9 +117,8 @@ func NewRequest(method, oid string) (*http.Request, error) {
 }
 
 func NewBatchRequest(operation string) (*http.Request, error) {
-	endpoint := config.Config.Endpoint(operation)
-
-	res, err := auth.SshAuthenticate(endpoint, operation, "")
+	cfg := config.Config
+	res, endpoint, err := auth.SshAuthenticate(cfg, operation, "")
 	if err != nil {
 		tracerx.Printf("ssh: %s attempted with %s.  Error: %s",
 			operation, endpoint.SshUserAndHost, err.Error(),

--- a/api/v1.go
+++ b/api/v1.go
@@ -19,8 +19,9 @@ const (
 
 // doLegacyApiRequest runs the request to the LFS legacy API.
 func DoLegacyRequest(req *http.Request) (*http.Response, *ObjectResource, error) {
+	cfg := config.Config
 	via := make([]*http.Request, 0, 4)
-	res, err := httputil.DoHttpRequestWithRedirects(req, via, true)
+	res, err := httputil.DoHttpRequestWithRedirects(cfg, req, via, true)
 	if err != nil {
 		return res, nil, err
 	}
@@ -29,7 +30,7 @@ func DoLegacyRequest(req *http.Request) (*http.Response, *ObjectResource, error)
 	err = httputil.DecodeResponse(res, obj)
 
 	if err != nil {
-		httputil.SetErrorResponseContext(err, res)
+		httputil.SetErrorResponseContext(cfg, err, res)
 		return nil, nil, err
 	}
 
@@ -51,7 +52,8 @@ type batchResponse struct {
 // re-run. When the repo is marked as having private access, credentials will
 // be retrieved.
 func DoBatchRequest(req *http.Request) (*http.Response, *batchResponse, error) {
-	res, err := DoRequest(req, config.Config.PrivateAccess(auth.GetOperationForRequest(req)))
+	cfg := config.Config
+	res, err := DoRequest(req, cfg.PrivateAccess(auth.GetOperationForRequest(req)))
 
 	if err != nil {
 		if res != nil && res.StatusCode == 401 {
@@ -64,7 +66,7 @@ func DoBatchRequest(req *http.Request) (*http.Response, *batchResponse, error) {
 	err = httputil.DecodeResponse(res, resp)
 
 	if err != nil {
-		httputil.SetErrorResponseContext(err, res)
+		httputil.SetErrorResponseContext(cfg, err, res)
 	}
 
 	return res, resp, err
@@ -76,7 +78,7 @@ func DoBatchRequest(req *http.Request) (*http.Response, *batchResponse, error) {
 // private access, credentials will be retrieved.
 func DoRequest(req *http.Request, useCreds bool) (*http.Response, error) {
 	via := make([]*http.Request, 0, 4)
-	return httputil.DoHttpRequestWithRedirects(req, via, useCreds)
+	return httputil.DoHttpRequestWithRedirects(config.Config, req, via, useCreds)
 }
 
 func NewRequest(method, oid string) (*http.Request, error) {

--- a/api/verify.go
+++ b/api/verify.go
@@ -7,13 +7,13 @@ import (
 	"io/ioutil"
 	"strconv"
 
+	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/errutil"
 	"github.com/github/git-lfs/httputil"
 )
 
 // VerifyUpload calls the "verify" API link relation on obj if it exists
 func VerifyUpload(obj *ObjectResource) error {
-
 	// Do we need to do verify?
 	if _, ok := obj.Rel("verify"); !ok {
 		return nil
@@ -38,7 +38,8 @@ func VerifyUpload(obj *ObjectResource) error {
 		return err
 	}
 
-	httputil.LogTransfer("lfs.data.verify", res)
+	cfg := config.Config
+	httputil.LogTransfer(cfg, "lfs.data.verify", res)
 	io.Copy(ioutil.Discard, res.Body)
 	res.Body.Close()
 

--- a/auth/credentials_test.go
+++ b/auth/credentials_test.go
@@ -129,7 +129,7 @@ func TestNetrcWithHostAndPort(t *testing.T) {
 	SetupTestCredentialsFunc()
 	defer RestoreCredentialsFunc()
 
-	cfg := config.NewConfig()
+	cfg := config.New()
 	cfg.SetNetrc(&fakeNetrc{})
 	u, err := url.Parse("http://some-host:123/foo/bar")
 	if err != nil {
@@ -155,7 +155,7 @@ func TestNetrcWithHost(t *testing.T) {
 	SetupTestCredentialsFunc()
 	defer RestoreCredentialsFunc()
 
-	cfg := config.NewConfig()
+	cfg := config.New()
 	cfg.SetNetrc(&fakeNetrc{})
 	u, err := url.Parse("http://some-host/foo/bar")
 	if err != nil {
@@ -181,7 +181,7 @@ func TestNetrcWithBadHost(t *testing.T) {
 	SetupTestCredentialsFunc()
 	defer RestoreCredentialsFunc()
 
-	cfg := config.NewConfig()
+	cfg := config.New()
 	cfg.SetNetrc(&fakeNetrc{})
 	u, err := url.Parse("http://other-host/foo/bar")
 	if err != nil {
@@ -206,7 +206,7 @@ func TestNetrcWithBadHost(t *testing.T) {
 func checkGetCredentials(t *testing.T, getCredsFunc func(*config.Configuration, *http.Request) (Creds, error), checks []*getCredentialCheck) {
 	for _, check := range checks {
 		t.Logf("Checking %q", check.Desc)
-		cfg := config.NewConfig()
+		cfg := config.New()
 		cfg.CurrentRemote = check.CurrentRemote
 
 		for key, value := range check.Config {

--- a/auth/credentials_test.go
+++ b/auth/credentials_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestGetCredentialsForApi(t *testing.T) {
 	SetupTestCredentialsFunc()
+	defer RestoreCredentialsFunc()
 
 	checkGetCredentials(t, GetCreds, []*getCredentialCheck{
 		{
@@ -113,8 +114,6 @@ func TestGetCredentialsForApi(t *testing.T) {
 			SkipAuth: true,
 		},
 	})
-
-	RestoreCredentialsFunc()
 }
 
 type fakeNetrc struct{}
@@ -128,8 +127,10 @@ func (n *fakeNetrc) FindMachine(host string) *netrc.Machine {
 
 func TestNetrcWithHostAndPort(t *testing.T) {
 	SetupTestCredentialsFunc()
+	defer RestoreCredentialsFunc()
 
-	config.Config.SetNetrc(&fakeNetrc{})
+	cfg := config.NewConfig()
+	cfg.SetNetrc(&fakeNetrc{})
 	u, err := url.Parse("http://some-host:123/foo/bar")
 	if err != nil {
 		t.Fatal(err)
@@ -140,7 +141,7 @@ func TestNetrcWithHostAndPort(t *testing.T) {
 		Header: http.Header{},
 	}
 
-	if !setCredURLFromNetrc(req) {
+	if !setCredURLFromNetrc(cfg, req) {
 		t.Fatal("no netrc match")
 	}
 
@@ -148,14 +149,14 @@ func TestNetrcWithHostAndPort(t *testing.T) {
 	if auth != "Basic YWJjOmRlZg==" {
 		t.Fatalf("bad basic auth: %q", auth)
 	}
-
-	RestoreCredentialsFunc()
 }
 
 func TestNetrcWithHost(t *testing.T) {
 	SetupTestCredentialsFunc()
+	defer RestoreCredentialsFunc()
 
-	config.Config.SetNetrc(&fakeNetrc{})
+	cfg := config.NewConfig()
+	cfg.SetNetrc(&fakeNetrc{})
 	u, err := url.Parse("http://some-host/foo/bar")
 	if err != nil {
 		t.Fatal(err)
@@ -166,7 +167,7 @@ func TestNetrcWithHost(t *testing.T) {
 		Header: http.Header{},
 	}
 
-	if !setCredURLFromNetrc(req) {
+	if !setCredURLFromNetrc(cfg, req) {
 		t.Fatalf("no netrc match")
 	}
 
@@ -174,14 +175,14 @@ func TestNetrcWithHost(t *testing.T) {
 	if auth != "Basic YWJjOmRlZg==" {
 		t.Fatalf("bad basic auth: %q", auth)
 	}
-
-	RestoreCredentialsFunc()
 }
 
 func TestNetrcWithBadHost(t *testing.T) {
 	SetupTestCredentialsFunc()
+	defer RestoreCredentialsFunc()
 
-	config.Config.SetNetrc(&fakeNetrc{})
+	cfg := config.NewConfig()
+	cfg.SetNetrc(&fakeNetrc{})
 	u, err := url.Parse("http://other-host/foo/bar")
 	if err != nil {
 		t.Fatal(err)
@@ -192,7 +193,7 @@ func TestNetrcWithBadHost(t *testing.T) {
 		Header: http.Header{},
 	}
 
-	if setCredURLFromNetrc(req) {
+	if setCredURLFromNetrc(cfg, req) {
 		t.Fatalf("unexpected netrc match")
 	}
 
@@ -200,18 +201,16 @@ func TestNetrcWithBadHost(t *testing.T) {
 	if auth != "" {
 		t.Fatalf("bad basic auth: %q", auth)
 	}
-
-	RestoreCredentialsFunc()
 }
 
-func checkGetCredentials(t *testing.T, getCredsFunc func(*http.Request) (Creds, error), checks []*getCredentialCheck) {
-	existingRemote := config.Config.CurrentRemote
+func checkGetCredentials(t *testing.T, getCredsFunc func(*config.Configuration, *http.Request) (Creds, error), checks []*getCredentialCheck) {
 	for _, check := range checks {
 		t.Logf("Checking %q", check.Desc)
-		config.Config.CurrentRemote = check.CurrentRemote
+		cfg := config.NewConfig()
+		cfg.CurrentRemote = check.CurrentRemote
 
 		for key, value := range check.Config {
-			config.Config.SetConfig(key, value)
+			cfg.SetConfig(key, value)
 		}
 
 		req, err := http.NewRequest(check.Method, check.Href, nil)
@@ -224,7 +223,7 @@ func checkGetCredentials(t *testing.T, getCredsFunc func(*http.Request) (Creds, 
 			req.Header.Set(key, value)
 		}
 
-		creds, err := getCredsFunc(req)
+		creds, err := getCredsFunc(cfg, req)
 		if err != nil {
 			t.Errorf("[%s] %s", check.Desc, err)
 			continue
@@ -275,9 +274,6 @@ func checkGetCredentials(t *testing.T, getCredsFunc func(*http.Request) (Creds, 
 				t.Errorf("[%s] Bad Authorization. Expected '%s', got '%s'", check.Desc, expected, reqAuth)
 			}
 		}
-
-		config.Config.ResetConfig()
-		config.Config.CurrentRemote = existingRemote
 	}
 }
 
@@ -308,7 +304,7 @@ var (
 )
 
 func init() {
-	TestCredentialsFunc = func(input Creds, subCommand string) (Creds, error) {
+	TestCredentialsFunc = func(cfg *config.Configuration, input Creds, subCommand string) (Creds, error) {
 		output := make(Creds)
 		for key, value := range input {
 			output[key] = value

--- a/auth/ssh_test.go
+++ b/auth/ssh_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSSHGetExeAndArgsSsh(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
@@ -25,7 +25,7 @@ func TestSSHGetExeAndArgsSsh(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsSshCustomPort(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
@@ -42,7 +42,7 @@ func TestSSHGetExeAndArgsSshCustomPort(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsPlink(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
@@ -60,7 +60,7 @@ func TestSSHGetExeAndArgsPlink(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsPlinkCustomPort(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
@@ -79,7 +79,7 @@ func TestSSHGetExeAndArgsPlinkCustomPort(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsTortoisePlink(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
@@ -97,7 +97,7 @@ func TestSSHGetExeAndArgsTortoisePlink(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsTortoisePlinkCustomPort(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
@@ -116,7 +116,7 @@ func TestSSHGetExeAndArgsTortoisePlinkCustomPort(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsSshCommandPrecedence(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
@@ -132,7 +132,7 @@ func TestSSHGetExeAndArgsSshCommandPrecedence(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsSshCommandArgs(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
@@ -145,7 +145,7 @@ func TestSSHGetExeAndArgsSshCommandArgs(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsSshCommandCustomPort(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
@@ -159,7 +159,7 @@ func TestSSHGetExeAndArgsSshCommandCustomPort(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsPlinkCommand(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
@@ -174,7 +174,7 @@ func TestSSHGetExeAndArgsPlinkCommand(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsPlinkCommandCustomPort(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
@@ -190,7 +190,7 @@ func TestSSHGetExeAndArgsPlinkCommandCustomPort(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsTortoisePlinkCommand(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
@@ -205,7 +205,7 @@ func TestSSHGetExeAndArgsTortoisePlinkCommand(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsTortoisePlinkCommandCustomPort(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"

--- a/auth/ssh_test.go
+++ b/auth/ssh_test.go
@@ -9,200 +9,213 @@ import (
 )
 
 func TestSSHGetExeAndArgsSsh(t *testing.T) {
-	endpoint := config.Config.Endpoint("download")
+	cfg := config.NewConfig()
+	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
-	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
-	config.Config.Setenv("GIT_SSH_COMMAND", "")
-	oldGITSSH := config.Config.Getenv("GIT_SSH")
-	config.Config.Setenv("GIT_SSH", "")
-	exe, args := sshGetExeAndArgs(endpoint)
+	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
+	cfg.Setenv("GIT_SSH_COMMAND", "")
+	oldGITSSH := cfg.Getenv("GIT_SSH")
+	cfg.Setenv("GIT_SSH", "")
+	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, "ssh", exe)
 	assert.Equal(t, []string{"user@foo.com"}, args)
 
-	config.Config.Setenv("GIT_SSH", oldGITSSH)
-	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+	cfg.Setenv("GIT_SSH", oldGITSSH)
+	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsSshCustomPort(t *testing.T) {
-	endpoint := config.Config.Endpoint("download")
+	cfg := config.NewConfig()
+	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
-	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
-	config.Config.Setenv("GIT_SSH_COMMAND", "")
-	oldGITSSH := config.Config.Getenv("GIT_SSH")
-	config.Config.Setenv("GIT_SSH", "")
-	exe, args := sshGetExeAndArgs(endpoint)
+	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
+	cfg.Setenv("GIT_SSH_COMMAND", "")
+	oldGITSSH := cfg.Getenv("GIT_SSH")
+	cfg.Setenv("GIT_SSH", "")
+	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, "ssh", exe)
 	assert.Equal(t, []string{"-p", "8888", "user@foo.com"}, args)
 
-	config.Config.Setenv("GIT_SSH", oldGITSSH)
-	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+	cfg.Setenv("GIT_SSH", oldGITSSH)
+	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsPlink(t *testing.T) {
-	endpoint := config.Config.Endpoint("download")
+	cfg := config.NewConfig()
+	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
-	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
-	config.Config.Setenv("GIT_SSH_COMMAND", "")
-	oldGITSSH := config.Config.Getenv("GIT_SSH")
+	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
+	cfg.Setenv("GIT_SSH_COMMAND", "")
+	oldGITSSH := cfg.Getenv("GIT_SSH")
 	// this will run on non-Windows platforms too but no biggie
 	plink := filepath.Join("Users", "joebloggs", "bin", "plink.exe")
-	config.Config.Setenv("GIT_SSH", plink)
-	exe, args := sshGetExeAndArgs(endpoint)
+	cfg.Setenv("GIT_SSH", plink)
+	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"user@foo.com"}, args)
 
-	config.Config.Setenv("GIT_SSH", oldGITSSH)
-	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+	cfg.Setenv("GIT_SSH", oldGITSSH)
+	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsPlinkCustomPort(t *testing.T) {
-	endpoint := config.Config.Endpoint("download")
+	cfg := config.NewConfig()
+	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
-	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
-	config.Config.Setenv("GIT_SSH_COMMAND", "")
-	oldGITSSH := config.Config.Getenv("GIT_SSH")
+	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
+	cfg.Setenv("GIT_SSH_COMMAND", "")
+	oldGITSSH := cfg.Getenv("GIT_SSH")
 	// this will run on non-Windows platforms too but no biggie
 	plink := filepath.Join("Users", "joebloggs", "bin", "plink")
-	config.Config.Setenv("GIT_SSH", plink)
-	exe, args := sshGetExeAndArgs(endpoint)
+	cfg.Setenv("GIT_SSH", plink)
+	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-P", "8888", "user@foo.com"}, args)
 
-	config.Config.Setenv("GIT_SSH", oldGITSSH)
-	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+	cfg.Setenv("GIT_SSH", oldGITSSH)
+	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsTortoisePlink(t *testing.T) {
-	endpoint := config.Config.Endpoint("download")
+	cfg := config.NewConfig()
+	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
-	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
-	config.Config.Setenv("GIT_SSH_COMMAND", "")
-	oldGITSSH := config.Config.Getenv("GIT_SSH")
+	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
+	cfg.Setenv("GIT_SSH_COMMAND", "")
+	oldGITSSH := cfg.Getenv("GIT_SSH")
 	// this will run on non-Windows platforms too but no biggie
 	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink.exe")
-	config.Config.Setenv("GIT_SSH", plink)
-	exe, args := sshGetExeAndArgs(endpoint)
+	cfg.Setenv("GIT_SSH", plink)
+	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-batch", "user@foo.com"}, args)
 
-	config.Config.Setenv("GIT_SSH", oldGITSSH)
-	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+	cfg.Setenv("GIT_SSH", oldGITSSH)
+	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsTortoisePlinkCustomPort(t *testing.T) {
-	endpoint := config.Config.Endpoint("download")
+	cfg := config.NewConfig()
+	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
-	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
-	config.Config.Setenv("GIT_SSH_COMMAND", "")
-	oldGITSSH := config.Config.Getenv("GIT_SSH")
+	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
+	cfg.Setenv("GIT_SSH_COMMAND", "")
+	oldGITSSH := cfg.Getenv("GIT_SSH")
 	// this will run on non-Windows platforms too but no biggie
 	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink")
-	config.Config.Setenv("GIT_SSH", plink)
-	exe, args := sshGetExeAndArgs(endpoint)
+	cfg.Setenv("GIT_SSH", plink)
+	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-batch", "-P", "8888", "user@foo.com"}, args)
 
-	config.Config.Setenv("GIT_SSH", oldGITSSH)
-	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+	cfg.Setenv("GIT_SSH", oldGITSSH)
+	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsSshCommandPrecedence(t *testing.T) {
-	endpoint := config.Config.Endpoint("download")
+	cfg := config.NewConfig()
+	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
-	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
-	config.Config.Setenv("GIT_SSH_COMMAND", "sshcmd")
-	oldGITSSH := config.Config.Getenv("GIT_SSH")
-	config.Config.Setenv("GIT_SSH", "bad")
-	exe, args := sshGetExeAndArgs(endpoint)
+	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
+	cfg.Setenv("GIT_SSH_COMMAND", "sshcmd")
+	oldGITSSH := cfg.Getenv("GIT_SSH")
+	cfg.Setenv("GIT_SSH", "bad")
+	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, "sshcmd", exe)
 	assert.Equal(t, []string{"user@foo.com"}, args)
 
-	config.Config.Setenv("GIT_SSH", oldGITSSH)
-	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+	cfg.Setenv("GIT_SSH", oldGITSSH)
+	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsSshCommandArgs(t *testing.T) {
-	endpoint := config.Config.Endpoint("download")
+	cfg := config.NewConfig()
+	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
-	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
-	config.Config.Setenv("GIT_SSH_COMMAND", "sshcmd --args 1")
-	exe, args := sshGetExeAndArgs(endpoint)
+	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
+	cfg.Setenv("GIT_SSH_COMMAND", "sshcmd --args 1")
+	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, "sshcmd", exe)
 	assert.Equal(t, []string{"--args", "1", "user@foo.com"}, args)
 
-	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsSshCommandCustomPort(t *testing.T) {
-	endpoint := config.Config.Endpoint("download")
+	cfg := config.NewConfig()
+	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
-	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
-	config.Config.Setenv("GIT_SSH_COMMAND", "sshcmd")
-	exe, args := sshGetExeAndArgs(endpoint)
+	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
+	cfg.Setenv("GIT_SSH_COMMAND", "sshcmd")
+	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, "sshcmd", exe)
 	assert.Equal(t, []string{"-p", "8888", "user@foo.com"}, args)
 
-	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsPlinkCommand(t *testing.T) {
-	endpoint := config.Config.Endpoint("download")
+	cfg := config.NewConfig()
+	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
-	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
 	// this will run on non-Windows platforms too but no biggie
 	plink := filepath.Join("Users", "joebloggs", "bin", "plink.exe")
-	config.Config.Setenv("GIT_SSH_COMMAND", plink)
-	exe, args := sshGetExeAndArgs(endpoint)
+	cfg.Setenv("GIT_SSH_COMMAND", plink)
+	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"user@foo.com"}, args)
 
-	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsPlinkCommandCustomPort(t *testing.T) {
-	endpoint := config.Config.Endpoint("download")
+	cfg := config.NewConfig()
+	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
-	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
 	// this will run on non-Windows platforms too but no biggie
 	plink := filepath.Join("Users", "joebloggs", "bin", "plink")
-	config.Config.Setenv("GIT_SSH_COMMAND", plink)
-	exe, args := sshGetExeAndArgs(endpoint)
+	cfg.Setenv("GIT_SSH_COMMAND", plink)
+	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-P", "8888", "user@foo.com"}, args)
 
-	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsTortoisePlinkCommand(t *testing.T) {
-	endpoint := config.Config.Endpoint("download")
+	cfg := config.NewConfig()
+	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
-	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
 	// this will run on non-Windows platforms too but no biggie
 	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink.exe")
-	config.Config.Setenv("GIT_SSH_COMMAND", plink)
-	exe, args := sshGetExeAndArgs(endpoint)
+	cfg.Setenv("GIT_SSH_COMMAND", plink)
+	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-batch", "user@foo.com"}, args)
 
-	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsTortoisePlinkCommandCustomPort(t *testing.T) {
-	endpoint := config.Config.Endpoint("download")
+	cfg := config.NewConfig()
+	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
-	oldGITSSHCommand := config.Config.Getenv("GIT_SSH_COMMAND")
+	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
 	// this will run on non-Windows platforms too but no biggie
 	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink")
-	config.Config.Setenv("GIT_SSH_COMMAND", plink)
-	exe, args := sshGetExeAndArgs(endpoint)
+	cfg.Setenv("GIT_SSH_COMMAND", plink)
+	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-batch", "-P", "8888", "user@foo.com"}, args)
 
-	config.Config.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
+	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"sync"
 
-	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/errutil"
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
@@ -119,7 +118,7 @@ func checkoutWithIncludeExclude(include []string, exclude []string) {
 	for _, pointer := range pointers {
 		totalBytes += pointer.Size
 	}
-	progress := progress.NewProgressMeter(len(pointers), totalBytes, false, config.Config.Getenv("GIT_LFS_PROGRESS"))
+	progress := progress.NewProgressMeter(len(pointers), totalBytes, false, Config.Getenv("GIT_LFS_PROGRESS"))
 	progress.Start()
 	totalBytes = 0
 	for _, pointer := range pointers {

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -118,7 +118,7 @@ func checkoutWithIncludeExclude(include []string, exclude []string) {
 	for _, pointer := range pointers {
 		totalBytes += pointer.Size
 	}
-	progress := progress.NewProgressMeter(len(pointers), totalBytes, false, Config.Getenv("GIT_LFS_PROGRESS"))
+	progress := progress.NewProgressMeter(len(pointers), totalBytes, false, cfg.Getenv("GIT_LFS_PROGRESS"))
 	progress.Start()
 	totalBytes = 0
 	for _, pointer := range pointers {

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -69,12 +69,12 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 	// Now just call pull with default args
 	// Support --origin option to clone
 	if len(cloneFlags.Origin) > 0 {
-		Config.CurrentRemote = cloneFlags.Origin
+		cfg.CurrentRemote = cloneFlags.Origin
 	} else {
-		Config.CurrentRemote = "origin"
+		cfg.CurrentRemote = "origin"
 	}
 
-	include, exclude := determineIncludeExcludePaths(Config, cloneIncludeArg, cloneExcludeArg)
+	include, exclude := determineIncludeExcludePaths(cfg, cloneIncludeArg, cloneExcludeArg)
 	if cloneFlags.NoCheckout || cloneFlags.Bare {
 		// If --no-checkout or --bare then we shouldn't check out, just fetch instead
 		fetchRef("HEAD", include, exclude)

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/github/git-lfs/subprocess"
 
-	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/localstorage"
 	"github.com/github/git-lfs/tools"
@@ -70,12 +69,12 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 	// Now just call pull with default args
 	// Support --origin option to clone
 	if len(cloneFlags.Origin) > 0 {
-		config.Config.CurrentRemote = cloneFlags.Origin
+		Config.CurrentRemote = cloneFlags.Origin
 	} else {
-		config.Config.CurrentRemote = "origin"
+		Config.CurrentRemote = "origin"
 	}
 
-	include, exclude := determineIncludeExcludePaths(config.Config, cloneIncludeArg, cloneExcludeArg)
+	include, exclude := determineIncludeExcludePaths(Config, cloneIncludeArg, cloneExcludeArg)
 	if cloneFlags.NoCheckout || cloneFlags.Bare {
 		// If --no-checkout or --bare then we shouldn't check out, just fetch instead
 		fetchRef("HEAD", include, exclude)

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -16,8 +16,7 @@ var (
 
 func envCommand(cmd *cobra.Command, args []string) {
 	config.ShowConfigWarnings = true
-	cfg := config.Config
-	endpoint := cfg.Endpoint("download")
+	endpoint := Config.Endpoint("download")
 
 	gitV, err := git.Config.Version()
 	if err != nil {
@@ -29,15 +28,15 @@ func envCommand(cmd *cobra.Command, args []string) {
 	Print("")
 
 	if len(endpoint.Url) > 0 {
-		Print("Endpoint=%s (auth=%s)", endpoint.Url, cfg.EndpointAccess(endpoint))
+		Print("Endpoint=%s (auth=%s)", endpoint.Url, Config.EndpointAccess(endpoint))
 		if len(endpoint.SshUserAndHost) > 0 {
 			Print("  SSH=%s:%s", endpoint.SshUserAndHost, endpoint.SshPath)
 		}
 	}
 
-	for _, remote := range cfg.Remotes() {
-		remoteEndpoint := cfg.RemoteEndpoint(remote, "download")
-		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, cfg.EndpointAccess(remoteEndpoint))
+	for _, remote := range Config.Remotes() {
+		remoteEndpoint := Config.RemoteEndpoint(remote, "download")
+		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, Config.EndpointAccess(remoteEndpoint))
 		if len(remoteEndpoint.SshUserAndHost) > 0 {
 			Print("  SSH=%s:%s", remoteEndpoint.SshUserAndHost, remoteEndpoint.SshPath)
 		}
@@ -48,7 +47,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 	}
 
 	for _, key := range []string{"filter.lfs.smudge", "filter.lfs.clean"} {
-		value, _ := cfg.GitConfig(key)
+		value, _ := Config.GitConfig(key)
 		Print("git config %s = %q", key, value)
 	}
 }

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -16,7 +16,7 @@ var (
 
 func envCommand(cmd *cobra.Command, args []string) {
 	config.ShowConfigWarnings = true
-	endpoint := Config.Endpoint("download")
+	endpoint := cfg.Endpoint("download")
 
 	gitV, err := git.Config.Version()
 	if err != nil {
@@ -28,15 +28,15 @@ func envCommand(cmd *cobra.Command, args []string) {
 	Print("")
 
 	if len(endpoint.Url) > 0 {
-		Print("Endpoint=%s (auth=%s)", endpoint.Url, Config.EndpointAccess(endpoint))
+		Print("Endpoint=%s (auth=%s)", endpoint.Url, cfg.EndpointAccess(endpoint))
 		if len(endpoint.SshUserAndHost) > 0 {
 			Print("  SSH=%s:%s", endpoint.SshUserAndHost, endpoint.SshPath)
 		}
 	}
 
-	for _, remote := range Config.Remotes() {
-		remoteEndpoint := Config.RemoteEndpoint(remote, "download")
-		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, Config.EndpointAccess(remoteEndpoint))
+	for _, remote := range cfg.Remotes() {
+		remoteEndpoint := cfg.RemoteEndpoint(remote, "download")
+		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, cfg.EndpointAccess(remoteEndpoint))
 		if len(remoteEndpoint.SshUserAndHost) > 0 {
 			Print("  SSH=%s:%s", remoteEndpoint.SshUserAndHost, remoteEndpoint.SshPath)
 		}
@@ -47,7 +47,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 	}
 
 	for _, key := range []string{"filter.lfs.smudge", "filter.lfs.clean"} {
-		value, _ := Config.GitConfig(key)
+		value, _ := cfg.GitConfig(key)
 		Print("git config %s = %q", key, value)
 	}
 }

--- a/commands/command_ext.go
+++ b/commands/command_ext.go
@@ -32,13 +32,13 @@ func extListCommand(cmd *cobra.Command, args []string) {
 	}
 
 	for _, key := range args {
-		ext := Config.Extensions()[key]
+		ext := cfg.Extensions()[key]
 		printExt(ext)
 	}
 }
 
 func printAllExts() {
-	extensions, err := Config.SortedExtensions()
+	extensions, err := cfg.SortedExtensions()
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/commands/command_ext.go
+++ b/commands/command_ext.go
@@ -31,17 +31,14 @@ func extListCommand(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	cfg := config.Config
 	for _, key := range args {
-		ext := cfg.Extensions()[key]
+		ext := Config.Extensions()[key]
 		printExt(ext)
 	}
 }
 
 func printAllExts() {
-	cfg := config.Config
-
-	extensions, err := cfg.SortedExtensions()
+	extensions, err := Config.SortedExtensions()
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/progress"
@@ -34,14 +33,14 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		if err := git.ValidateRemote(args[0]); err != nil {
 			Exit("Invalid remote name %q", args[0])
 		}
-		config.Config.CurrentRemote = args[0]
+		Config.CurrentRemote = args[0]
 	} else {
 		// Actively find the default remote, don't just assume origin
 		defaultRemote, err := git.DefaultRemote()
 		if err != nil {
 			Exit("No default remote")
 		}
-		config.Config.CurrentRemote = defaultRemote
+		Config.CurrentRemote = defaultRemote
 	}
 
 	if len(args) > 1 {
@@ -66,13 +65,13 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		if fetchIncludeArg != "" || fetchExcludeArg != "" {
 			Exit("Cannot combine --all with --include or --exclude")
 		}
-		if len(config.Config.FetchIncludePaths()) > 0 || len(config.Config.FetchExcludePaths()) > 0 {
+		if len(Config.FetchIncludePaths()) > 0 || len(Config.FetchExcludePaths()) > 0 {
 			Print("Ignoring global include / exclude paths to fulfil --all")
 		}
 		success = fetchAll()
 
 	} else { // !all
-		includePaths, excludePaths := determineIncludeExcludePaths(config.Config, fetchIncludeArg, fetchExcludeArg)
+		includePaths, excludePaths := determineIncludeExcludePaths(Config, fetchIncludeArg, fetchExcludeArg)
 
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored
 		for _, ref := range refs {
@@ -81,14 +80,14 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 			success = success && s
 		}
 
-		if fetchRecentArg || config.Config.FetchPruneConfig().FetchRecentAlways {
+		if fetchRecentArg || Config.FetchPruneConfig().FetchRecentAlways {
 			s := fetchRecent(refs, includePaths, excludePaths)
 			success = success && s
 		}
 	}
 
 	if fetchPruneArg {
-		verify := config.Config.FetchPruneConfig().PruneVerifyRemoteAlways
+		verify := Config.FetchPruneConfig().PruneVerifyRemoteAlways
 		// no dry-run or verbose options in fetch, assume false
 		prune(verify, false, false)
 	}
@@ -148,7 +147,7 @@ func fetchPreviousVersions(ref string, since time.Time, include, exclude []strin
 
 // Fetch recent objects based on config
 func fetchRecent(alreadyFetchedRefs []*git.Ref, include, exclude []string) bool {
-	fetchconf := config.Config.FetchPruneConfig()
+	fetchconf := Config.FetchPruneConfig()
 
 	if fetchconf.FetchRecentRefsDays == 0 && fetchconf.FetchRecentCommitsDays == 0 {
 		return true
@@ -164,7 +163,7 @@ func fetchRecent(alreadyFetchedRefs []*git.Ref, include, exclude []string) bool 
 	if fetchconf.FetchRecentRefsDays > 0 {
 		Print("Fetching recent branches within %v days", fetchconf.FetchRecentRefsDays)
 		refsSince := time.Now().AddDate(0, 0, -fetchconf.FetchRecentRefsDays)
-		refs, err := git.RecentBranches(refsSince, fetchconf.FetchRecentRefsIncludeRemotes, config.Config.CurrentRemote)
+		refs, err := git.RecentBranches(refsSince, fetchconf.FetchRecentRefsIncludeRemotes, Config.CurrentRemote)
 		if err != nil {
 			Panic(err, "Could not scan for recent refs")
 		}

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -30,7 +30,7 @@ var (
 )
 
 func lockCommand(cmd *cobra.Command, args []string) {
-	setLockRemoteFor(config.Config)
+	setLockRemoteFor(Config)
 
 	if len(args) == 0 {
 		Print("Usage: git lfs lock <path>")
@@ -107,9 +107,9 @@ func lockPath(file string) (string, error) {
 }
 
 func init() {
-	lockCmd.Flags().StringVarP(&lockRemote, "remote", "r", config.Config.CurrentRemote, lockRemoteHelp)
+	lockCmd.Flags().StringVarP(&lockRemote, "remote", "r", Config.CurrentRemote, lockRemoteHelp)
 
-	if isCommandEnabled(config.Config, "locks") {
+	if isCommandEnabled(Config, "locks") {
 		RootCmd.AddCommand(lockCmd)
 	}
 }

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -30,7 +30,7 @@ var (
 )
 
 func lockCommand(cmd *cobra.Command, args []string) {
-	setLockRemoteFor(Config)
+	setLockRemoteFor(cfg)
 
 	if len(args) == 0 {
 		Print("Usage: git lfs lock <path>")
@@ -107,9 +107,9 @@ func lockPath(file string) (string, error) {
 }
 
 func init() {
-	lockCmd.Flags().StringVarP(&lockRemote, "remote", "r", Config.CurrentRemote, lockRemoteHelp)
+	lockCmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
 
-	if isCommandEnabled(Config, "locks") {
+	if isCommandEnabled(cfg, "locks") {
 		RootCmd.AddCommand(lockCmd)
 	}
 }

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -14,7 +14,7 @@ var (
 )
 
 func locksCommand(cmd *cobra.Command, args []string) {
-	setLockRemoteFor(Config)
+	setLockRemoteFor(cfg)
 
 	filters, err := locksCmdFlags.Filters()
 	if err != nil {
@@ -56,13 +56,13 @@ func locksCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	locksCmd.Flags().StringVarP(&lockRemote, "remote", "r", Config.CurrentRemote, lockRemoteHelp)
+	locksCmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
 
 	locksCmd.Flags().StringVarP(&locksCmdFlags.Path, "path", "p", "", "filter locks results matching a particular path")
 	locksCmd.Flags().StringVarP(&locksCmdFlags.Id, "id", "i", "", "filter locks results matching a particular ID")
 	locksCmd.Flags().IntVarP(&locksCmdFlags.Limit, "limit", "l", 0, "optional limit for number of results to return")
 
-	if isCommandEnabled(Config, "locks") {
+	if isCommandEnabled(cfg, "locks") {
 		RootCmd.AddCommand(locksCmd)
 	}
 }

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"github.com/github/git-lfs/api"
-	"github.com/github/git-lfs/config"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +14,7 @@ var (
 )
 
 func locksCommand(cmd *cobra.Command, args []string) {
-	setLockRemoteFor(config.Config)
+	setLockRemoteFor(Config)
 
 	filters, err := locksCmdFlags.Filters()
 	if err != nil {
@@ -57,13 +56,13 @@ func locksCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	locksCmd.Flags().StringVarP(&lockRemote, "remote", "r", config.Config.CurrentRemote, lockRemoteHelp)
+	locksCmd.Flags().StringVarP(&lockRemote, "remote", "r", Config.CurrentRemote, lockRemoteHelp)
 
 	locksCmd.Flags().StringVarP(&locksCmdFlags.Path, "path", "p", "", "filter locks results matching a particular path")
 	locksCmd.Flags().StringVarP(&locksCmdFlags.Id, "id", "i", "", "filter locks results matching a particular ID")
 	locksCmd.Flags().IntVarP(&locksCmdFlags.Limit, "limit", "l", 0, "optional limit for number of results to return")
 
-	if isCommandEnabled(config.Config, "locks") {
+	if isCommandEnabled(Config, "locks") {
 		RootCmd.AddCommand(locksCmd)
 	}
 }

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/spf13/cobra"
@@ -53,12 +52,12 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 		Exit("Invalid remote name %q", args[0])
 	}
 
-	config.Config.CurrentRemote = args[0]
+	Config.CurrentRemote = args[0]
 	ctx := newUploadContext(prePushDryRun)
 
 	scanOpt := lfs.NewScanRefsOptions()
 	scanOpt.ScanMode = lfs.ScanLeftToRemoteMode
-	scanOpt.RemoteName = config.Config.CurrentRemote
+	scanOpt.RemoteName = Config.CurrentRemote
 
 	// We can be passed multiple lines of refs
 	scanner := bufio.NewScanner(os.Stdin)

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -52,12 +52,12 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 		Exit("Invalid remote name %q", args[0])
 	}
 
-	Config.CurrentRemote = args[0]
+	cfg.CurrentRemote = args[0]
 	ctx := newUploadContext(prePushDryRun)
 
 	scanOpt := lfs.NewScanRefsOptions()
 	scanOpt.ScanMode = lfs.ScanLeftToRemoteMode
-	scanOpt.RemoteName = Config.CurrentRemote
+	scanOpt.RemoteName = cfg.CurrentRemote
 
 	// We can be passed multiple lines of refs
 	scanner := bufio.NewScanner(os.Stdin)

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -37,7 +37,7 @@ func pruneCommand(cmd *cobra.Command, args []string) {
 	}
 
 	verify := !pruneDoNotVerifyArg &&
-		(config.Config.FetchPruneConfig().PruneVerifyRemoteAlways || pruneVerifyArg)
+		(Config.FetchPruneConfig().PruneVerifyRemoteAlways || pruneVerifyArg)
 
 	prune(verify, pruneDryRunArg, pruneVerboseArg)
 
@@ -123,7 +123,7 @@ func prune(verifyRemote, dryRun, verbose bool) {
 	var verifyc chan string
 
 	if verifyRemote {
-		config.Config.CurrentRemote = config.Config.FetchPruneConfig().PruneRemoteName
+		Config.CurrentRemote = Config.FetchPruneConfig().PruneRemoteName
 		// build queue now, no estimates or progress output
 		verifyQueue = lfs.NewDownloadCheckQueue(0, 0)
 		verifiedObjects = tools.NewStringSetWithCapacity(len(localObjects) / 2)
@@ -365,7 +365,7 @@ func pruneTaskGetRetainedCurrentAndRecentRefs(retainChan chan string, errorChan 
 	go pruneTaskGetRetainedAtRef(ref.Sha, retainChan, errorChan, waitg)
 
 	// Now recent
-	fetchconf := config.Config.FetchPruneConfig()
+	fetchconf := Config.FetchPruneConfig()
 	if fetchconf.FetchRecentRefsDays > 0 {
 		pruneRefDays := fetchconf.FetchRecentRefsDays + fetchconf.PruneOffsetDays
 		tracerx.Printf("PRUNE: Retaining non-HEAD refs within %d (%d+%d) days", pruneRefDays, fetchconf.FetchRecentRefsDays, fetchconf.PruneOffsetDays)
@@ -406,7 +406,7 @@ func pruneTaskGetRetainedCurrentAndRecentRefs(retainChan chan string, errorChan 
 func pruneTaskGetRetainedUnpushed(retainChan chan string, errorChan chan error, waitg *sync.WaitGroup) {
 	defer waitg.Done()
 
-	remoteName := config.Config.FetchPruneConfig().PruneRemoteName
+	remoteName := Config.FetchPruneConfig().PruneRemoteName
 
 	refchan, err := lfs.ScanUnpushedToChan(remoteName)
 	if err != nil {

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -37,7 +37,7 @@ func pruneCommand(cmd *cobra.Command, args []string) {
 	}
 
 	verify := !pruneDoNotVerifyArg &&
-		(Config.FetchPruneConfig().PruneVerifyRemoteAlways || pruneVerifyArg)
+		(cfg.FetchPruneConfig().PruneVerifyRemoteAlways || pruneVerifyArg)
 
 	prune(verify, pruneDryRunArg, pruneVerboseArg)
 
@@ -123,7 +123,7 @@ func prune(verifyRemote, dryRun, verbose bool) {
 	var verifyc chan string
 
 	if verifyRemote {
-		Config.CurrentRemote = Config.FetchPruneConfig().PruneRemoteName
+		cfg.CurrentRemote = cfg.FetchPruneConfig().PruneRemoteName
 		// build queue now, no estimates or progress output
 		verifyQueue = lfs.NewDownloadCheckQueue(0, 0)
 		verifiedObjects = tools.NewStringSetWithCapacity(len(localObjects) / 2)
@@ -365,7 +365,7 @@ func pruneTaskGetRetainedCurrentAndRecentRefs(retainChan chan string, errorChan 
 	go pruneTaskGetRetainedAtRef(ref.Sha, retainChan, errorChan, waitg)
 
 	// Now recent
-	fetchconf := Config.FetchPruneConfig()
+	fetchconf := cfg.FetchPruneConfig()
 	if fetchconf.FetchRecentRefsDays > 0 {
 		pruneRefDays := fetchconf.FetchRecentRefsDays + fetchconf.PruneOffsetDays
 		tracerx.Printf("PRUNE: Retaining non-HEAD refs within %d (%d+%d) days", pruneRefDays, fetchconf.FetchRecentRefsDays, fetchconf.PruneOffsetDays)
@@ -406,7 +406,7 @@ func pruneTaskGetRetainedCurrentAndRecentRefs(retainChan chan string, errorChan 
 func pruneTaskGetRetainedUnpushed(retainChan chan string, errorChan chan error, waitg *sync.WaitGroup) {
 	defer waitg.Done()
 
-	remoteName := Config.FetchPruneConfig().PruneRemoteName
+	remoteName := cfg.FetchPruneConfig().PruneRemoteName
 
 	refchan, err := lfs.ScanUnpushedToChan(remoteName)
 	if err != nil {

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -35,7 +35,7 @@ func pullCommand(cmd *cobra.Command, args []string) {
 		config.Config.CurrentRemote = defaultRemote
 	}
 
-	pull(determineIncludeExcludePaths(config.Config, pullIncludeArg, pullExcludeArg))
+	pull(determineIncludeExcludePaths(Config, pullIncludeArg, pullExcludeArg))
 
 }
 

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -35,7 +35,7 @@ func pullCommand(cmd *cobra.Command, args []string) {
 		config.Config.CurrentRemote = defaultRemote
 	}
 
-	pull(determineIncludeExcludePaths(Config, pullIncludeArg, pullExcludeArg))
+	pull(determineIncludeExcludePaths(cfg, pullIncludeArg, pullExcludeArg))
 
 }
 

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"fmt"
 
-	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/git"
 	"github.com/spf13/cobra"
 )
@@ -25,14 +24,14 @@ func pullCommand(cmd *cobra.Command, args []string) {
 		if err := git.ValidateRemote(args[0]); err != nil {
 			Panic(err, fmt.Sprintf("Invalid remote name '%v'", args[0]))
 		}
-		config.Config.CurrentRemote = args[0]
+		cfg.CurrentRemote = args[0]
 	} else {
 		// Actively find the default remote, don't just assume origin
 		defaultRemote, err := git.DefaultRemote()
 		if err != nil {
 			Panic(err, "No default remote")
 		}
-		config.Config.CurrentRemote = defaultRemote
+		cfg.CurrentRemote = defaultRemote
 	}
 
 	pull(determineIncludeExcludePaths(cfg, pullIncludeArg, pullExcludeArg))

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/rubyist/tracerx"
@@ -29,7 +28,7 @@ func uploadsBetweenRefs(ctx *uploadContext, left string, right string) {
 
 	scanOpt := lfs.NewScanRefsOptions()
 	scanOpt.ScanMode = lfs.ScanRefsMode
-	scanOpt.RemoteName = config.Config.CurrentRemote
+	scanOpt.RemoteName = Config.CurrentRemote
 
 	pointers, err := lfs.ScanRefs(left, right, scanOpt)
 	if err != nil {
@@ -40,11 +39,11 @@ func uploadsBetweenRefs(ctx *uploadContext, left string, right string) {
 }
 
 func uploadsBetweenRefAndRemote(ctx *uploadContext, refnames []string) {
-	tracerx.Printf("Upload refs %v to remote %v", refnames, config.Config.CurrentRemote)
+	tracerx.Printf("Upload refs %v to remote %v", refnames, Config.CurrentRemote)
 
 	scanOpt := lfs.NewScanRefsOptions()
 	scanOpt.ScanMode = lfs.ScanLeftToRemoteMode
-	scanOpt.RemoteName = config.Config.CurrentRemote
+	scanOpt.RemoteName = Config.CurrentRemote
 
 	if pushAll {
 		scanOpt.ScanMode = lfs.ScanRefsMode
@@ -123,7 +122,7 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		Exit("Invalid remote name %q", args[0])
 	}
 
-	config.Config.CurrentRemote = args[0]
+	Config.CurrentRemote = args[0]
 	ctx := newUploadContext(pushDryRun)
 
 	if useStdin {

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -28,7 +28,7 @@ func uploadsBetweenRefs(ctx *uploadContext, left string, right string) {
 
 	scanOpt := lfs.NewScanRefsOptions()
 	scanOpt.ScanMode = lfs.ScanRefsMode
-	scanOpt.RemoteName = Config.CurrentRemote
+	scanOpt.RemoteName = cfg.CurrentRemote
 
 	pointers, err := lfs.ScanRefs(left, right, scanOpt)
 	if err != nil {
@@ -39,11 +39,11 @@ func uploadsBetweenRefs(ctx *uploadContext, left string, right string) {
 }
 
 func uploadsBetweenRefAndRemote(ctx *uploadContext, refnames []string) {
-	tracerx.Printf("Upload refs %v to remote %v", refnames, Config.CurrentRemote)
+	tracerx.Printf("Upload refs %v to remote %v", refnames, cfg.CurrentRemote)
 
 	scanOpt := lfs.NewScanRefsOptions()
 	scanOpt.ScanMode = lfs.ScanLeftToRemoteMode
-	scanOpt.RemoteName = Config.CurrentRemote
+	scanOpt.RemoteName = cfg.CurrentRemote
 
 	if pushAll {
 		scanOpt.ScanMode = lfs.ScanRefsMode
@@ -122,7 +122,7 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		Exit("Invalid remote name %q", args[0])
 	}
 
-	Config.CurrentRemote = args[0]
+	cfg.CurrentRemote = args[0]
 	ctx := newUploadContext(pushDryRun)
 
 	if useStdin {

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/errutil"
 	"github.com/github/git-lfs/lfs"
 	"github.com/spf13/cobra"
@@ -62,7 +61,6 @@ func smudgeCommand(cmd *cobra.Command, args []string) {
 		Error(err.Error())
 	}
 
-	cfg := config.Config
 	download := lfs.FilenamePassesIncludeExcludeFilter(filename, cfg.FetchIncludePaths(), cfg.FetchExcludePaths())
 
 	if smudgeSkip || cfg.GetenvBool("GIT_LFS_SKIP_SMUDGE", false) {

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/github/git-lfs/api"
-	"github.com/github/git-lfs/config"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +33,7 @@ type unlockFlags struct {
 }
 
 func unlockCommand(cmd *cobra.Command, args []string) {
-	setLockRemoteFor(config.Config)
+	setLockRemoteFor(cfg)
 
 	var id string
 	if len(args) != 0 {
@@ -98,13 +97,12 @@ func lockIdFromPath(path string) (string, error) {
 }
 
 func init() {
-	unlockCmd.Flags().StringVarP(&lockRemote, "remote", "r", config.Config.CurrentRemote, lockRemoteHelp)
+	unlockCmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
 
 	unlockCmd.Flags().StringVarP(&unlockCmdFlags.Id, "id", "i", "", "unlock a lock by its ID")
 	unlockCmd.Flags().BoolVarP(&unlockCmdFlags.Force, "force", "f", false, "forcibly break another user's lock(s)")
 
-	if isCommandEnabled(config.Config, "locks") {
+	if isCommandEnabled(cfg, "locks") {
 		RootCmd.AddCommand(unlockCmd)
 	}
-
 }

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -25,7 +25,7 @@ func updateCommand(cmd *cobra.Command, args []string) {
 	requireInRepo()
 
 	lfsAccessRE := regexp.MustCompile(`\Alfs\.(.*)\.access\z`)
-	for key, value := range config.Config.AllGitConfig() {
+	for key, value := range cfg.AllGitConfig() {
 		matches := lfsAccessRE.FindStringSubmatch(key)
 		if len(matches) < 2 {
 			continue

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"regexp"
 
-	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/spf13/cobra"

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -40,7 +40,7 @@ var (
 		},
 	}
 	ManPages = make(map[string]string, 20)
-	Config   = config.Config
+	cfg      = config.Config
 )
 
 // Error prints a formatted message to Stderr.  It also gets printed to the

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -15,6 +15,7 @@ import (
 	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/errutil"
 	"github.com/github/git-lfs/git"
+	"github.com/github/git-lfs/httputil"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/tools"
 	"github.com/spf13/cobra"
@@ -106,6 +107,13 @@ func Panic(err error, format string, args ...interface{}) {
 
 func Run() {
 	RootCmd.Execute()
+	httputil.LogHttpStats(cfg)
+}
+
+func Cleanup() {
+	if err := lfs.ClearTempObjects(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error clearing old temp files: %s\n", err)
+	}
 }
 
 func PipeMediaCommand(name string, args ...string) error {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -40,6 +40,7 @@ var (
 		},
 	}
 	ManPages = make(map[string]string, 20)
+	Config   = config.Config
 )
 
 // Error prints a formatted message to Stderr.  It also gets printed to the

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -8,21 +8,21 @@ import (
 )
 
 var (
-	cfg = config.NewFromValues(map[string]string{
+	testcfg = config.NewFromValues(map[string]string{
 		"lfs.fetchinclude": "/default/include",
 		"lfs.fetchexclude": "/default/exclude",
 	})
 )
 
 func TestDetermineIncludeExcludePathsReturnsCleanedPaths(t *testing.T) {
-	i, e := determineIncludeExcludePaths(cfg, "/some/include", "/some/exclude")
+	i, e := determineIncludeExcludePaths(testcfg, "/some/include", "/some/exclude")
 
 	assert.Equal(t, []string{"/some/include"}, i)
 	assert.Equal(t, []string{"/some/exclude"}, e)
 }
 
 func TestDetermineIncludeExcludePathsReturnsDefaultsWhenAbsent(t *testing.T) {
-	i, e := determineIncludeExcludePaths(cfg, "", "")
+	i, e := determineIncludeExcludePaths(testcfg, "", "")
 
 	assert.Equal(t, []string{"/default/include"}, i)
 	assert.Equal(t, []string{"/default/exclude"}, e)

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -29,7 +29,7 @@ func TestDetermineIncludeExcludePathsReturnsDefaultsWhenAbsent(t *testing.T) {
 }
 
 func TestCommandEnabledFromEnvironmentVariables(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 	err := cfg.Setenv("GITLFSLOCKSENABLED", "1")
 
 	assert.Nil(t, err)
@@ -37,7 +37,7 @@ func TestCommandEnabledFromEnvironmentVariables(t *testing.T) {
 }
 
 func TestCommandEnabledDisabledByDefault(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 
 	// Since config.Configuration.Setenv makes a call to os.Setenv, we have
 	// to make sure that the LFSLOCKSENABLED enviornment variable is not

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	Config                 = NewConfig()
+	Config                 = New()
 	ShowConfigWarnings     = false
 	defaultRemote          = "origin"
 	gitConfigWarningPrefix = "lfs."
@@ -67,7 +67,7 @@ type Configuration struct {
 	parsedNetrc       netrcfinder
 }
 
-func NewConfig() *Configuration {
+func New() *Configuration {
 	c := &Configuration{
 		CurrentRemote: defaultRemote,
 		envVars:       make(map[string]string),

--- a/config/endpoint.go
+++ b/config/endpoint.go
@@ -21,12 +21,12 @@ type Endpoint struct {
 // NewEndpointFromCloneURL creates an Endpoint from a git clone URL by appending
 // "[.git]/info/lfs".
 func NewEndpointFromCloneURL(url string) Endpoint {
-	return NewEndpointFromCloneURLWithConfig(url, NewConfig())
+	return NewEndpointFromCloneURLWithConfig(url, New())
 }
 
 // NewEndpoint initializes a new Endpoint for a given URL.
 func NewEndpoint(rawurl string) Endpoint {
-	return NewEndpointWithConfig(rawurl, NewConfig())
+	return NewEndpointWithConfig(rawurl, New())
 }
 
 // NewEndpointFromCloneURLWithConfig creates an Endpoint from a git clone URL by appending

--- a/git-lfs.go
+++ b/git-lfs.go
@@ -8,8 +8,6 @@ import (
 	"syscall"
 
 	"github.com/github/git-lfs/commands"
-	"github.com/github/git-lfs/httputil"
-	"github.com/github/git-lfs/lfs"
 )
 
 func main() {
@@ -21,7 +19,7 @@ func main() {
 	go func() {
 		for {
 			sig := <-c
-			once.Do(clearTempObjects)
+			once.Do(commands.Cleanup)
 			fmt.Fprintf(os.Stderr, "\nExiting because of %q signal.\n", sig)
 
 			exitCode := 1
@@ -33,12 +31,5 @@ func main() {
 	}()
 
 	commands.Run()
-	httputil.LogHttpStats()
-	once.Do(clearTempObjects)
-}
-
-func clearTempObjects() {
-	if err := lfs.ClearTempObjects(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error clearing old temp files: %s\n", err)
-	}
+	once.Do(commands.Cleanup)
 }

--- a/httputil/certs.go
+++ b/httputil/certs.go
@@ -12,14 +12,14 @@ import (
 
 // isCertVerificationDisabledForHost returns whether SSL certificate verification
 // has been disabled for the given host, or globally
-func isCertVerificationDisabledForHost(host string) bool {
-	hostSslVerify, _ := config.Config.GitConfig(fmt.Sprintf("http.https://%v/.sslverify", host))
+func isCertVerificationDisabledForHost(cfg *config.Configuration, host string) bool {
+	hostSslVerify, _ := cfg.GitConfig(fmt.Sprintf("http.https://%v/.sslverify", host))
 	if hostSslVerify == "false" {
 		return true
 	}
 
-	globalSslVerify, _ := config.Config.GitConfig("http.sslverify")
-	if globalSslVerify == "false" || config.Config.GetenvBool("GIT_SSL_NO_VERIFY", false) {
+	globalSslVerify, _ := cfg.GitConfig("http.sslverify")
+	if globalSslVerify == "false" || cfg.GetenvBool("GIT_SSL_NO_VERIFY", false) {
 		return true
 	}
 
@@ -32,41 +32,41 @@ func isCertVerificationDisabledForHost(host string) bool {
 // source which is not included by default in the golang certificate search)
 // May return nil if it doesn't have anything to add, in which case the default
 // RootCAs will be used if passed to TLSClientConfig.RootCAs
-func getRootCAsForHost(host string) *x509.CertPool {
+func getRootCAsForHost(cfg *config.Configuration, host string) *x509.CertPool {
 
 	// don't init pool, want to return nil not empty if none found; init only on successful add cert
 	var pool *x509.CertPool
 
 	// gitconfig first
-	pool = appendRootCAsForHostFromGitconfig(pool, host)
+	pool = appendRootCAsForHostFromGitconfig(cfg, pool, host)
 	// Platform specific
 	return appendRootCAsForHostFromPlatform(pool, host)
 
 }
 
-func appendRootCAsForHostFromGitconfig(pool *x509.CertPool, host string) *x509.CertPool {
+func appendRootCAsForHostFromGitconfig(cfg *config.Configuration, pool *x509.CertPool, host string) *x509.CertPool {
 	// Accumulate certs from all these locations:
 
 	// GIT_SSL_CAINFO first
-	if cafile := config.Config.Getenv("GIT_SSL_CAINFO"); len(cafile) > 0 {
+	if cafile := cfg.Getenv("GIT_SSL_CAINFO"); len(cafile) > 0 {
 		return appendCertsFromFile(pool, cafile)
 	}
 	// http.<url>.sslcainfo
 	// we know we have simply "host" or "host:port"
 	key := fmt.Sprintf("http.https://%v/.sslcainfo", host)
-	if cafile, ok := config.Config.GitConfig(key); ok {
+	if cafile, ok := cfg.GitConfig(key); ok {
 		return appendCertsFromFile(pool, cafile)
 	}
 	// http.sslcainfo
-	if cafile, ok := config.Config.GitConfig("http.sslcainfo"); ok {
+	if cafile, ok := cfg.GitConfig("http.sslcainfo"); ok {
 		return appendCertsFromFile(pool, cafile)
 	}
 	// GIT_SSL_CAPATH
-	if cadir := config.Config.Getenv("GIT_SSL_CAPATH"); len(cadir) > 0 {
+	if cadir := cfg.Getenv("GIT_SSL_CAPATH"); len(cadir) > 0 {
 		return appendCertsFromFilesInDir(pool, cadir)
 	}
 	// http.sslcapath
-	if cadir, ok := config.Config.GitConfig("http.sslcapath"); ok {
+	if cadir, ok := cfg.GitConfig("http.sslcapath"); ok {
 		return appendCertsFromFilesInDir(pool, cadir)
 	}
 

--- a/httputil/ntlm.go
+++ b/httputil/ntlm.go
@@ -53,7 +53,7 @@ func doNTLMRequest(request *http.Request, retry bool) (*http.Response, error) {
 	//If the status is 401 then we need to re-authenticate, otherwise it was successful
 	if res.StatusCode == 401 {
 
-		creds, err := auth.GetCreds(request)
+		creds, err := auth.GetCreds(config.Config, request)
 		if err != nil {
 			return nil, err
 		}
@@ -83,7 +83,7 @@ func doNTLMRequest(request *http.Request, retry bool) (*http.Response, error) {
 			return doNTLMRequest(challengeReq, false)
 		}
 
-		auth.SaveCredentials(creds, res)
+		auth.SaveCredentials(config.Config, creds, res)
 
 		return res, nil
 	}

--- a/httputil/ntlm.go
+++ b/httputil/ntlm.go
@@ -24,7 +24,7 @@ func ntlmClientSession(c *config.Configuration, creds auth.Creds) (ntlm.ClientSe
 	splits := strings.Split(creds["username"], "\\")
 
 	if len(splits) != 2 {
-		errorMessage := fmt.Sprintf("Your user name must be of the form DOMAIN\\user. It is currently %s", creds["username"], "string")
+		errorMessage := fmt.Sprintf("Your user name must be of the form DOMAIN\\user. It is currently %s", creds["username"])
 		return nil, errors.New(errorMessage)
 	}
 
@@ -39,21 +39,20 @@ func ntlmClientSession(c *config.Configuration, creds auth.Creds) (ntlm.ClientSe
 	return session, nil
 }
 
-func doNTLMRequest(request *http.Request, retry bool) (*http.Response, error) {
+func doNTLMRequest(cfg *config.Configuration, request *http.Request, retry bool) (*http.Response, error) {
 	handReq, err := cloneRequest(request)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := NewHttpClient(config.Config, handReq.Host).Do(handReq)
+	res, err := NewHttpClient(cfg, handReq.Host).Do(handReq)
 	if err != nil && res == nil {
 		return nil, err
 	}
 
 	//If the status is 401 then we need to re-authenticate, otherwise it was successful
 	if res.StatusCode == 401 {
-
-		creds, err := auth.GetCreds(config.Config, request)
+		creds, err := auth.GetCreds(cfg, request)
 		if err != nil {
 			return nil, err
 		}
@@ -63,7 +62,7 @@ func doNTLMRequest(request *http.Request, retry bool) (*http.Response, error) {
 			return nil, err
 		}
 
-		challengeMessage, err := negotiate(negotiateReq, ntlmNegotiateMessage)
+		challengeMessage, err := negotiate(cfg, negotiateReq, ntlmNegotiateMessage)
 		if err != nil {
 			return nil, err
 		}
@@ -73,26 +72,26 @@ func doNTLMRequest(request *http.Request, retry bool) (*http.Response, error) {
 			return nil, err
 		}
 
-		res, err := challenge(challengeReq, challengeMessage, creds)
+		res, err := challenge(cfg, challengeReq, challengeMessage, creds)
 		if err != nil {
 			return nil, err
 		}
 
 		//If the status is 401 then we need to re-authenticate
 		if res.StatusCode == 401 && retry == true {
-			return doNTLMRequest(challengeReq, false)
+			return doNTLMRequest(cfg, challengeReq, false)
 		}
 
-		auth.SaveCredentials(config.Config, creds, res)
+		auth.SaveCredentials(cfg, creds, res)
 
 		return res, nil
 	}
 	return res, nil
 }
 
-func negotiate(request *http.Request, message string) ([]byte, error) {
+func negotiate(cfg *config.Configuration, request *http.Request, message string) ([]byte, error) {
 	request.Header.Add("Authorization", message)
-	res, err := NewHttpClient(config.Config, request.Host).Do(request)
+	res, err := NewHttpClient(cfg, request.Host).Do(request)
 
 	if res == nil && err != nil {
 		return nil, err
@@ -109,13 +108,13 @@ func negotiate(request *http.Request, message string) ([]byte, error) {
 	return ret, nil
 }
 
-func challenge(request *http.Request, challengeBytes []byte, creds auth.Creds) (*http.Response, error) {
+func challenge(cfg *config.Configuration, request *http.Request, challengeBytes []byte, creds auth.Creds) (*http.Response, error) {
 	challenge, err := ntlm.ParseChallengeMessage(challengeBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	session, err := ntlmClientSession(config.Config, creds)
+	session, err := ntlmClientSession(cfg, creds)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +127,7 @@ func challenge(request *http.Request, challengeBytes []byte, creds auth.Creds) (
 
 	authMsg := base64.StdEncoding.EncodeToString(authenticate.Bytes())
 	request.Header.Add("Authorization", "NTLM "+authMsg)
-	return NewHttpClient(config.Config, request.Host).Do(request)
+	return NewHttpClient(cfg, request.Host).Do(request)
 }
 
 func parseChallengeResponse(response *http.Response) ([]byte, error) {

--- a/httputil/ntlm_test.go
+++ b/httputil/ntlm_test.go
@@ -14,34 +14,22 @@ import (
 )
 
 func TestNtlmClientSession(t *testing.T) {
-
-	//Make sure to clear ntlmSession so test order doesn't matter.
-	config.Config.NtlmSession = nil
-
+	cfg := config.New()
 	creds := auth.Creds{"username": "MOOSEDOMAIN\\canadian", "password": "MooseAntlersYeah"}
-	_, err := ntlmClientSession(config.Config, creds)
+	_, err := ntlmClientSession(cfg, creds)
 	assert.Nil(t, err)
 
 	//The second call should ignore creds and give the session we just created.
 	badCreds := auth.Creds{"username": "badusername", "password": "MooseAntlersYeah"}
-	_, err = ntlmClientSession(config.Config, badCreds)
+	_, err = ntlmClientSession(cfg, badCreds)
 	assert.Nil(t, err)
-
-	//clean up
-	config.Config.NtlmSession = nil
 }
 
 func TestNtlmClientSessionBadCreds(t *testing.T) {
-
-	//Make sure to clear ntlmSession so test order doesn't matter.
-	config.Config.NtlmSession = nil
-
+	cfg := config.New()
 	creds := auth.Creds{"username": "badusername", "password": "MooseAntlersYeah"}
-	_, err := ntlmClientSession(config.Config, creds)
+	_, err := ntlmClientSession(cfg, creds)
 	assert.NotNil(t, err)
-
-	//clean up
-	config.Config.NtlmSession = nil
 }
 
 func TestNtlmCloneRequest(t *testing.T) {

--- a/httputil/proxy_test.go
+++ b/httputil/proxy_test.go
@@ -47,7 +47,7 @@ func TestHttpProxyFromGitConfig(t *testing.T) {
 }
 
 func TestProxyFromEnvironment(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 	cfg.SetAllEnv(map[string]string{
 		"HTTPS_PROXY": "https://proxy-from-env:8080",
 	})
@@ -64,7 +64,7 @@ func TestProxyFromEnvironment(t *testing.T) {
 }
 
 func TestProxyIsNil(t *testing.T) {
-	cfg := config.NewConfig()
+	cfg := config.New()
 
 	req, err := http.NewRequest("GET", "http://some-host.com:123/foo/bar", nil)
 	if err != nil {

--- a/httputil/request.go
+++ b/httputil/request.go
@@ -43,16 +43,16 @@ func (e *ClientError) Error() string {
 }
 
 // Internal http request management
-func doHttpRequest(req *http.Request, creds auth.Creds) (*http.Response, error) {
+func doHttpRequest(cfg *config.Configuration, req *http.Request, creds auth.Creds) (*http.Response, error) {
 	var (
 		res *http.Response
 		err error
 	)
 
-	if config.Config.NtlmAccess(auth.GetOperationForRequest(req)) {
-		res, err = doNTLMRequest(req, true)
+	if cfg.NtlmAccess(auth.GetOperationForRequest(req)) {
+		res, err = doNTLMRequest(cfg, req, true)
 	} else {
-		res, err = NewHttpClient(config.Config, req.Host).Do(req)
+		res, err = NewHttpClient(cfg, req.Host).Do(req)
 	}
 
 	if res == nil {
@@ -66,20 +66,20 @@ func doHttpRequest(req *http.Request, creds auth.Creds) (*http.Response, error) 
 
 	if err != nil {
 		if errutil.IsAuthError(err) {
-			SetAuthType(req, res)
-			doHttpRequest(req, creds)
+			SetAuthType(cfg, req, res)
+			doHttpRequest(cfg, req, creds)
 		} else {
 			err = errutil.Error(err)
 		}
 	} else {
-		err = handleResponse(res, creds)
+		err = handleResponse(cfg, res, creds)
 	}
 
 	if err != nil {
 		if res != nil {
-			SetErrorResponseContext(err, res)
+			SetErrorResponseContext(cfg, err, res)
 		} else {
-			setErrorRequestContext(err, req)
+			setErrorRequestContext(cfg, err, req)
 		}
 	}
 
@@ -87,31 +87,31 @@ func doHttpRequest(req *http.Request, creds auth.Creds) (*http.Response, error) 
 }
 
 // DoHttpRequest performs a single HTTP request
-func DoHttpRequest(req *http.Request, useCreds bool) (*http.Response, error) {
+func DoHttpRequest(cfg *config.Configuration, req *http.Request, useCreds bool) (*http.Response, error) {
 	var creds auth.Creds
 	if useCreds {
-		c, err := auth.GetCreds(config.Config, req)
+		c, err := auth.GetCreds(cfg, req)
 		if err != nil {
 			return nil, err
 		}
 		creds = c
 	}
 
-	return doHttpRequest(req, creds)
+	return doHttpRequest(cfg, req, creds)
 }
 
 // DoHttpRequestWithRedirects runs a HTTP request and responds to redirects
-func DoHttpRequestWithRedirects(req *http.Request, via []*http.Request, useCreds bool) (*http.Response, error) {
+func DoHttpRequestWithRedirects(cfg *config.Configuration, req *http.Request, via []*http.Request, useCreds bool) (*http.Response, error) {
 	var creds auth.Creds
 	if useCreds {
-		c, err := auth.GetCreds(config.Config, req)
+		c, err := auth.GetCreds(cfg, req)
 		if err != nil {
 			return nil, err
 		}
 		creds = c
 	}
 
-	res, err := doHttpRequest(req, creds)
+	res, err := doHttpRequest(cfg, req, creds)
 	if err != nil {
 		return res, err
 	}
@@ -152,7 +152,7 @@ func DoHttpRequestWithRedirects(req *http.Request, via []*http.Request, useCreds
 			return res, errutil.Errorf(err, err.Error())
 		}
 
-		return DoHttpRequestWithRedirects(redirectedReq, via, useCreds)
+		return DoHttpRequestWithRedirects(cfg, redirectedReq, via, useCreds)
 	}
 
 	return res, nil
@@ -174,15 +174,14 @@ func NewHttpRequest(method, rawurl string, header map[string]string) (*http.Requ
 	return req, nil
 }
 
-func SetAuthType(req *http.Request, res *http.Response) {
+func SetAuthType(cfg *config.Configuration, req *http.Request, res *http.Response) {
 	authType := GetAuthType(res)
 	operation := auth.GetOperationForRequest(req)
-	config.Config.SetAccess(operation, authType)
+	cfg.SetAccess(operation, authType)
 	tracerx.Printf("api: http response indicates %q authentication. Resubmitting...", authType)
 }
 
 func GetAuthType(res *http.Response) string {
-
 	for _, headerName := range authenticateHeaders {
 		for _, auth := range res.Header[headerName] {
 

--- a/httputil/request.go
+++ b/httputil/request.go
@@ -90,7 +90,7 @@ func doHttpRequest(req *http.Request, creds auth.Creds) (*http.Response, error) 
 func DoHttpRequest(req *http.Request, useCreds bool) (*http.Response, error) {
 	var creds auth.Creds
 	if useCreds {
-		c, err := auth.GetCreds(req)
+		c, err := auth.GetCreds(config.Config, req)
 		if err != nil {
 			return nil, err
 		}
@@ -104,7 +104,7 @@ func DoHttpRequest(req *http.Request, useCreds bool) (*http.Response, error) {
 func DoHttpRequestWithRedirects(req *http.Request, via []*http.Request, useCreds bool) (*http.Response, error) {
 	var creds auth.Creds
 	if useCreds {
-		c, err := auth.GetCreds(req)
+		c, err := auth.GetCreds(config.Config, req)
 		if err != nil {
 			return nil, err
 		}

--- a/httputil/request_error_test.go
+++ b/httputil/request_error_test.go
@@ -9,19 +9,22 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/errutil"
 )
 
 func TestSuccessStatus(t *testing.T) {
+	cfg := config.New()
 	for _, status := range []int{200, 201, 202} {
 		res := &http.Response{StatusCode: status}
-		if err := handleResponse(res, nil); err != nil {
+		if err := handleResponse(cfg, res, nil); err != nil {
 			t.Errorf("Unexpected error for HTTP %d: %s", status, err.Error())
 		}
 	}
 }
 
 func TestErrorStatusWithCustomMessage(t *testing.T) {
+	cfg := config.New()
 	u, err := url.Parse("https://lfs-server.com/objects/oid")
 	if err != nil {
 		t.Fatal(err)
@@ -61,7 +64,7 @@ func TestErrorStatusWithCustomMessage(t *testing.T) {
 		}
 		res.Header.Set("Content-Type", "application/vnd.git-lfs+json; charset=utf-8")
 
-		err = handleResponse(res, nil)
+		err = handleResponse(cfg, res, nil)
 		if err == nil {
 			t.Errorf("No error from HTTP %d", status)
 			continue
@@ -81,6 +84,7 @@ func TestErrorStatusWithCustomMessage(t *testing.T) {
 }
 
 func TestErrorStatusWithDefaultMessage(t *testing.T) {
+	cfg := config.New()
 	rawurl := "https://lfs-server.com/objects/oid"
 	u, err := url.Parse(rawurl)
 	if err != nil {
@@ -123,7 +127,7 @@ func TestErrorStatusWithDefaultMessage(t *testing.T) {
 		// purposely wrong content type so it falls back to default
 		res.Header.Set("Content-Type", "application/vnd.git-lfs+json2")
 
-		err = handleResponse(res, nil)
+		err = handleResponse(cfg, res, nil)
 		if err == nil {
 			t.Errorf("No error from HTTP %d", status)
 			continue

--- a/httputil/response.go
+++ b/httputil/response.go
@@ -56,8 +56,8 @@ func GetDefaultError(code int) string {
 }
 
 // Check the response from a HTTP request for problems
-func handleResponse(res *http.Response, creds auth.Creds) error {
-	auth.SaveCredentials(config.Config, creds, res)
+func handleResponse(cfg *config.Configuration, res *http.Response, creds auth.Creds) error {
+	auth.SaveCredentials(cfg, creds, res)
 
 	if res.StatusCode < 400 {
 		return nil
@@ -103,14 +103,14 @@ func defaultError(res *http.Response) error {
 	return errutil.Error(fmt.Errorf(msgFmt, res.Request.URL))
 }
 
-func SetErrorResponseContext(err error, res *http.Response) {
+func SetErrorResponseContext(cfg *config.Configuration, err error, res *http.Response) {
 	errutil.ErrorSetContext(err, "Status", res.Status)
 	setErrorHeaderContext(err, "Request", res.Header)
-	setErrorRequestContext(err, res.Request)
+	setErrorRequestContext(cfg, err, res.Request)
 }
 
-func setErrorRequestContext(err error, req *http.Request) {
-	errutil.ErrorSetContext(err, "Endpoint", config.Config.Endpoint(auth.GetOperationForRequest(req)).Url)
+func setErrorRequestContext(cfg *config.Configuration, err error, req *http.Request) {
+	errutil.ErrorSetContext(err, "Endpoint", cfg.Endpoint(auth.GetOperationForRequest(req)).Url)
 	errutil.ErrorSetContext(err, "URL", TraceHttpReq(req))
 	setErrorHeaderContext(err, "Response", req.Header)
 }

--- a/httputil/response.go
+++ b/httputil/response.go
@@ -57,7 +57,7 @@ func GetDefaultError(code int) string {
 
 // Check the response from a HTTP request for problems
 func handleResponse(res *http.Response, creds auth.Creds) error {
-	auth.SaveCredentials(creds, res)
+	auth.SaveCredentials(config.Config, creds, res)
 
 	if res.StatusCode < 400 {
 		return nil

--- a/test/cmd/lfstest-customadapter.go
+++ b/test/cmd/lfstest-customadapter.go
@@ -13,10 +13,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/httputil"
 	"github.com/github/git-lfs/progress"
 	"github.com/github/git-lfs/tools"
 )
+
+var cfg = config.New()
 
 // This test custom adapter just acts as a bridge for uploads/downloads
 // in order to demonstrate & test the custom transfer adapter protocols
@@ -103,7 +106,7 @@ func performDownload(oid string, size int64, a *action, writer, errWriter *bufio
 		sendTransferError(oid, 2, err.Error(), writer, errWriter)
 		return
 	}
-	res, err := httputil.DoHttpRequest(req, true)
+	res, err := httputil.DoHttpRequest(cfg, req, true)
 	if err != nil {
 		sendTransferError(oid, res.StatusCode, err.Error(), writer, errWriter)
 		return
@@ -184,7 +187,7 @@ func performUpload(oid string, size int64, a *action, fromPath string, writer, e
 
 	req.Body = ioutil.NopCloser(reader)
 
-	res, err := httputil.DoHttpRequest(req, true)
+	res, err := httputil.DoHttpRequest(cfg, req, true)
 	if err != nil {
 		sendTransferError(oid, res.StatusCode, fmt.Sprintf("Error uploading data for %s: %v", oid, err), writer, errWriter)
 		return

--- a/transfer/basic_upload.go
+++ b/transfer/basic_upload.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/github/git-lfs/api"
+	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/errutil"
 	"github.com/github/git-lfs/httputil"
 	"github.com/github/git-lfs/progress"
@@ -96,11 +97,11 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Transfe
 
 	req.Body = ioutil.NopCloser(reader)
 
-	res, err := httputil.DoHttpRequest(req, true)
+	res, err := httputil.DoHttpRequest(config.Config, req, true)
 	if err != nil {
 		return errutil.NewRetriableError(err)
 	}
-	httputil.LogTransfer("lfs.data.upload", res)
+	httputil.LogTransfer(config.Config, "lfs.data.upload", res)
 
 	// A status code of 403 likely means that an authentication token for the
 	// upload has expired. This can be safely retried.

--- a/transfer/tus_upload.go
+++ b/transfer/tus_upload.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/github/git-lfs/api"
+	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/errutil"
 	"github.com/github/git-lfs/httputil"
 	"github.com/github/git-lfs/progress"
@@ -52,7 +53,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb TransferP
 		return err
 	}
 	req.Header.Set("Tus-Resumable", TusVersion)
-	res, err := httputil.DoHttpRequest(req, false)
+	res, err := httputil.DoHttpRequest(config.Config, req, false)
 	if err != nil {
 		return errutil.NewRetriableError(err)
 	}
@@ -133,11 +134,11 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb TransferP
 
 	req.Body = ioutil.NopCloser(reader)
 
-	res, err = httputil.DoHttpRequest(req, false)
+	res, err = httputil.DoHttpRequest(config.Config, req, false)
 	if err != nil {
 		return errutil.NewRetriableError(err)
 	}
-	httputil.LogTransfer("lfs.data.upload", res)
+	httputil.LogTransfer(config.Config, "lfs.data.upload", res)
 
 	// A status code of 403 likely means that an authentication token for the
 	// upload has expired. This can be safely retried.


### PR DESCRIPTION
I want to live in a world where most of the LFS functions don't use a global `config.Config` value. The `commands` package is the only exception, so I created a `commands.Config` value to use.

This is a small first step towards removing `config.Config` around the app.