### PR TITLE
config-next: Remove config.{Setenv,SetAllEnv}

### DIFF
--- a/auth/ssh_test.go
+++ b/auth/ssh_test.go
@@ -9,213 +9,225 @@ import (
 )
 
 func TestSSHGetExeAndArgsSsh(t *testing.T) {
-	cfg := config.New()
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSH_COMMAND": "",
+			"GIT_SSH":         "",
+		},
+	})
+
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
-	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
-	cfg.Setenv("GIT_SSH_COMMAND", "")
-	oldGITSSH := cfg.Getenv("GIT_SSH")
-	cfg.Setenv("GIT_SSH", "")
+
 	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, "ssh", exe)
 	assert.Equal(t, []string{"user@foo.com"}, args)
-
-	cfg.Setenv("GIT_SSH", oldGITSSH)
-	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsSshCustomPort(t *testing.T) {
-	cfg := config.New()
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSH_COMMAND": "",
+			"GIT_SSH":         "",
+		},
+	})
+
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
-	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
-	cfg.Setenv("GIT_SSH_COMMAND", "")
-	oldGITSSH := cfg.Getenv("GIT_SSH")
-	cfg.Setenv("GIT_SSH", "")
+
 	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, "ssh", exe)
 	assert.Equal(t, []string{"-p", "8888", "user@foo.com"}, args)
-
-	cfg.Setenv("GIT_SSH", oldGITSSH)
-	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsPlink(t *testing.T) {
-	cfg := config.New()
+	plink := filepath.Join("Users", "joebloggs", "bin", "plink.exe")
+
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSH_COMMAND": "",
+			"GIT_SSH":         plink,
+		},
+	})
+
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
-	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
-	cfg.Setenv("GIT_SSH_COMMAND", "")
-	oldGITSSH := cfg.Getenv("GIT_SSH")
-	// this will run on non-Windows platforms too but no biggie
-	plink := filepath.Join("Users", "joebloggs", "bin", "plink.exe")
-	cfg.Setenv("GIT_SSH", plink)
+
 	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"user@foo.com"}, args)
-
-	cfg.Setenv("GIT_SSH", oldGITSSH)
-	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsPlinkCustomPort(t *testing.T) {
-	cfg := config.New()
+	plink := filepath.Join("Users", "joebloggs", "bin", "plink")
+
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSH_COMMAND": "",
+			"GIT_SSH":         plink,
+		},
+	})
+
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
-	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
-	cfg.Setenv("GIT_SSH_COMMAND", "")
-	oldGITSSH := cfg.Getenv("GIT_SSH")
-	// this will run on non-Windows platforms too but no biggie
-	plink := filepath.Join("Users", "joebloggs", "bin", "plink")
-	cfg.Setenv("GIT_SSH", plink)
+
 	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-P", "8888", "user@foo.com"}, args)
-
-	cfg.Setenv("GIT_SSH", oldGITSSH)
-	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsTortoisePlink(t *testing.T) {
-	cfg := config.New()
+	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink.exe")
+
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSH_COMMAND": "",
+			"GIT_SSH":         plink,
+		},
+	})
+
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
-	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
-	cfg.Setenv("GIT_SSH_COMMAND", "")
-	oldGITSSH := cfg.Getenv("GIT_SSH")
-	// this will run on non-Windows platforms too but no biggie
-	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink.exe")
-	cfg.Setenv("GIT_SSH", plink)
+
 	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-batch", "user@foo.com"}, args)
-
-	cfg.Setenv("GIT_SSH", oldGITSSH)
-	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsTortoisePlinkCustomPort(t *testing.T) {
-	cfg := config.New()
+	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink")
+
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSH_COMMAND": "",
+			"GIT_SSH":         plink,
+		},
+	})
+
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
-	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
-	cfg.Setenv("GIT_SSH_COMMAND", "")
-	oldGITSSH := cfg.Getenv("GIT_SSH")
-	// this will run on non-Windows platforms too but no biggie
-	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink")
-	cfg.Setenv("GIT_SSH", plink)
+
 	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-batch", "-P", "8888", "user@foo.com"}, args)
-
-	cfg.Setenv("GIT_SSH", oldGITSSH)
-	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsSshCommandPrecedence(t *testing.T) {
-	cfg := config.New()
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSH_COMMAND": "sshcmd",
+			"GIT_SSH":         "bad",
+		},
+	})
+
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
-	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
-	cfg.Setenv("GIT_SSH_COMMAND", "sshcmd")
-	oldGITSSH := cfg.Getenv("GIT_SSH")
-	cfg.Setenv("GIT_SSH", "bad")
+
 	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, "sshcmd", exe)
 	assert.Equal(t, []string{"user@foo.com"}, args)
-
-	cfg.Setenv("GIT_SSH", oldGITSSH)
-	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsSshCommandArgs(t *testing.T) {
-	cfg := config.New()
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSH_COMMAND": "sshcmd --args 1",
+		},
+	})
+
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
-	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
-	cfg.Setenv("GIT_SSH_COMMAND", "sshcmd --args 1")
+
 	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, "sshcmd", exe)
 	assert.Equal(t, []string{"--args", "1", "user@foo.com"}, args)
-
-	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsSshCommandCustomPort(t *testing.T) {
-	cfg := config.New()
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSH_COMMAND": "sshcmd",
+		},
+	})
+
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
-	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
-	cfg.Setenv("GIT_SSH_COMMAND", "sshcmd")
+
 	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, "sshcmd", exe)
 	assert.Equal(t, []string{"-p", "8888", "user@foo.com"}, args)
-
-	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsPlinkCommand(t *testing.T) {
-	cfg := config.New()
+	plink := filepath.Join("Users", "joebloggs", "bin", "plink.exe")
+
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSH_COMMAND": plink,
+		},
+	})
+
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
-	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
-	// this will run on non-Windows platforms too but no biggie
-	plink := filepath.Join("Users", "joebloggs", "bin", "plink.exe")
-	cfg.Setenv("GIT_SSH_COMMAND", plink)
+
 	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"user@foo.com"}, args)
-
-	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsPlinkCommandCustomPort(t *testing.T) {
-	cfg := config.New()
+	plink := filepath.Join("Users", "joebloggs", "bin", "plink")
+
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSH_COMMAND": plink,
+		},
+	})
+
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
-	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
-	// this will run on non-Windows platforms too but no biggie
-	plink := filepath.Join("Users", "joebloggs", "bin", "plink")
-	cfg.Setenv("GIT_SSH_COMMAND", plink)
+
 	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-P", "8888", "user@foo.com"}, args)
-
-	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsTortoisePlinkCommand(t *testing.T) {
-	cfg := config.New()
+	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink.exe")
+
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSH_COMMAND": plink,
+		},
+	})
+
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
-	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
-	// this will run on non-Windows platforms too but no biggie
-	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink.exe")
-	cfg.Setenv("GIT_SSH_COMMAND", plink)
+
 	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-batch", "user@foo.com"}, args)
-
-	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }
 
 func TestSSHGetExeAndArgsTortoisePlinkCommandCustomPort(t *testing.T) {
-	cfg := config.New()
+	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink")
+
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSH_COMMAND": plink,
+		},
+	})
+
 	endpoint := cfg.Endpoint("download")
 	endpoint.SshUserAndHost = "user@foo.com"
 	endpoint.SshPort = "8888"
-	oldGITSSHCommand := cfg.Getenv("GIT_SSH_COMMAND")
-	// this will run on non-Windows platforms too but no biggie
-	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink")
-	cfg.Setenv("GIT_SSH_COMMAND", plink)
+
 	exe, args := sshGetExeAndArgs(cfg, endpoint)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-batch", "-P", "8888", "user@foo.com"}, args)
-
-	cfg.Setenv("GIT_SSH_COMMAND", oldGITSSHCommand)
 }

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -8,9 +8,11 @@ import (
 )
 
 var (
-	testcfg = config.NewFromValues(map[string]string{
-		"lfs.fetchinclude": "/default/include",
-		"lfs.fetchexclude": "/default/exclude",
+	testcfg = config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.fetchinclude": "/default/include",
+			"lfs.fetchexclude": "/default/exclude",
+		},
 	})
 )
 

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -42,26 +42,15 @@ func TestDetermineIncludeExcludePathsReturnsDefaultsWhenAbsent(t *testing.T) {
 }
 
 func TestCommandEnabledFromEnvironmentVariables(t *testing.T) {
-	cfg := config.New()
-	err := cfg.Setenv("GITLFSLOCKSENABLED", "1")
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{"GITLFSLOCKSENABLED": "1"},
+	})
 
-	assert.Nil(t, err)
 	assert.True(t, isCommandEnabled(cfg, "locks"))
 }
 
 func TestCommandEnabledDisabledByDefault(t *testing.T) {
-	cfg := config.New()
+	cfg := config.NewFrom(config.Values{})
 
-	// Since config.Configuration.Setenv makes a call to os.Setenv, we have
-	// to make sure that the LFSLOCKSENABLED enviornment variable is not
-	// present in the configuration object during the lifecycle of this
-	// test.
-	//
-	// This behavior can cause race conditions with the above test when
-	// running in parallel, so this should be investigated further in the
-	// future.
-	err := cfg.Setenv("GITLFSLOCKSENABLED", "")
-
-	assert.Nil(t, err)
 	assert.False(t, isCommandEnabled(cfg, "locks"))
 }

--- a/config/config.go
+++ b/config/config.go
@@ -126,13 +126,6 @@ func (c *Configuration) Getenv(key string) string {
 	return c.Env.Get(key)
 }
 
-// Setenv is shorthand for `c.Setenv(key, value)`.
-//
-// TODO(taylor): remove calls to this method and avoid cast.
-func (c *Configuration) Setenv(key, value string) error {
-	return c.Env.(*EnvFetcher).Set(key, value)
-}
-
 // GetenvBool is shorthand for `c.Env.Bool(key, def)`.
 func (c *Configuration) GetenvBool(key string, def bool) bool {
 	return c.Env.Bool(key, def)

--- a/config/config.go
+++ b/config/config.go
@@ -133,13 +133,6 @@ func (c *Configuration) Setenv(key, value string) error {
 	return c.Env.(*EnvFetcher).Set(key, value)
 }
 
-// SetAllEnv is shorthand for `c.Env.SetAll(env)`.
-//
-// TODO(taylor): remove calls to this method and avoid cast.
-func (c *Configuration) SetAllEnv(env map[string]string) {
-	c.Env.(*EnvFetcher).SetAll(env)
-}
-
 // GetenvBool is shorthand for `c.Env.Bool(key, def)`.
 func (c *Configuration) GetenvBool(key string, def bool) bool {
 	return c.Env.Bool(key, def)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -567,9 +567,11 @@ func TestFetchPruneConfigCustom(t *testing.T) {
 }
 
 func TestFetchIncludeExcludesAreCleaned(t *testing.T) {
-	config := NewFromValues(map[string]string{
-		"lfs.fetchinclude": "/path/to/clean/",
-		"lfs.fetchexclude": "/other/path/to/clean/",
+	config := NewFrom(Values{
+		Git: map[string]string{
+			"lfs.fetchinclude": "/path/to/clean/",
+			"lfs.fetchexclude": "/other/path/to/clean/",
+		},
 	})
 
 	assert.Equal(t, []string{"/path/to/clean"}, config.FetchIncludePaths())

--- a/config/env_fetcher.go
+++ b/config/env_fetcher.go
@@ -91,18 +91,3 @@ func (e *EnvFetcher) Set(key, val string) error {
 
 	return os.Setenv(key, val)
 }
-
-// SetAll replaces all key-value pairs with the given set, but does not modify
-// the system's environment.
-//
-// Note: this method is a temporary measure while some of the old tests still
-// rely on this mutable behavior.
-func (e *EnvFetcher) SetAll(env map[string]string) {
-	e.vmu.Lock()
-	defer e.vmu.Unlock()
-
-	e.vals = make(map[string]string)
-	for k, v := range env {
-		e.vals[k] = v
-	}
-}

--- a/config/env_fetcher.go
+++ b/config/env_fetcher.go
@@ -73,21 +73,3 @@ func (e *EnvFetcher) Bool(key string, def bool) (val bool) {
 		return false
 	}
 }
-
-// Set replaces a given key-value pair in the cache (if previously present in
-// the cache) and in the system's environment variables. It returns an error if
-// one was encountered in setting the environment variable, or `nil` if
-// successful.
-//
-// Note: this method is a temporary measure while some of the old tests still
-// rely on this mutable behavior.
-func (e *EnvFetcher) Set(key, val string) error {
-	e.vmu.Lock()
-	defer e.vmu.Unlock()
-
-	if _, ok := e.vals[key]; ok {
-		e.vals[key] = val
-	}
-
-	return os.Setenv(key, val)
-}

--- a/config/map_fetcher.go
+++ b/config/map_fetcher.go
@@ -1,0 +1,28 @@
+package config
+
+import "strconv"
+
+// mapFetcher provides an implementation of the Fetcher interface by wrapping
+// the `map[string]string` type.
+type mapFetcher map[string]string
+
+// Get implements the func `Fetcher.Get`.
+func (m mapFetcher) Get(key string) (val string) { return m[key] }
+
+// Bool implements the function Fetcher.Bool.
+//
+// NOTE: It exists as a temporary measure before the Environment type is
+// abstracted (see github/git-lfs#1415).
+func (m mapFetcher) Bool(key string, def bool) (val bool) {
+	s := m.Get(key)
+	if len(s) == 0 {
+		return def
+	}
+
+	b, err := strconv.ParseBool(m.Get(key))
+	if err != nil {
+		return def
+	}
+
+	return b
+}

--- a/httputil/certs_test.go
+++ b/httputil/certs_test.go
@@ -101,8 +101,11 @@ func TestCertFromSSLCAInfoEnv(t *testing.T) {
 	assert.Nil(t, err, "Error writing temp cert file")
 	tempfile.Close()
 
-	cfg := config.New()
-	cfg.SetAllEnv(map[string]string{"GIT_SSL_CAINFO": tempfile.Name()})
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSL_CAINFO": tempfile.Name(),
+		},
+	})
 
 	// Should match any host at all
 	for _, matchedHostTest := range sslCAInfoMatchedHostTests {
@@ -139,8 +142,11 @@ func TestCertFromSSLCAPathEnv(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(tempdir, "cert1.pem"), []byte(testCert), 0644)
 	assert.Nil(t, err, "Error creating cert file")
 
-	cfg := config.New()
-	cfg.SetAllEnv(map[string]string{"GIT_SSL_CAPATH": tempdir})
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSL_CAPATH": tempdir,
+		},
+	})
 
 	// Should match any host at all
 	for _, matchedHostTest := range sslCAInfoMatchedHostTests {
@@ -154,7 +160,11 @@ func TestCertVerifyDisabledGlobalEnv(t *testing.T) {
 	cfg := config.New()
 	assert.False(t, isCertVerificationDisabledForHost(cfg, "anyhost.com"))
 
-	cfg.SetAllEnv(map[string]string{"GIT_SSL_NO_VERIFY": "1"})
+	cfg = config.NewFrom(config.Values{
+		Env: map[string]string{
+			"GIT_SSL_NO_VERIFY": "1",
+		},
+	})
 	assert.True(t, isCertVerificationDisabledForHost(cfg, "anyhost.com"))
 }
 

--- a/httputil/proxy_test.go
+++ b/httputil/proxy_test.go
@@ -9,11 +9,13 @@ import (
 )
 
 func TestProxyFromGitConfig(t *testing.T) {
-	cfg := config.NewFromValues(map[string]string{
-		"http.proxy": "https://proxy-from-git-config:8080",
-	})
-	cfg.SetAllEnv(map[string]string{
-		"HTTPS_PROXY": "https://proxy-from-env:8080",
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"http.proxy": "https://proxy-from-git-config:8080",
+		},
+		Env: map[string]string{
+			"HTTPS_PROXY": "https://proxy-from-env:8080",
+		},
 	})
 
 	req, err := http.NewRequest("GET", "https://some-host.com:123/foo/bar", nil)
@@ -28,11 +30,13 @@ func TestProxyFromGitConfig(t *testing.T) {
 }
 
 func TestHttpProxyFromGitConfig(t *testing.T) {
-	cfg := config.NewFromValues(map[string]string{
-		"http.proxy": "http://proxy-from-git-config:8080",
-	})
-	cfg.SetAllEnv(map[string]string{
-		"HTTPS_PROXY": "https://proxy-from-env:8080",
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"http.proxy": "http://proxy-from-git-config:8080",
+		},
+		Env: map[string]string{
+			"HTTPS_PROXY": "https://proxy-from-env:8080",
+		},
 	})
 
 	req, err := http.NewRequest("GET", "https://some-host.com:123/foo/bar", nil)
@@ -47,9 +51,10 @@ func TestHttpProxyFromGitConfig(t *testing.T) {
 }
 
 func TestProxyFromEnvironment(t *testing.T) {
-	cfg := config.New()
-	cfg.SetAllEnv(map[string]string{
-		"HTTPS_PROXY": "https://proxy-from-env:8080",
+	cfg := config.NewFrom(config.Values{
+		Env: map[string]string{
+			"HTTPS_PROXY": "https://proxy-from-env:8080",
+		},
 	})
 
 	req, err := http.NewRequest("GET", "https://some-host.com:123/foo/bar", nil)
@@ -78,11 +83,13 @@ func TestProxyIsNil(t *testing.T) {
 }
 
 func TestProxyNoProxy(t *testing.T) {
-	cfg := config.NewFromValues(map[string]string{
-		"http.proxy": "https://proxy-from-git-config:8080",
-	})
-	cfg.SetAllEnv(map[string]string{
-		"NO_PROXY": "some-host",
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"http.proxy": "https://proxy-from-git-config:8080",
+		},
+		Env: map[string]string{
+			"NO_PROXY": "some-host",
+		},
 	})
 
 	req, err := http.NewRequest("GET", "https://some-host:8080", nil)


### PR DESCRIPTION
This pull-request removes all instances of `config.Config.Setenv` and `config.config.SetAllEnv`. References to `SetConfig` still exist, but those are `.gitconfig` related, meaning they'll be addressed in a future pull-request.

There is also now considerably more repetition in the `auth/ssh_test.go` file. It's a good candidate for table-style tests, but I also appreciate its clarity right now.

This completes step 2 of config-next:

> Update tests to not use mutable behavior like Set and SetAll.

-----------------

/cc @technoweenie @rubyist @sinbad @larsxschneider