### PR TITLE
lfs/hook: teach `lfs.Hook` about `core.hooksPath`

### DIFF
--- a/docs/man/git-lfs-install.1.ronn
+++ b/docs/man/git-lfs-install.1.ronn
@@ -12,7 +12,9 @@ Perform the following actions to ensure that Git LFS is setup properly:
 * Set up the clean and smudge filters under the name "lfs" in the global Git
   config.
 * Install a pre-push hook to run git-lfs-pre-push(1) for the current repository,
-  if run from inside one.
+  if run from inside one. If "core.hooksPath" is configured in any Git
+  configuration (and supported, i.e., the installed Git version is at least
+  2.9.0), then the pre-push hook will be installed to that directory instead.
 
 ## OPTIONS
 

--- a/test/test-install-custom-hooks-path-unsupported.sh
+++ b/test/test-install-custom-hooks-path-unsupported.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+# These tests rely on behavior found in Git versions less than 2.9.0 to preform
+# themselves, specifically:
+#   - lack of core.hooksPath support
+ensure_git_version_isnt $VERSION_HIGHER "2.9.0"
+
+begin_test "install with unsupported core.hooksPath"
+(
+  set -e
+
+  repo_name="unsupported-custom-hooks-path"
+  git init "$repo_name"
+  cd "$repo_name"
+
+  hooks_dir="custom_hooks_dir"
+  mkdir -p "$hooks_dir"
+
+  git config --local core.hooksPath "$hooks_dir"
+
+  git lfs install 2>&1 | tee install.log
+  grep "Updated pre-push hook" install.log
+
+  [ ! -e "$hooks_dir/pre-push" ]
+  [ -e ".git/hooks/pre-push" ]
+)
+end_test

--- a/test/test-install-custom-hooks-path-unsupported.sh
+++ b/test/test-install-custom-hooks-path-unsupported.sh
@@ -2,7 +2,7 @@
 
 . "test/testlib.sh"
 
-# These tests rely on behavior found in Git versions less than 2.9.0 to preform
+# These tests rely on behavior found in Git versions less than 2.9.0 to perform
 # themselves, specifically:
 #   - lack of core.hooksPath support
 ensure_git_version_isnt $VERSION_HIGHER "2.9.0"

--- a/test/test-install-custom-hooks-path.sh
+++ b/test/test-install-custom-hooks-path.sh
@@ -24,5 +24,6 @@ begin_test "install with supported core.hooksPath"
   grep "Updated pre-push hook" install.log
 
   [ -e "$hooks_dir/pre-push" ]
+  [ ! -e ".git/pre-push" ]
 )
 end_test

--- a/test/test-install-custom-hooks-path.sh
+++ b/test/test-install-custom-hooks-path.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+# These tests rely on behavior found in 2.9.0 to preform themselves,
+# specifically:
+#   - core.hooksPath support
+ensure_git_version_isnt $VERSION_LOWER "2.9.0"
+
+begin_test "install with supported core.hooksPath"
+(
+  set -e
+
+  repo_name="supported-custom-hooks-path"
+  git init "$repo_name"
+  cd "$repo_name"
+
+  hooks_dir="custom_hooks_dir"
+  mkdir -p "$hooks_dir"
+
+  git config --local core.hooksPath "$hooks_dir"
+
+  git lfs install 2>&1 | tee install.log
+  grep "Updated pre-push hook" install.log
+
+  [ -e "$hooks_dir/pre-push" ]
+)
+end_test

--- a/test/test-install-custom-hooks-path.sh
+++ b/test/test-install-custom-hooks-path.sh
@@ -2,7 +2,7 @@
 
 . "test/testlib.sh"
 
-# These tests rely on behavior found in 2.9.0 to preform themselves,
+# These tests rely on behavior found in 2.9.0 to perform themselves,
 # specifically:
 #   - core.hooksPath support
 ensure_git_version_isnt $VERSION_LOWER "2.9.0"


### PR DESCRIPTION
This commit gives the `lfs.Hook` knowledge of the new `core.hooksPath`
configuration value that was introduce in Git 2.9.0.

When `core.HooksPath` is found in the Git configuration AND is supported (i.e.,
installed Git binary has a version greater than or equal to "2.9.0"), `git-lfs
install` will place new hooks in that directory. If the `core.hooksPath` is
specified, but the installed verison of Git does NOT support it, then it will
be ignored and installed in `.git/hooks` as per usual.

To test this behavior, two new shell tests were added:
  - One that runs on Git >= 2.9.0, and tests that `core.hooksPath` is respected
  - One that runs on Git < 2.9.0, and tests that `core.hooksPath` is ignored

Unfortunately, our current testing framework does not support skipping
individual tests, only skipping entire files, so two new shell test files were
added.

Resolves github/git-lfs#1407.

--------------

/cc @technoweenie 