### PR TITLE
Bump version number

### DIFF
--- a/config/version.go
+++ b/config/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	GitCommit   string
-	Version     = "1.2.0"
+	Version     = "1.3.0"
 	VersionDesc string
 )
 


### PR DESCRIPTION
I'm not sure what the convention is here. Version 1.3.0 is everywhere in this branch except in version.go.