### PR TITLE
Trim custom adapter output before tracing to avoid extra newline

### DIFF
--- a/transfer/custom.go
+++ b/transfer/custom.go
@@ -193,7 +193,7 @@ func (a *customAdapter) readResponse(ctx *customAdapterWorkerContext) (*customAd
 	if err != nil {
 		return nil, err
 	}
-	tracerx.Printf("xfer: Custom adapter worker %d received response: %v", ctx.workerNum, line)
+	tracerx.Printf("xfer: Custom adapter worker %d received response: %v", ctx.workerNum, strings.TrimSpace(line))
 	resp := &customAdapterResponseMessage{}
 	err = json.Unmarshal([]byte(line), resp)
 	return resp, err


### PR DESCRIPTION
Tiny tweak to tracing, makes custom adapters not add newlines everywhere when GIT_TRACE=1