### PR TITLE
Fix sslCAInfo config lookup when host in config doesn't have a trailing slash

### DIFF
--- a/httputil/certs.go
+++ b/httputil/certs.go
@@ -51,10 +51,14 @@ func appendRootCAsForHostFromGitconfig(pool *x509.CertPool, host string) *x509.C
 	if cafile := config.Config.Getenv("GIT_SSL_CAINFO"); len(cafile) > 0 {
 		return appendCertsFromFile(pool, cafile)
 	}
-	// http.<url>.sslcainfo
+	// http.<url>/.sslcainfo or http.<url>.sslcainfo
 	// we know we have simply "host" or "host:port"
-	key := fmt.Sprintf("http.https://%v/.sslcainfo", host)
-	if cafile, ok := config.Config.GitConfig(key); ok {
+	hostKeyWithSlash := fmt.Sprintf("http.https://%v/.sslcainfo", host)
+	if cafile, ok := config.Config.GitConfig(hostKeyWithSlash); ok {
+		return appendCertsFromFile(pool, cafile)
+	}
+	hostKeyWithoutSlash := fmt.Sprintf("http.https://%v.sslcainfo", host)
+	if cafile, ok := config.Config.GitConfig(hostKeyWithoutSlash); ok {
 		return appendCertsFromFile(pool, cafile)
 	}
 	// http.sslcainfo


### PR DESCRIPTION
Corresponding issue: #1403

appendRootCAsForHostFromGitconfig() modified to check hosts with and without a trailing slash.

Cert unit tests made "table driven" and extended to cover this case.