### PR TITLE
config-next: cleanup FetchPruneConfig()

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -100,9 +100,10 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if fetchPruneArg {
-		verify := cfg.FetchPruneConfig().PruneVerifyRemoteAlways
+		fetchconf := cfg.FetchPruneConfig()
+		verify := fetchconf.PruneVerifyRemoteAlways
 		// no dry-run or verbose options in fetch, assume false
-		prune(verify, false, false)
+		prune(fetchconf, verify, false, false)
 	}
 
 	if !success {

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -30,17 +30,15 @@ var (
 )
 
 func pruneCommand(cmd *cobra.Command, args []string) {
-
 	// Guts of this must be re-usable from fetch --prune so just parse & dispatch
 	if pruneVerifyArg && pruneDoNotVerifyArg {
 		Exit("Cannot specify both --verify-remote and --no-verify-remote")
 	}
 
+	fetchPruneConfig := cfg.FetchPruneConfig()
 	verify := !pruneDoNotVerifyArg &&
-		(cfg.FetchPruneConfig().PruneVerifyRemoteAlways || pruneVerifyArg)
-
-	prune(verify, pruneDryRunArg, pruneVerboseArg)
-
+		(fetchPruneConfig.PruneVerifyRemoteAlways || pruneVerifyArg)
+	prune(fetchPruneConfig, verify, pruneDryRunArg, pruneVerboseArg)
 }
 
 type PruneProgressType int
@@ -58,7 +56,7 @@ type PruneProgress struct {
 }
 type PruneProgressChan chan PruneProgress
 
-func prune(verifyRemote, dryRun, verbose bool) {
+func prune(fetchPruneConfig config.FetchPruneConfig, verifyRemote, dryRun, verbose bool) {
 	localObjects := make([]localstorage.Object, 0, 100)
 	retainedObjects := tools.NewStringSetWithCapacity(100)
 	var reachableObjects tools.StringSet
@@ -87,8 +85,8 @@ func prune(verifyRemote, dryRun, verbose bool) {
 	// Now find files to be retained from many sources
 	retainChan := make(chan string, 100)
 
-	go pruneTaskGetRetainedCurrentAndRecentRefs(retainChan, errorChan, &taskwait)
-	go pruneTaskGetRetainedUnpushed(retainChan, errorChan, &taskwait)
+	go pruneTaskGetRetainedCurrentAndRecentRefs(fetchPruneConfig, retainChan, errorChan, &taskwait)
+	go pruneTaskGetRetainedUnpushed(fetchPruneConfig, retainChan, errorChan, &taskwait)
 	go pruneTaskGetRetainedWorktree(retainChan, errorChan, &taskwait)
 	if verifyRemote {
 		reachableObjects = tools.NewStringSetWithCapacity(100)
@@ -123,7 +121,7 @@ func prune(verifyRemote, dryRun, verbose bool) {
 	var verifyc chan string
 
 	if verifyRemote {
-		cfg.CurrentRemote = cfg.FetchPruneConfig().PruneRemoteName
+		cfg.CurrentRemote = fetchPruneConfig.PruneRemoteName
 		// build queue now, no estimates or progress output
 		verifyQueue = lfs.NewDownloadCheckQueue(0, 0)
 		verifiedObjects = tools.NewStringSetWithCapacity(len(localObjects) / 2)
@@ -348,7 +346,7 @@ func pruneTaskGetPreviousVersionsOfRef(ref string, since time.Time, retainChan c
 }
 
 // Background task, must call waitg.Done() once at end
-func pruneTaskGetRetainedCurrentAndRecentRefs(retainChan chan string, errorChan chan error, waitg *sync.WaitGroup) {
+func pruneTaskGetRetainedCurrentAndRecentRefs(fetchconf config.FetchPruneConfig, retainChan chan string, errorChan chan error, waitg *sync.WaitGroup) {
 	defer waitg.Done()
 
 	// We actually increment the waitg in this func since we kick off sub-goroutines
@@ -365,7 +363,6 @@ func pruneTaskGetRetainedCurrentAndRecentRefs(retainChan chan string, errorChan 
 	go pruneTaskGetRetainedAtRef(ref.Sha, retainChan, errorChan, waitg)
 
 	// Now recent
-	fetchconf := cfg.FetchPruneConfig()
 	if fetchconf.FetchRecentRefsDays > 0 {
 		pruneRefDays := fetchconf.FetchRecentRefsDays + fetchconf.PruneOffsetDays
 		tracerx.Printf("PRUNE: Retaining non-HEAD refs within %d (%d+%d) days", pruneRefDays, fetchconf.FetchRecentRefsDays, fetchconf.PruneOffsetDays)
@@ -403,10 +400,10 @@ func pruneTaskGetRetainedCurrentAndRecentRefs(retainChan chan string, errorChan 
 }
 
 // Background task, must call waitg.Done() once at end
-func pruneTaskGetRetainedUnpushed(retainChan chan string, errorChan chan error, waitg *sync.WaitGroup) {
+func pruneTaskGetRetainedUnpushed(fetchconf config.FetchPruneConfig, retainChan chan string, errorChan chan error, waitg *sync.WaitGroup) {
 	defer waitg.Done()
 
-	remoteName := cfg.FetchPruneConfig().PruneRemoteName
+	remoteName := fetchconf.PruneRemoteName
 
 	refchan, err := lfs.ScanUnpushedToChan(remoteName)
 	if err != nil {


### PR DESCRIPTION
This pull-request updates the `FetchPruneConfig` type to be loaded from the new Git config parsing hotness.

-

/cc @technoweenie @rubyist @sinbad 