### PR TITLE
Report actual list of transfers that will be tried from `git lfs env`

### DIFF
--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/github/git-lfs/config"
@@ -69,6 +70,11 @@ func ObjectExistsOfSize(oid string, size int64) bool {
 func Environ() []string {
 	osEnviron := os.Environ()
 	env := make([]string, 0, len(osEnviron)+7)
+	dltransfers := transfer.GetDownloadAdapterNames()
+	sort.Strings(dltransfers)
+	ultransfers := transfer.GetUploadAdapterNames()
+	sort.Strings(ultransfers)
+
 	env = append(env,
 		fmt.Sprintf("LocalWorkingDir=%s", config.LocalWorkingDir),
 		fmt.Sprintf("LocalGitDir=%s", config.LocalGitDir),
@@ -90,8 +96,8 @@ func Environ() []string {
 		fmt.Sprintf("PruneRemoteName=%s", config.Config.FetchPruneConfig().PruneRemoteName),
 		fmt.Sprintf("AccessDownload=%s", config.Config.Access("download")),
 		fmt.Sprintf("AccessUpload=%s", config.Config.Access("upload")),
-		fmt.Sprintf("DownloadTransfers=%s", strings.Join(transfer.GetDownloadAdapterNames(), ",")),
-		fmt.Sprintf("UploadTransfers=%s", strings.Join(transfer.GetUploadAdapterNames(), ",")),
+		fmt.Sprintf("DownloadTransfers=%s", strings.Join(dltransfers, ",")),
+		fmt.Sprintf("UploadTransfers=%s", strings.Join(ultransfers, ",")),
 	)
 	if len(config.Config.FetchExcludePaths()) > 0 {
 		env = append(env, fmt.Sprintf("FetchExclude=%s", strings.Join(config.Config.FetchExcludePaths(), ", ")))

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/localstorage"
 	"github.com/github/git-lfs/tools"
+	"github.com/github/git-lfs/transfer"
 	"github.com/rubyist/tracerx"
 )
 
@@ -89,6 +90,8 @@ func Environ() []string {
 		fmt.Sprintf("PruneRemoteName=%s", config.Config.FetchPruneConfig().PruneRemoteName),
 		fmt.Sprintf("AccessDownload=%s", config.Config.Access("download")),
 		fmt.Sprintf("AccessUpload=%s", config.Config.Access("upload")),
+		fmt.Sprintf("DownloadTransfers=%s", strings.Join(transfer.GetDownloadAdapterNames(), ",")),
+		fmt.Sprintf("UploadTransfers=%s", strings.Join(transfer.GetUploadAdapterNames(), ",")),
 	)
 	if len(config.Config.FetchExcludePaths()) > 0 {
 		env = append(env, fmt.Sprintf("FetchExclude=%s", strings.Join(config.Config.FetchExcludePaths(), ", ")))

--- a/test/test-env.sh
+++ b/test/test-env.sh
@@ -43,6 +43,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
@@ -92,6 +94,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$endpoint" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
@@ -148,6 +152,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$endpoint" "$endpoint2" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
@@ -202,6 +208,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$endpoint" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
@@ -258,6 +266,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$endpoint" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
@@ -315,6 +325,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
@@ -374,6 +386,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
@@ -439,6 +453,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
@@ -498,6 +514,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
@@ -550,6 +568,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
@@ -593,6 +613,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 git config filter.lfs.smudge = \"\"
 git config filter.lfs.clean = \"\"
@@ -625,6 +647,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
@@ -656,6 +680,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
@@ -698,6 +724,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 %s
 " "$(git lfs version)" "$(git version)" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
@@ -771,6 +799,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
@@ -802,6 +832,105 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
+%s
+%s
+' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
+  actual=$(git lfs env)
+  contains_same_elements "$expecteddisabled" "$actual"
+
+  # now enable via env var
+  actual=$(GIT_LFS_SKIP_DOWNLOAD_ERRORS=1 git lfs env)
+  contains_same_elements "$expectedenabled" "$actual"
+
+
+
+
+)
+end_test
+
+begin_test "env with extra transfer methods"
+(
+  set -e
+  reponame="env-with-transfers"
+  git init $reponame
+  cd $reponame
+
+  git config lfs.tustransfers true
+  git config lfs.customtransfer.supertransfer.path /path/to/something
+
+  localgit=$(native_path "$TRASHDIR/$reponame")
+  localgitstore=$(native_path "$TRASHDIR/$reponame")
+  localmedia=$(native_path "$TRASHDIR/$reponame/lfs/objects")
+  tempdir=$(native_path "$TRASHDIR/$reponame/lfs/tmp")
+  envVars=$(printf "%s" "$(env | grep "^GIT")")
+
+  localwd=$(native_path "$TRASHDIR/$reponame")
+  localgit=$(native_path "$TRASHDIR/$reponame/.git")
+  localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
+  localmedia=$(native_path "$TRASHDIR/$reponame/.git/lfs/objects")
+  tempdir=$(native_path "$TRASHDIR/$reponame/.git/lfs/tmp")
+  envVars=$(printf "%s" "$(env | grep "^GIT")")
+
+  expectedenabled=$(printf '%s
+%s
+
+LocalWorkingDir=%s
+LocalGitDir=%s
+LocalGitStorageDir=%s
+LocalMediaDir=%s
+LocalReferenceDir=
+TempDir=%s
+ConcurrentTransfers=3
+TusTransfers=true
+BasicTransfersOnly=false
+BatchTransfer=true
+SkipDownloadErrors=false
+FetchRecentAlways=false
+FetchRecentRefsDays=7
+FetchRecentCommitsDays=0
+FetchRecentRefsIncludeRemotes=true
+PruneOffsetDays=3
+PruneVerifyRemoteAlways=false
+PruneRemoteName=origin
+AccessDownload=none
+AccessUpload=none
+DownloadTransfers=basic,supertransfer
+UploadTransfers=basic,tus,supertransfer
+%s
+%s
+' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
+  actual=$(git lfs env)
+  contains_same_elements "$expectedenabled" "$actual"
+
+  git config --unset lfs.skipdownloaderrors
+  # prove it's usually off
+  expecteddisabled=$(printf '%s
+%s
+
+LocalWorkingDir=%s
+LocalGitDir=%s
+LocalGitStorageDir=%s
+LocalMediaDir=%s
+LocalReferenceDir=
+TempDir=%s
+ConcurrentTransfers=3
+TusTransfers=false
+BasicTransfersOnly=false
+BatchTransfer=true
+SkipDownloadErrors=true
+FetchRecentAlways=false
+FetchRecentRefsDays=7
+FetchRecentCommitsDays=0
+FetchRecentRefsIncludeRemotes=true
+PruneOffsetDays=3
+PruneVerifyRemoteAlways=false
+PruneRemoteName=origin
+AccessDownload=none
+AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")

--- a/test/test-env.sh
+++ b/test/test-env.sh
@@ -904,45 +904,5 @@ UploadTransfers=basic,tus,supertransfer
   actual=$(git lfs env)
   contains_same_elements "$expectedenabled" "$actual"
 
-  git config --unset lfs.skipdownloaderrors
-  # prove it's usually off
-  expecteddisabled=$(printf '%s
-%s
-
-LocalWorkingDir=%s
-LocalGitDir=%s
-LocalGitStorageDir=%s
-LocalMediaDir=%s
-LocalReferenceDir=
-TempDir=%s
-ConcurrentTransfers=3
-TusTransfers=false
-BasicTransfersOnly=false
-BatchTransfer=true
-SkipDownloadErrors=true
-FetchRecentAlways=false
-FetchRecentRefsDays=7
-FetchRecentCommitsDays=0
-FetchRecentRefsIncludeRemotes=true
-PruneOffsetDays=3
-PruneVerifyRemoteAlways=false
-PruneRemoteName=origin
-AccessDownload=none
-AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
-%s
-%s
-' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")
-  actual=$(git lfs env)
-  contains_same_elements "$expecteddisabled" "$actual"
-
-  # now enable via env var
-  actual=$(GIT_LFS_SKIP_DOWNLOAD_ERRORS=1 git lfs env)
-  contains_same_elements "$expectedenabled" "$actual"
-
-
-
-
 )
 end_test

--- a/test/test-env.sh
+++ b/test/test-env.sh
@@ -897,7 +897,7 @@ PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
 DownloadTransfers=basic,supertransfer
-UploadTransfers=basic,tus,supertransfer
+UploadTransfers=basic,supertransfer,tus
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$envVars" "$envInitConfig")

--- a/test/test-worktree.sh
+++ b/test/test-worktree.sh
@@ -40,6 +40,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 $(escape_path "$(env | grep "^GIT")")
 %s
 " "$(git lfs version)" "$(git version)" "$envInitConfig")
@@ -74,6 +76,8 @@ PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
 AccessDownload=none
 AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
 $(escape_path "$(env | grep "^GIT")")
 %s
 " "$(git lfs version)" "$(git version)" "$envInitConfig")


### PR DESCRIPTION
I found this useful when debugging transfers, above and beyond just showing the booleans or having to dig into the actual JSON that was sent. 

@technoweenie would be great if this could make it into 1.3 but no big deal if not.