### PR TITLE
distinguish between empty include/exclude paths

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -74,7 +74,8 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 		cfg.CurrentRemote = "origin"
 	}
 
-	include, exclude := determineIncludeExcludePaths(cfg, cloneIncludeArg, cloneExcludeArg)
+	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
+	include, exclude := determineIncludeExcludePaths(cfg, includeArg, excludeArg)
 	if cloneFlags.NoCheckout || cloneFlags.Bare {
 		// If --no-checkout or --bare then we shouldn't check out, just fetch instead
 		fetchRef("HEAD", include, exclude)

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -74,7 +74,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 		cfg.CurrentRemote = "origin"
 	}
 
-	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
+	includeArg, excludeArg := getIncludeExcludeArgs(cmd, &cloneIncludeArg, &cloneExcludeArg)
 	include, exclude := determineIncludeExcludePaths(cfg, includeArg, excludeArg)
 	if cloneFlags.NoCheckout || cloneFlags.Bare {
 		// If --no-checkout or --bare then we shouldn't check out, just fetch instead

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -20,9 +20,7 @@ var (
 		Run: cloneCommand,
 	}
 
-	cloneFlags      git.CloneFlags
-	cloneIncludeArg string
-	cloneExcludeArg string
+	cloneFlags git.CloneFlags
 )
 
 func cloneCommand(cmd *cobra.Command, args []string) {
@@ -74,7 +72,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 		cfg.CurrentRemote = "origin"
 	}
 
-	includeArg, excludeArg := getIncludeExcludeArgs(cmd, &cloneIncludeArg, &cloneExcludeArg)
+	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
 	include, exclude := determineIncludeExcludePaths(cfg, includeArg, excludeArg)
 	if cloneFlags.NoCheckout || cloneFlags.Bare {
 		// If --no-checkout or --bare then we shouldn't check out, just fetch instead
@@ -140,8 +138,8 @@ func init() {
 	cloneCmd.Flags().BoolVarP(&cloneFlags.Ipv4, "ipv4", "", false, "See 'git clone --help'")
 	cloneCmd.Flags().BoolVarP(&cloneFlags.Ipv6, "ipv6", "", false, "See 'git clone --help'")
 
-	cloneCmd.Flags().StringVarP(&cloneIncludeArg, "include", "I", "", "Include a list of paths")
-	cloneCmd.Flags().StringVarP(&cloneExcludeArg, "exclude", "X", "", "Exclude a list of paths")
+	cloneCmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
+	cloneCmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
 
 	RootCmd.AddCommand(cloneCmd)
 }

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -16,21 +16,19 @@ var (
 		Use: "fetch",
 		Run: fetchCommand,
 	}
-	fetchIncludeArg string
-	fetchExcludeArg string
-	fetchRecentArg  bool
-	fetchAllArg     bool
-	fetchPruneArg   bool
+	fetchRecentArg bool
+	fetchAllArg    bool
+	fetchPruneArg  bool
 )
 
-func getIncludeExcludeArgs(cmd *cobra.Command, includeFlagArg, excludeFlagArg *string) (includeArg, excludeArg *string) {
+func getIncludeExcludeArgs(cmd *cobra.Command) (include, exclude *string) {
 	includeFlag := cmd.Flag("include")
 	excludeFlag := cmd.Flag("exclude")
 	if includeFlag.Changed {
-		includeArg = includeFlagArg
+		include = &includeArg
 	}
 	if excludeFlag.Changed {
-		excludeArg = excludeFlagArg
+		exclude = &excludeArg
 	}
 
 	return
@@ -71,11 +69,13 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 	}
 
 	success := true
+	include, exclude := getIncludeExcludeArgs(cmd)
+
 	if fetchAllArg {
 		if fetchRecentArg || len(args) > 1 {
 			Exit("Cannot combine --all with ref arguments or --recent")
 		}
-		if fetchIncludeArg != "" || fetchExcludeArg != "" {
+		if include != nil || exclude != nil {
 			Exit("Cannot combine --all with --include or --exclude")
 		}
 		if len(cfg.FetchIncludePaths()) > 0 || len(cfg.FetchExcludePaths()) > 0 {
@@ -84,8 +84,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		success = fetchAll()
 
 	} else { // !all
-		includeArg, excludeArg := getIncludeExcludeArgs(cmd, &fetchIncludeArg, &fetchExcludeArg)
-		includePaths, excludePaths := determineIncludeExcludePaths(cfg, includeArg, excludeArg)
+		includePaths, excludePaths := determineIncludeExcludePaths(cfg, include, exclude)
 
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored
 		for _, ref := range refs {
@@ -112,8 +111,8 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	fetchCmd.Flags().StringVarP(&fetchIncludeArg, "include", "I", "", "Include a list of paths")
-	fetchCmd.Flags().StringVarP(&fetchExcludeArg, "exclude", "X", "", "Exclude a list of paths")
+	fetchCmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
+	fetchCmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
 	fetchCmd.Flags().BoolVarP(&fetchRecentArg, "recent", "r", false, "Fetch recent refs & commits")
 	fetchCmd.Flags().BoolVarP(&fetchAllArg, "all", "a", false, "Fetch all LFS files ever referenced")
 	fetchCmd.Flags().BoolVarP(&fetchPruneArg, "prune", "p", false, "After fetching, prune old data")

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -23,6 +23,19 @@ var (
 	fetchPruneArg   bool
 )
 
+func getIncludeExcludeArgs(cmd *cobra.Command) (includeArg, excludeArg *string) {
+	includeFlag := cmd.Flag("include")
+	excludeFlag := cmd.Flag("exclude")
+	if includeFlag.Changed {
+		includeArg = &fetchIncludeArg
+	}
+	if excludeFlag.Changed {
+		excludeArg = &fetchExcludeArg
+	}
+
+	return
+}
+
 func fetchCommand(cmd *cobra.Command, args []string) {
 	requireInRepo()
 
@@ -71,7 +84,8 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		success = fetchAll()
 
 	} else { // !all
-		includePaths, excludePaths := determineIncludeExcludePaths(cfg, fetchIncludeArg, fetchExcludeArg)
+		includeArg, excludeArg := getIncludeExcludeArgs(cmd)
+		includePaths, excludePaths := determineIncludeExcludePaths(cfg, includeArg, excludeArg)
 
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored
 		for _, ref := range refs {

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -23,14 +23,14 @@ var (
 	fetchPruneArg   bool
 )
 
-func getIncludeExcludeArgs(cmd *cobra.Command) (includeArg, excludeArg *string) {
+func getIncludeExcludeArgs(cmd *cobra.Command, includeFlagArg, excludeFlagArg *string) (includeArg, excludeArg *string) {
 	includeFlag := cmd.Flag("include")
 	excludeFlag := cmd.Flag("exclude")
 	if includeFlag.Changed {
-		includeArg = &fetchIncludeArg
+		includeArg = includeFlagArg
 	}
 	if excludeFlag.Changed {
-		excludeArg = &fetchExcludeArg
+		excludeArg = excludeFlagArg
 	}
 
 	return
@@ -84,7 +84,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		success = fetchAll()
 
 	} else { // !all
-		includeArg, excludeArg := getIncludeExcludeArgs(cmd)
+		includeArg, excludeArg := getIncludeExcludeArgs(cmd, &fetchIncludeArg, &fetchExcludeArg)
 		includePaths, excludePaths := determineIncludeExcludePaths(cfg, includeArg, excludeArg)
 
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -12,8 +12,6 @@ var (
 		Use: "pull",
 		Run: pullCommand,
 	}
-	pullIncludeArg string
-	pullExcludeArg string
 )
 
 func pullCommand(cmd *cobra.Command, args []string) {
@@ -34,7 +32,7 @@ func pullCommand(cmd *cobra.Command, args []string) {
 		cfg.CurrentRemote = defaultRemote
 	}
 
-	includeArg, excludeArg := getIncludeExcludeArgs(cmd, &pullIncludeArg, &pullExcludeArg)
+	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
 	pull(determineIncludeExcludePaths(cfg, includeArg, excludeArg))
 
 }
@@ -52,7 +50,7 @@ func pull(includePaths, excludePaths []string) {
 }
 
 func init() {
-	pullCmd.Flags().StringVarP(&pullIncludeArg, "include", "I", "", "Include a list of paths")
-	pullCmd.Flags().StringVarP(&pullExcludeArg, "exclude", "X", "", "Exclude a list of paths")
+	pullCmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
+	pullCmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
 	RootCmd.AddCommand(pullCmd)
 }

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -34,7 +34,7 @@ func pullCommand(cmd *cobra.Command, args []string) {
 		cfg.CurrentRemote = defaultRemote
 	}
 
-	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
+	includeArg, excludeArg := getIncludeExcludeArgs(cmd, &pullIncludeArg, &pullExcludeArg)
 	pull(determineIncludeExcludePaths(cfg, includeArg, excludeArg))
 
 }

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -34,7 +34,8 @@ func pullCommand(cmd *cobra.Command, args []string) {
 		cfg.CurrentRemote = defaultRemote
 	}
 
-	pull(determineIncludeExcludePaths(cfg, pullIncludeArg, pullExcludeArg))
+	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
+	pull(determineIncludeExcludePaths(cfg, includeArg, excludeArg))
 
 }
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -42,6 +42,9 @@ var (
 	}
 	ManPages = make(map[string]string, 20)
 	cfg      = config.Config
+
+	includeArg string
+	excludeArg string
 )
 
 // Error prints a formatted message to Stderr.  It also gets printed to the

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -233,9 +233,18 @@ type ErrorWithStack interface {
 	Stack() []byte
 }
 
-func determineIncludeExcludePaths(config *config.Configuration, includeArg, excludeArg string) (include, exclude []string) {
-	return tools.CleanPathsDefault(includeArg, ",", config.FetchIncludePaths()),
-		tools.CleanPathsDefault(excludeArg, ",", config.FetchExcludePaths())
+func determineIncludeExcludePaths(config *config.Configuration, includeArg, excludeArg *string) (include, exclude []string) {
+	if includeArg == nil {
+		include = config.FetchIncludePaths()
+	} else {
+		include = tools.CleanPaths(*includeArg, ",")
+	}
+	if excludeArg == nil {
+		exclude = config.FetchExcludePaths()
+	} else {
+		exclude = tools.CleanPaths(*excludeArg, ",")
+	}
+	return
 }
 
 func printHelp(commandName string) {

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -15,14 +15,25 @@ var (
 )
 
 func TestDetermineIncludeExcludePathsReturnsCleanedPaths(t *testing.T) {
-	i, e := determineIncludeExcludePaths(testcfg, "/some/include", "/some/exclude")
+	inc := "/some/include"
+	exc := "/some/exclude"
+	i, e := determineIncludeExcludePaths(testcfg, &inc, &exc)
 
 	assert.Equal(t, []string{"/some/include"}, i)
 	assert.Equal(t, []string{"/some/exclude"}, e)
 }
 
+func TestDetermineIncludeExcludePathsReturnsEmptyPaths(t *testing.T) {
+	inc := ""
+	exc := ""
+	i, e := determineIncludeExcludePaths(testcfg, &inc, &exc)
+
+	assert.Empty(t, i)
+	assert.Empty(t, e)
+}
+
 func TestDetermineIncludeExcludePathsReturnsDefaultsWhenAbsent(t *testing.T) {
-	i, e := determineIncludeExcludePaths(testcfg, "", "")
+	i, e := determineIncludeExcludePaths(testcfg, nil, nil)
 
 	assert.Equal(t, []string{"/default/include"}, i)
 	assert.Equal(t, []string{"/default/exclude"}, e)

--- a/test/test-fetch-paths.sh
+++ b/test/test-fetch-paths.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+reponame="$(basename "$0" ".sh")"
+contents="a"
+contents_oid=$(calc_oid "$contents")
+
+begin_test "init fetch unclean paths"
+(
+  set -e
+
+  setup_remote_repo $reponame
+  clone_repo $reponame repo
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \*.dat" track.log
+
+  mkdir dir
+  printf "$contents" > dir/a.dat
+
+  git add dir/a.dat
+  git add .gitattributes
+  git commit -m "add dir/a.dat" 2>&1 | tee commit.log
+  grep "master (root-commit)" commit.log
+  grep "2 files changed" commit.log
+  grep "create mode 100644 dir/a.dat" commit.log
+  grep "create mode 100644 .gitattributes" commit.log
+
+  [ "a" = "$(cat dir/a.dat)" ]
+
+  assert_local_object "$contents_oid" 1
+  refute_server_object "$contents_oid"
+
+  git push origin master 2>&1 | tee push.log
+  grep "(1 of 1 files)" push.log
+  grep "master -> master" push.log
+
+  assert_server_object "$reponame" "$contents_oid"
+
+  # This clone is used for subsequent tests
+  clone_repo "$reponame" clone
+)
+end_test
+
+begin_test "fetch unclean paths with include filter in gitconfig"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+
+  git config "lfs.fetchinclude" "dir/"
+  git lfs fetch
+  assert_local_object "$contents_oid" 1
+)
+end_test
+
+begin_test "fetch unclean paths with exclude filter in gitconfig"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+  git config --unset "lfs.fetchinclude"
+
+  git config "lfs.fetchexclude" "dir/"
+  git lfs fetch
+  refute_local_object "$contents_oid"
+)
+end_test
+
+begin_test "fetch unclean paths with include filter in cli"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+
+  git config --unset "lfs.fetchexclude"
+
+  rm -rf .git/lfs/objects
+  git lfs fetch -I="dir/"
+  assert_local_object "$contents_oid" 1
+)
+end_test
+
+begin_test "fetch unclean paths with exclude filter in cli"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+
+  git lfs fetch -X="dir/"
+  refute_local_object "$contents_oid"
+)
+end_test

--- a/test/test-fetch-recent.sh
+++ b/test/test-fetch-recent.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+reponame="fetch-recent"
+
+# generate content we'll use
+content0="filecontent0"
+content1="filecontent1"
+content2="filecontent2"
+content3="filecontent3"
+content4="filecontent4"
+content5="filecontent5"
+oid0=$(calc_oid "$content0")
+oid1=$(calc_oid "$content1")
+oid2=$(calc_oid "$content2")
+oid3=$(calc_oid "$content3")
+oid4=$(calc_oid "$content4")
+oid5=$(calc_oid "$content5")
+
+begin_test "init fetch-recent"
+(
+  set -e
+
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \*.dat" track.log
+
+  echo "[
+  {
+    \"CommitDate\":\"$(get_date -18d)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":${#content0}, \"Data\":\"$content0\"},
+      {\"Filename\":\"file3.dat\",\"Size\":${#content5}, \"Data\":\"$content5\"}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -14d)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":${#content1}, \"Data\":\"$content1\"}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -5d)\",
+    \"NewBranch\":\"other_branch\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":${#content4}, \"Data\":\"$content4\"}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -1d)\",
+    \"ParentBranches\":[\"master\"],
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":${#content2}, \"Data\":\"$content2\"},
+      {\"Filename\":\"file2.dat\",\"Size\":${#content3}, \"Data\":\"$content3\"}]
+  }
+  ]" | lfstest-testutils addcommits
+
+  git push origin master
+  git push origin other_branch
+  assert_server_object "$reponame" "$oid0"
+  assert_server_object "$reponame" "$oid1"
+  assert_server_object "$reponame" "$oid2"
+  assert_server_object "$reponame" "$oid3"
+  assert_server_object "$reponame" "$oid4"
+
+  # This clone is used for subsequent tests
+  clone_repo "$reponame" clone
+  git checkout other_branch
+  git checkout master
+)
+end_test
+
+begin_test "fetch-recent normal"
+(
+  set -e
+
+  cd clone
+  rm -rf .git/lfs/objects
+
+  git config lfs.fetchrecentalways false
+  git config lfs.fetchrecentrefsdays 0
+  git config lfs.fetchrecentremoterefs false
+  git config lfs.fetchrecentcommitsdays 7
+
+  # fetch normally, should just get the last state for file1/2
+  git lfs fetch origin master
+  assert_local_object "$oid2" "${#content2}"
+  assert_local_object "$oid3" "${#content3}"
+  assert_local_object "$oid5" "${#content5}"
+  refute_local_object "$oid0"
+  refute_local_object "$oid1"
+  refute_local_object "$oid4"
+)
+end_test
+
+begin_test "fetch-recent commits"
+(
+  set -e
+
+  cd clone
+  rm -rf .git/lfs/objects
+
+  # now fetch recent - just commits for now
+  git config lfs.fetchrecentrefsdays 0
+  git config lfs.fetchrecentremoterefs false
+  git config lfs.fetchrecentcommitsdays 7
+
+  git lfs fetch --recent origin
+  # that should have fetched master plus previous state needed within 7 days
+  # current state
+  assert_local_object "$oid2" "${#content2}"
+  assert_local_object "$oid3" "${#content3}"
+  # previous state is the 'before' state of any commits made in last 7 days
+  # ie you can check out anything in last 7 days (may have non-LFS commits in between)
+  assert_local_object "$oid1" "${#content1}"
+  refute_local_object "$oid0"
+  refute_local_object "$oid4"
+)
+end_test
+
+begin_test "fetch-recent days"
+(
+  set -e
+
+  cd clone
+  rm -rf .git/lfs/objects
+
+  # now fetch other_branch as well
+  git config lfs.fetchrecentrefsdays 6
+  git config lfs.fetchrecentremoterefs false
+  git config lfs.fetchrecentcommitsdays 7
+
+  git lfs fetch --recent origin
+  # that should have fetched master plus previous state needed within 7 days
+  # current state PLUS refs within 6 days (& their commits within 7)
+  assert_local_object "$oid2" "${#content2}"
+  assert_local_object "$oid3" "${#content3}"
+  assert_local_object "$oid1" "${#content1}"
+  assert_local_object "$oid4" "${#content4}"
+  # still omits oid0 since that's at best 13 days prior to other_branch tip
+  refute_local_object "$oid0"
+)
+end_test
+
+begin_test "fetch-recent older commits"
+(
+  set -e
+
+  cd clone
+  # now test that a 14 day limit picks oid0 up from other_branch
+  # because other_branch was itself 5 days ago, 5+14=19 day search limit
+  git config lfs.fetchrecentcommitsdays 14
+
+  rm -rf .git/lfs/objects
+  git lfs fetch --recent origin
+  assert_local_object "$oid0" "${#content0}"
+)
+end_test
+
+begin_test "fetch-recent remote branch"
+(
+  set -e
+
+  cd "$reponame"
+  # push branch & test remote branch recent
+  git push origin other_branch
+
+  cd ../clone
+  git branch -D other_branch
+  rm -rf .git/lfs/objects
+  git config lfs.fetchrecentcommitsdays 0
+  git config lfs.fetchrecentremoterefs false
+  git config lfs.fetchrecentrefsdays 6
+
+  git lfs fetch --recent origin
+  # should miss #4 until we include remote branches (#1 will always be missing commitdays=0)
+  assert_local_object "$oid2" "${#content2}"
+  assert_local_object "$oid3" "${#content3}"
+  refute_local_object "$oid1"
+  refute_local_object "$oid0"
+  refute_local_object "$oid4"
+)
+end_test
+
+begin_test "fetch-recent remote refs"
+(
+  set -e
+
+  cd clone
+  rm -rf .git/lfs/objects
+
+  # pick up just snapshot at remote ref, ie #4
+  git config lfs.fetchrecentremoterefs true
+  git lfs fetch --recent origin
+  assert_local_object "$oid4" "${#content4}"
+  refute_local_object "$oid0"
+  refute_local_object "$oid1"
+)
+end_test

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -145,6 +145,14 @@ begin_test "fetch"
   refute_local_object "$contents_oid"
   refute_local_object "$b_oid"
 
+  echo Test include filter overriding exclude filter
+  rm -rf .git/lfs/objects
+  git config lfs.fetchexclude "b*"
+  refute_local_object "$b_oid"
+  git lfs fetch -I "b.dat" -X "" origin master newbranch
+  assert_local_object "$b_oid" "1"
+  git config --unset lfs.fetchexclude
+
   # test fail case error code
   rm -rf .git/lfs/objects
   delete_server_object "$reponame" "$b_oid"

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -2,22 +2,23 @@
 
 . "test/testlib.sh"
 
-begin_test "fetch"
+contents="a"
+contents_oid=$(calc_oid "$contents")
+b="b"
+b_oid=$(calc_oid "$b")
+reponame="$(basename "$0" ".sh")"
+
+begin_test "init for fetch tests"
 (
   set -e
 
-  reponame="$(basename "$0" ".sh")"
   setup_remote_repo "$reponame"
-
-  clone_repo "$reponame" clone
 
   clone_repo "$reponame" repo
 
   git lfs track "*.dat" 2>&1 | tee track.log
   grep "Tracking \*.dat" track.log
 
-  contents="a"
-  contents_oid=$(calc_oid "$contents")
 
   printf "$contents" > a.dat
   git add a.dat
@@ -42,8 +43,6 @@ begin_test "fetch"
 
   # Add a file in a different branch
   git checkout -b newbranch
-  b="b"
-  b_oid=$(calc_oid "$b")
   printf "$b" > b.dat
   git add b.dat
   git commit -m "add b.dat"
@@ -52,63 +51,111 @@ begin_test "fetch"
   git push origin newbranch
   assert_server_object "$reponame" "$b_oid"
 
-  # change to the clone's working directory
-  cd ../clone
+  # This clone is used for subsequent tests
+  clone_repo "$reponame" clone
+)
+end_test
 
-  git pull 2>&1 | grep "Downloading a.dat (1 B)"
-
-  [ "a" = "$(cat a.dat)" ]
-
-  assert_local_object "$contents_oid" 1
-
-
-  # Remove the working directory and lfs files
+begin_test "fetch"
+(
+  set -e
+  cd clone
   rm -rf .git/lfs/objects
+
   git lfs fetch 2>&1 | grep "(1 of 1 files)"
   assert_local_object "$contents_oid" 1
+)
+end_test
 
-  # test with just remote specified
+begin_test "fetch with remote"
+(
+  set -e
+  cd clone
   rm -rf .git/lfs/objects
+
   git lfs fetch origin 2>&1 | grep "(1 of 1 files)"
   assert_local_object "$contents_oid" 1
+  refute_local_object "$b_oid" 1
+)
+end_test
+
+begin_test "fetch with remote and branches"
+(
+  set -e
+  cd clone
 
   git checkout newbranch
   git checkout master
+
   rm -rf .git/lfs/objects
 
   git lfs fetch origin master newbranch
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
+)
+end_test
 
-  # test with master commit sha1 specified
+begin_test "fetch with master commit sha1"
+(
+  set -e
+  cd clone
   rm -rf .git/lfs/objects
+
   master_sha1=$(git rev-parse master)
   git lfs fetch origin "$master_sha1"
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid" 1
+)
+end_test
 
-  # test with newbranch commit sha1 specified
+begin_test "fetch with newbranch commit sha1"
+(
+  set -e
+  cd clone
   rm -rf .git/lfs/objects
+
   newbranch_sha1=$(git rev-parse newbranch)
   git lfs fetch origin "$newbranch_sha1"
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
+)
+end_test
 
-  # Test include / exclude filters supplied in gitconfig
+begin_test "fetch with include filters in gitconfig"
+(
+  set -e
+  cd clone
   rm -rf .git/lfs/objects
+
   git config "lfs.fetchinclude" "a*"
   git lfs fetch origin master newbranch
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid"
+)
+end_test
 
-  rm -rf .git/lfs/objects
+begin_test "fetch with exclude filters in gitconfig"
+(
+  set -e
+
+  cd clone
   git config --unset "lfs.fetchinclude"
+  rm -rf .git/lfs/objects
+
   git config "lfs.fetchexclude" "a*"
   git lfs fetch origin master newbranch
   refute_local_object "$contents_oid"
   assert_local_object "$b_oid" 1
+)
+end_test
 
+begin_test "fetch with include/exclude filters in gitconfig"
+(
+  set -e
+  cd clone
   rm -rf .git/lfs/objects
+  git config --unset "lfs.fetchexclude"
+
   git config "lfs.fetchinclude" "a*,b*"
   git config "lfs.fetchexclude" "c*,d*"
   git lfs fetch origin master newbranch
@@ -121,20 +168,38 @@ begin_test "fetch"
   git lfs fetch origin master newbranch
   refute_local_object "$contents_oid"
   refute_local_object "$b_oid"
+)
+end_test
 
-  # Test include / exclude filters supplied on the command line
+begin_test "fetch with include filter in cli"
+(
+  set -e
+  cd clone
   git config --unset "lfs.fetchinclude"
   git config --unset "lfs.fetchexclude"
   rm -rf .git/lfs/objects
+
   git lfs fetch --include="a*" origin master newbranch
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid"
+)
+end_test
 
+begin_test "fetch with exclude filter in cli"
+(
+  set -e
+  cd clone
   rm -rf .git/lfs/objects
   git lfs fetch --exclude="a*" origin master newbranch
   refute_local_object "$contents_oid"
   assert_local_object "$b_oid" 1
+)
+end_test
 
+begin_test "fetch with include/exclude filters in cli"
+(
+  set -e
+  cd clone
   rm -rf .git/lfs/objects
   git lfs fetch -I "a*,b*" -X "c*,d*" origin master newbranch
   assert_local_object "$contents_oid" 1
@@ -144,19 +209,30 @@ begin_test "fetch"
   git lfs fetch --include="c*,d*" --exclude="a*,b*" origin master newbranch
   refute_local_object "$contents_oid"
   refute_local_object "$b_oid"
+)
+end_test
 
-  echo Test include filter overriding exclude filter
+begin_test "fetch with include filter overriding exclude filter"
+(
+  set -e
+  cd clone
   rm -rf .git/lfs/objects
   git config lfs.fetchexclude "b*"
-  refute_local_object "$b_oid"
   git lfs fetch -I "b.dat" -X "" origin master newbranch
   assert_local_object "$b_oid" "1"
-  git config --unset lfs.fetchexclude
+)
+end_test
 
-  # test fail case error code
+begin_test "fetch with missing object"
+(
+  set -e
+  cd clone
+  git config --unset lfs.fetchexclude
   rm -rf .git/lfs/objects
+
   delete_server_object "$reponame" "$b_oid"
   refute_server_object "$reponame" "$b_oid"
+
   # should return non-zero, but should also download all the other valid files too
   set +e
   git lfs fetch origin master newbranch
@@ -165,150 +241,6 @@ begin_test "fetch"
   [ "$fetch_exit" != "0" ]
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid"
-
-)
-end_test
-
-begin_test "fetch-recent"
-(
-  set -e
-
-  reponame="fetch-recent"
-  setup_remote_repo "$reponame"
-
-  clone_repo "$reponame" "$reponame"
-
-  git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
-
-  # generate content we'll use
-  content0="filecontent0"
-  content1="filecontent1"
-  content2="filecontent2"
-  content3="filecontent3"
-  content4="filecontent4"
-  content5="filecontent5"
-  oid0=$(calc_oid "$content0")
-  oid1=$(calc_oid "$content1")
-  oid2=$(calc_oid "$content2")
-  oid3=$(calc_oid "$content3")
-  oid4=$(calc_oid "$content4")
-  oid5=$(calc_oid "$content5")
-
-  echo "[
-  {
-    \"CommitDate\":\"$(get_date -18d)\",
-    \"Files\":[
-      {\"Filename\":\"file1.dat\",\"Size\":${#content0}, \"Data\":\"$content0\"},
-      {\"Filename\":\"file3.dat\",\"Size\":${#content5}, \"Data\":\"$content5\"}]
-  },
-  {
-    \"CommitDate\":\"$(get_date -14d)\",
-    \"Files\":[
-      {\"Filename\":\"file1.dat\",\"Size\":${#content1}, \"Data\":\"$content1\"}]
-  },
-  {
-    \"CommitDate\":\"$(get_date -5d)\",
-    \"NewBranch\":\"other_branch\",
-    \"Files\":[
-      {\"Filename\":\"file1.dat\",\"Size\":${#content4}, \"Data\":\"$content4\"}]
-  },
-  {
-    \"CommitDate\":\"$(get_date -1d)\",
-    \"ParentBranches\":[\"master\"],
-    \"Files\":[
-      {\"Filename\":\"file1.dat\",\"Size\":${#content2}, \"Data\":\"$content2\"},
-      {\"Filename\":\"file2.dat\",\"Size\":${#content3}, \"Data\":\"$content3\"}]
-  }
-  ]" | lfstest-testutils addcommits
-
-  git push origin master
-  git push origin other_branch
-  assert_server_object "$reponame" "$oid0"
-  assert_server_object "$reponame" "$oid1"
-  assert_server_object "$reponame" "$oid2"
-  assert_server_object "$reponame" "$oid3"
-  assert_server_object "$reponame" "$oid4"
-
-  rm -rf .git/lfs/objects
-
-  git config lfs.fetchrecentalways false
-  git config lfs.fetchrecentrefsdays 0
-  git config lfs.fetchrecentremoterefs false
-  git config lfs.fetchrecentcommitsdays 7
-
-  # fetch normally, should just get the last state for file1/2
-  git lfs fetch origin master
-  assert_local_object "$oid2" "${#content2}"
-  assert_local_object "$oid3" "${#content3}"
-  assert_local_object "$oid5" "${#content5}"
-  refute_local_object "$oid0"
-  refute_local_object "$oid1"
-  refute_local_object "$oid4"
-
-  rm -rf .git/lfs/objects
-
-  # now fetch recent - just commits for now
-  git config lfs.fetchrecentrefsdays 0
-  git config lfs.fetchrecentremoterefs false
-  git config lfs.fetchrecentcommitsdays 7
-
-  git lfs fetch --recent origin
-  # that should have fetched master plus previous state needed within 7 days
-  # current state
-  assert_local_object "$oid2" "${#content2}"
-  assert_local_object "$oid3" "${#content3}"
-  # previous state is the 'before' state of any commits made in last 7 days
-  # ie you can check out anything in last 7 days (may have non-LFS commits in between)
-  assert_local_object "$oid1" "${#content1}"
-  refute_local_object "$oid0"
-  refute_local_object "$oid4"
-
-  rm -rf .git/lfs/objects
-  # now fetch other_branch as well
-  git config lfs.fetchrecentrefsdays 6
-  git config lfs.fetchrecentremoterefs false
-  git config lfs.fetchrecentcommitsdays 7
-
-  git lfs fetch --recent origin
-  # that should have fetched master plus previous state needed within 7 days
-  # current state PLUS refs within 6 days (& their commits within 7)
-  assert_local_object "$oid2" "${#content2}"
-  assert_local_object "$oid3" "${#content3}"
-  assert_local_object "$oid1" "${#content1}"
-  assert_local_object "$oid4" "${#content4}"
-  # still omits oid0 since that's at best 13 days prior to other_branch tip
-  refute_local_object "$oid0"
-
-  # now test that a 14 day limit picks oid0 up from other_branch
-  # because other_branch was itself 5 days ago, 5+14=19 day search limit
-  git config lfs.fetchrecentcommitsdays 14
-
-  git lfs fetch --recent origin
-  assert_local_object "$oid0" "${#content0}"
-
-  # push branch & test remote branch recent
-  git push origin other_branch
-  git branch -D other_branch
-
-  rm -rf .git/lfs/objects
-  git config lfs.fetchrecentcommitsdays 0
-  git config lfs.fetchrecentremoterefs false
-  git config lfs.fetchrecentrefsdays 6
-  git lfs fetch --recent origin
-  # should miss #4 until we include remote branches (#1 will always be missing commitdays=0)
-  assert_local_object "$oid2" "${#content2}"
-  assert_local_object "$oid3" "${#content3}"
-  refute_local_object "$oid1"
-  refute_local_object "$oid0"
-  refute_local_object "$oid4"
-  # pick up just snapshot at remote ref, ie #4
-  git config lfs.fetchrecentremoterefs true
-  git lfs fetch --recent origin
-  assert_local_object "$oid4" "${#content4}"
-  refute_local_object "$oid0"
-  refute_local_object "$oid1"
-
 )
 end_test
 
@@ -432,68 +364,6 @@ begin_test "fetch-all"
   for ((a=0; a < NUMFILES ; a++)); do
     assert_local_object "${oid[$a]}" "${#content[$a]}"
   done
-)
-end_test
-
-begin_test "fetch include/exclude with unclean paths"
-(
-  set -e
-
-  reponame="fetch-unclean-paths"
-  setup_remote_repo $reponame
-  clone_repo $reponame include_exclude_repo
-
-  git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
-
-  contents="a"
-  contents_oid=$(calc_oid "$contents")
-
-  mkdir dir
-  printf "$contents" > dir/a.dat
-
-  git add dir/a.dat
-  git add .gitattributes
-  git commit -m "add dir/a.dat" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
-  grep "2 files changed" commit.log
-  grep "create mode 100644 dir/a.dat" commit.log
-  grep "create mode 100644 .gitattributes" commit.log
-
-  [ "a" = "$(cat dir/a.dat)" ]
-
-  assert_local_object "$contents_oid" 1
-  refute_server_object "$contents_oid"
-
-  git push origin master 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
-  grep "master -> master" push.log
-
-  assert_server_object "$reponame" "$contents_oid"
-
-  echo "lfs pull with include/exclude filters in gitconfig"
-
-  rm -rf .git/lfs/objects
-  git config "lfs.fetchinclude" "dir/"
-  git lfs pull
-  assert_local_object "$contents_oid" 1
-  git config --unset "lfs.fetchinclude"
-
-  rm -rf .git/lfs/objects
-  git config "lfs.fetchexclude" "dir/"
-  git lfs pull
-  refute_local_object "$contents_oid"
-  git config --unset "lfs.fetchexclude"
-
-  echo "lfs pull with include/exclude filters in arguments"
-
-  rm -rf .git/lfs/objects
-  git lfs pull -I="dir/"
-  assert_local_object "$contents_oid" 1
-
-  rm -rf .git/lfs/objects
-  git lfs pull -X="dir/"
-  refute_local_object "$contents_oid"
 )
 end_test
 

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -99,19 +99,6 @@ func CleanPaths(paths, delim string) (cleaned []string) {
 	return cleaned
 }
 
-// CleanPathsDefault cleans the paths contained in the given `paths` argument
-// delimited by the `delim`, argument. If an empty set is returned from that
-// split, then the fallback argument is returned instead.
-// Note always cleans to '/' path separators regardless of platform (git friendly)
-func CleanPathsDefault(paths, delim string, fallback []string) []string {
-	cleaned := CleanPaths(paths, delim)
-	if len(cleaned) == 0 {
-		return fallback
-	}
-
-	return cleaned
-}
-
 // VerifyFileHash reads a file and verifies whether the SHA is correct
 // Returns an error if there is a problem
 func VerifyFileHash(oid, path string) error {

--- a/tools/filetools_test.go
+++ b/tools/filetools_test.go
@@ -18,15 +18,3 @@ func TestCleanPathsReturnsNoResultsWhenGivenNoPaths(t *testing.T) {
 
 	assert.Empty(t, cleaned)
 }
-
-func TestCleanPathsDefaultReturnsInputWhenResultsPresent(t *testing.T) {
-	cleaned := tools.CleanPathsDefault("/foo/bar/", ",", []string{"/default"})
-
-	assert.Equal(t, []string{"/foo/bar"}, cleaned)
-}
-
-func TestCleanPathsDefaultReturnsDefaultWhenResultsAbsent(t *testing.T) {
-	cleaned := tools.CleanPathsDefault("", ",", []string{"/default"})
-
-	assert.Equal(t, []string{"/default"}, cleaned)
-}


### PR DESCRIPTION
This uses a `pflag.Flag`'s `Changed` property to determine if the `--include` or `--exclude` flags are empty or omitted. I'm not convinced using `*string` is any better than setting the default flag value to some magic string like `OPTIONAL`. It does remove any possibility of clashing with a directory in a user's repository, I suppose.

I also ran into some failures in large `test-fetch.sh` tests that run `git lfs fetch` multiple times. Those instances were really difficult to debug, so I split a couple of them up into separate files.

Fixes #1249