### PR TITLE
properly report `git update-index` errors

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -167,6 +167,7 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 	// and which has unexpected side effects (e.g. downloading filtered-out files)
 	var cmd *exec.Cmd
 	var updateIdxStdin io.WriteCloser
+	var updateIdxOut bytes.Buffer
 
 	// From this point on, git update-index is running. Code in this loop MUST
 	// NOT Panic() or otherwise cause the process to exit. If the process exits
@@ -210,6 +211,8 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 		if cmd == nil {
 			// Fire up the update-index command
 			cmd = exec.Command("git", "update-index", "-q", "--refresh", "--stdin")
+			cmd.Stdout = &updateIdxOut
+			cmd.Stderr = &updateIdxOut
 			updateIdxStdin, err = cmd.StdinPipe()
 			if err != nil {
 				Panic(err, "Could not update the index")
@@ -228,8 +231,7 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 	if cmd != nil && updateIdxStdin != nil {
 		updateIdxStdin.Close()
 		if err := cmd.Wait(); err != nil {
-			outp, _ := cmd.CombinedOutput()
-			LoggedError(err, "Error updating the git index\n%v", string(outp))
+			LoggedError(err, "Error updating the git index:\n%s", updateIdxOut.String())
 		}
 	}
 }

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"os/exec"


### PR DESCRIPTION
I've been baffled by the various issues about `git update-index` failing with no reporting. Then it dawned on me that `CombinedOutput()` is the culprit. The [implementation](https://golang.org/src/os/exec/exec.go?s=11924:11970#L433) clearly shows that the stdout and stderr on the command aren't captured until `CombinedOutput()` is called. It's designed for situations where you want to run a simple command and capture it's output in a single line.