### PR TITLE
config-next: Unmarshalling

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -100,9 +100,10 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if fetchPruneArg {
-		verify := cfg.FetchPruneConfig().PruneVerifyRemoteAlways
+		fetchconf := cfg.FetchPruneConfig()
+		verify := fetchconf.PruneVerifyRemoteAlways
 		// no dry-run or verbose options in fetch, assume false
-		prune(verify, false, false)
+		prune(fetchconf, verify, false, false)
 	}
 
 	if !success {

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -30,17 +30,15 @@ var (
 )
 
 func pruneCommand(cmd *cobra.Command, args []string) {
-
 	// Guts of this must be re-usable from fetch --prune so just parse & dispatch
 	if pruneVerifyArg && pruneDoNotVerifyArg {
 		Exit("Cannot specify both --verify-remote and --no-verify-remote")
 	}
 
+	fetchPruneConfig := cfg.FetchPruneConfig()
 	verify := !pruneDoNotVerifyArg &&
-		(cfg.FetchPruneConfig().PruneVerifyRemoteAlways || pruneVerifyArg)
-
-	prune(verify, pruneDryRunArg, pruneVerboseArg)
-
+		(fetchPruneConfig.PruneVerifyRemoteAlways || pruneVerifyArg)
+	prune(fetchPruneConfig, verify, pruneDryRunArg, pruneVerboseArg)
 }
 
 type PruneProgressType int
@@ -58,7 +56,7 @@ type PruneProgress struct {
 }
 type PruneProgressChan chan PruneProgress
 
-func prune(verifyRemote, dryRun, verbose bool) {
+func prune(fetchPruneConfig config.FetchPruneConfig, verifyRemote, dryRun, verbose bool) {
 	localObjects := make([]localstorage.Object, 0, 100)
 	retainedObjects := tools.NewStringSetWithCapacity(100)
 	var reachableObjects tools.StringSet
@@ -87,8 +85,8 @@ func prune(verifyRemote, dryRun, verbose bool) {
 	// Now find files to be retained from many sources
 	retainChan := make(chan string, 100)
 
-	go pruneTaskGetRetainedCurrentAndRecentRefs(retainChan, errorChan, &taskwait)
-	go pruneTaskGetRetainedUnpushed(retainChan, errorChan, &taskwait)
+	go pruneTaskGetRetainedCurrentAndRecentRefs(fetchPruneConfig, retainChan, errorChan, &taskwait)
+	go pruneTaskGetRetainedUnpushed(fetchPruneConfig, retainChan, errorChan, &taskwait)
 	go pruneTaskGetRetainedWorktree(retainChan, errorChan, &taskwait)
 	if verifyRemote {
 		reachableObjects = tools.NewStringSetWithCapacity(100)
@@ -123,7 +121,7 @@ func prune(verifyRemote, dryRun, verbose bool) {
 	var verifyc chan string
 
 	if verifyRemote {
-		cfg.CurrentRemote = cfg.FetchPruneConfig().PruneRemoteName
+		cfg.CurrentRemote = fetchPruneConfig.PruneRemoteName
 		// build queue now, no estimates or progress output
 		verifyQueue = lfs.NewDownloadCheckQueue(0, 0)
 		verifiedObjects = tools.NewStringSetWithCapacity(len(localObjects) / 2)
@@ -348,7 +346,7 @@ func pruneTaskGetPreviousVersionsOfRef(ref string, since time.Time, retainChan c
 }
 
 // Background task, must call waitg.Done() once at end
-func pruneTaskGetRetainedCurrentAndRecentRefs(retainChan chan string, errorChan chan error, waitg *sync.WaitGroup) {
+func pruneTaskGetRetainedCurrentAndRecentRefs(fetchconf config.FetchPruneConfig, retainChan chan string, errorChan chan error, waitg *sync.WaitGroup) {
 	defer waitg.Done()
 
 	// We actually increment the waitg in this func since we kick off sub-goroutines
@@ -365,7 +363,6 @@ func pruneTaskGetRetainedCurrentAndRecentRefs(retainChan chan string, errorChan 
 	go pruneTaskGetRetainedAtRef(ref.Sha, retainChan, errorChan, waitg)
 
 	// Now recent
-	fetchconf := cfg.FetchPruneConfig()
 	if fetchconf.FetchRecentRefsDays > 0 {
 		pruneRefDays := fetchconf.FetchRecentRefsDays + fetchconf.PruneOffsetDays
 		tracerx.Printf("PRUNE: Retaining non-HEAD refs within %d (%d+%d) days", pruneRefDays, fetchconf.FetchRecentRefsDays, fetchconf.PruneOffsetDays)
@@ -403,10 +400,10 @@ func pruneTaskGetRetainedCurrentAndRecentRefs(retainChan chan string, errorChan 
 }
 
 // Background task, must call waitg.Done() once at end
-func pruneTaskGetRetainedUnpushed(retainChan chan string, errorChan chan error, waitg *sync.WaitGroup) {
+func pruneTaskGetRetainedUnpushed(fetchconf config.FetchPruneConfig, retainChan chan string, errorChan chan error, waitg *sync.WaitGroup) {
 	defer waitg.Done()
 
-	remoteName := cfg.FetchPruneConfig().PruneRemoteName
+	remoteName := fetchconf.PruneRemoteName
 
 	refchan, err := lfs.ScanUnpushedToChan(remoteName)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -282,7 +282,7 @@ func (c *Configuration) FetchIncludePaths() []string {
 
 func (c *Configuration) FetchExcludePaths() []string {
 	c.loadGitConfig()
-	patterns, _ := c.Git.Get("lfs.fetchexclude")
+	patterns, _ := c.Git.Get("lfs.fetchclude")
 	return tools.CleanPaths(patterns, ",")
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -111,7 +111,8 @@ func NewFrom(v Values) *Configuration {
 
 // Getenv is shorthand for `c.Os.Get(key)`.
 func (c *Configuration) Getenv(key string) string {
-	return c.Os.Get(key)
+	v, _ := c.Os.Get(key)
+	return v
 }
 
 // GetenvBool is shorthand for `c.Os.Bool(key, def)`.
@@ -275,12 +276,14 @@ func (c *Configuration) SetEndpointAccess(e Endpoint, authType string) {
 
 func (c *Configuration) FetchIncludePaths() []string {
 	c.loadGitConfig()
-	return tools.CleanPaths(c.Git.Get("lfs.fetchinclude"), ",")
+	patterns, _ := c.Git.Get("lfs.fetchinclude")
+	return tools.CleanPaths(patterns, ",")
 }
 
 func (c *Configuration) FetchExcludePaths() []string {
 	c.loadGitConfig()
-	return tools.CleanPaths(c.Git.Get("lfs.fetchexclude"), ",")
+	patterns, _ := c.Git.Get("lfs.fetchexclude")
+	return tools.CleanPaths(patterns, ",")
 }
 
 func (c *Configuration) RemoteEndpoint(remote, operation string) Endpoint {

--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,9 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -52,7 +54,7 @@ type Configuration struct {
 	// Git provides a `*Environment` used to access to the various levels of
 	// `.gitconfig`'s. It is the point of entry for all Git environment
 	// configuration.
-	Git       *Environment
+	Git *Environment
 
 	//
 	gitConfig map[string]string
@@ -108,6 +110,93 @@ func NewFrom(v Values) *Configuration {
 
 		envVars: make(map[string]string, 0),
 	}
+}
+
+// Unmarshal unmarshals the *Configuration in context into all of `v`'s fields,
+// according to the following rules:
+//
+// Values are marshaled according to the given key and environment, as follows:
+//	type T struct {
+//		Field string `git:"key"`
+//		Other string `os:"key"`
+//	}
+//
+// If an unknown environment is given, an error will be returned. If there is no
+// method supporting conversion into a field's type, an error will be returned.
+// If no value is associated with the given key and environment, the field will
+// be left alone. If the field is already set to a non-zero value of that
+// field's type, then it will be left alone.
+//
+// Otherwise, the field will be set to the value of calling the
+// appropriately-typed method on the specified environment.
+func (c *Configuration) Unmarshal(v interface{}) error {
+	into := reflect.ValueOf(v)
+	if into.Kind() != reflect.Ptr {
+		return fmt.Errorf("lfs/config: unable to parse non-pointer type of %T", v)
+	}
+	into = into.Elem()
+
+	for i := 0; i < into.Type().NumField(); i++ {
+		field := into.Field(i)
+		sfield := into.Type().Field(i)
+
+		zero := reflect.Zero(field.Type())
+		if field.Interface() != zero.Interface() {
+			continue
+		}
+
+		key, env, err := c.parseTag(sfield.Tag)
+		if err != nil {
+			return err
+		}
+
+		if env == nil {
+			continue
+		}
+
+		var val interface{}
+		switch sfield.Type.Kind() {
+		case reflect.String:
+			val, _ = env.Get(key)
+		case reflect.Int:
+			val = env.Int(key, 0)
+		case reflect.Bool:
+			val = env.Bool(key, false)
+		default:
+			return fmt.Errorf(
+				"lfs/config: unsupported target type for field %q: %v",
+				sfield.Name, sfield.Type.String())
+		}
+
+		if val != nil {
+			into.Field(i).Set(reflect.ValueOf(val))
+		}
+	}
+
+	return nil
+}
+
+// parseTag returns the key, environment, and optional error assosciated with a
+// given tag. It will return the XOR of either the `git` or `os` tag. That is to
+// say, a field tagged with EITHER `git` OR `os` is valid, but pone tagged with
+// both is not.
+//
+// If neither field was found, then a nil environment will be returned.
+func (c *Configuration) parseTag(tag reflect.StructTag) (key string, env *Environment, err error) {
+	git, os := tag.Get("git"), tag.Get("os")
+
+	if len(git) != 0 && len(os) != 0 {
+		return "", nil, errors.New("lfs/config: ambiguous tags")
+	}
+
+	if len(git) != 0 {
+		return git, c.Git, nil
+	}
+	if len(os) != 0 {
+		return os, c.Os, nil
+	}
+
+	return
 }
 
 // Getenv is shorthand for `c.Os.Get(key)`.

--- a/config/config.go
+++ b/config/config.go
@@ -282,7 +282,7 @@ func (c *Configuration) FetchIncludePaths() []string {
 
 func (c *Configuration) FetchExcludePaths() []string {
 	c.loadGitConfig()
-	patterns, _ := c.Git.Get("lfs.fetchclude")
+	patterns, _ := c.Git.Get("lfs.fetchexclude")
 	return tools.CleanPaths(patterns, ",")
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -604,7 +604,24 @@ func TestUnmarshalErrsOnNonPointerType(t *testing.T) {
 	assert.Equal(t, "lfs/config: unable to parse non-pointer type of config.T", err.Error())
 }
 
-func TestUnmarshalDoesNotOverrideNonZeroValues(t *testing.T) {
+func TestUnmarshalLeavesNonZeroValuesWhenKeysEmpty(t *testing.T) {
+	v := &struct {
+		String string `git:"string"`
+		Int    int    `git:"int"`
+		Bool   bool   `git:"bool"`
+	}{"foo", 1, true}
+
+	cfg := NewFrom(Values{})
+
+	err := cfg.Unmarshal(v)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "foo", v.String)
+	assert.Equal(t, 1, v.Int)
+	assert.Equal(t, true, v.Bool)
+}
+
+func TestUnmarshalOverridesNonZeroValuesWhenValuesPresent(t *testing.T) {
 	v := &struct {
 		String string `git:"string"`
 		Int    int    `git:"int"`
@@ -622,9 +639,9 @@ func TestUnmarshalDoesNotOverrideNonZeroValues(t *testing.T) {
 	err := cfg.Unmarshal(v)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "foo", v.String)
-	assert.Equal(t, 1, v.Int)
-	assert.Equal(t, true, v.Bool)
+	assert.Equal(t, "bar", v.String)
+	assert.Equal(t, 2, v.Int)
+	assert.Equal(t, false, v.Bool)
 }
 
 func TestUnmarshalDoesNotAllowBothOsAndGitTags(t *testing.T) {

--- a/config/environment.go
+++ b/config/environment.go
@@ -38,8 +38,8 @@ func (e *Environment) Get(key string) (val string, ok bool) {
 // 2) false if...
 //   "false", "0", "off", "no", "f", or otherwise.
 func (e *Environment) Bool(key string, def bool) (val bool) {
-	s, ok := e.Fetcher.Get(key)
-	if !ok {
+	s, _ := e.Fetcher.Get(key)
+	if len(s) == 0 {
 		return def
 	}
 
@@ -63,8 +63,8 @@ func (e *Environment) Bool(key string, def bool) (val bool) {
 // Otherwise, if the value was converted `string -> int` successfully, then it
 // will be returned wholesale.
 func (e *Environment) Int(key string, def int) (val int) {
-	s, ok := e.Fetcher.Get(key)
-	if !ok {
+	s, _ := e.Fetcher.Get(key)
+	if len(s) == 0 {
 		return def
 	}
 

--- a/config/environment.go
+++ b/config/environment.go
@@ -23,7 +23,7 @@ func EnvironmentOf(f Fetcher) *Environment {
 }
 
 // Get is shorthand for calling `e.Fetcher.Get(key)`.
-func (e *Environment) Get(key string) (val string) {
+func (e *Environment) Get(key string) (val string, ok bool) {
 	return e.Fetcher.Get(key)
 }
 
@@ -38,8 +38,8 @@ func (e *Environment) Get(key string) (val string) {
 // 2) false if...
 //   "false", "0", "off", "no", "f", or otherwise.
 func (e *Environment) Bool(key string, def bool) (val bool) {
-	s := e.Fetcher.Get(key)
-	if len(s) == 0 {
+	s, ok := e.Fetcher.Get(key)
+	if !ok {
 		return def
 	}
 
@@ -63,8 +63,8 @@ func (e *Environment) Bool(key string, def bool) (val bool) {
 // Otherwise, if the value was converted `string -> int` successfully, then it
 // will be returned wholesale.
 func (e *Environment) Int(key string, def int) (val int) {
-	s := e.Fetcher.Get(key)
-	if len(s) == 0 {
+	s, ok := e.Fetcher.Get(key)
+	if !ok {
 		return def
 	}
 

--- a/config/environment_test.go
+++ b/config/environment_test.go
@@ -20,14 +20,19 @@ func TestEnvironmentGetDelegatesToFetcher(t *testing.T) {
 	})
 
 	env := EnvironmentOf(fetcher)
-	val := env.Get("foo")
+	val, ok := env.Get("foo")
 
+	assert.True(t, ok)
 	assert.Equal(t, "bar", val)
+}
+
+func TestEnvironmentUnsetBoolDefault(t *testing.T) {
+	env := EnvironmentOf(MapFetcher(nil))
+	assert.True(t, env.Bool("unset", true))
 }
 
 func TestEnvironmentBoolTruthyConversion(t *testing.T) {
 	for _, c := range []EnvironmentConversionTestCase{
-		{"", true, GetBoolDefault(true)},
 		{"", false, GetBoolDefault(false)},
 
 		{"true", true, GetBoolDefault(false)},

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -4,7 +4,7 @@ package config
 // "source". These sources could be the OS enviornment, a .gitconfig, or even
 // just a `map`.
 type Fetcher interface {
-	// Get returns the string value assosicated with a given key, or an
-	// empty string if none exists.
-	Get(key string) (val string)
+	// Get returns the string value associated with a given key and a bool
+	// determining if the key exists.
+	Get(key string) (val string, ok bool)
 }

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -110,11 +110,12 @@ func ReadGitConfig(configs ...*GitConfig) (gf *GitFetcher, extensions map[string
 	return
 }
 
-func (g *GitFetcher) Get(key string) (val string) {
+func (g *GitFetcher) Get(key string) (val string, ok bool) {
 	g.vmu.RLock()
 	defer g.vmu.RUnlock()
 
-	return g.vals[key]
+	val, ok = g.vals[key]
+	return
 }
 
 func getGitConfigs() (sources []*GitConfig) {

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-
-	"github.com/github/git-lfs/tools"
 )
 
 type GitFetcher struct {
@@ -20,7 +18,7 @@ type GitConfig struct {
 	OnlySafeKeys bool
 }
 
-func ReadGitConfig(configs ...*GitConfig) (gf *GitFetcher, extensions map[string]Extension, uniqRemotes map[string]bool, include, exclude []string) {
+func ReadGitConfig(configs ...*GitConfig) (gf *GitFetcher, extensions map[string]Extension, uniqRemotes map[string]bool) {
 	vals := make(map[string]string)
 
 	extensions = make(map[string]Extension)
@@ -67,7 +65,7 @@ func ReadGitConfig(configs ...*GitConfig) (gf *GitFetcher, extensions map[string
 					if gc.OnlySafeKeys {
 						continue
 					}
-					ext.Clean = val
+					ext.Smudge = val
 				case "priority":
 					allowed = true
 					p, err := strconv.Atoi(val)
@@ -94,15 +92,6 @@ func ReadGitConfig(configs ...*GitConfig) (gf *GitFetcher, extensions map[string
 			}
 
 			vals[key] = val
-
-			if len(parts) == 2 && parts[0] == "lfs" {
-				switch parts[1] {
-				case "fetchinclude":
-					include = tools.CleanPaths(val, ",")
-				case "fetchexclude":
-					exclude = tools.CleanPaths(val, ",")
-				}
-			}
 		}
 	}
 

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -1,0 +1,135 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/github/git-lfs/tools"
+)
+
+type GitFetcher struct {
+	vmu  sync.RWMutex
+	vals map[string]string
+}
+
+type GitConfig struct {
+	Lines        []string
+	OnlySafeKeys bool
+}
+
+func ReadGitConfig(configs ...*GitConfig) (gf *GitFetcher, extensions map[string]Extension, uniqRemotes map[string]bool, include, exclude []string) {
+	vals := make(map[string]string)
+
+	extensions = make(map[string]Extension)
+	uniqRemotes = make(map[string]bool)
+
+	for _, gc := range configs {
+		uniqKeys := make(map[string]string)
+
+		for _, line := range gc.Lines {
+			pieces := strings.SplitN(line, "=", 2)
+			if len(pieces) < 2 {
+				continue
+			}
+
+			allowed := !gc.OnlySafeKeys
+			key, val := strings.ToLower(pieces[0]), pieces[1]
+
+			if origKey, ok := uniqKeys[key]; ok {
+				if ShowConfigWarnings && vals[key] != val && strings.HasPrefix(key, gitConfigWarningPrefix) {
+					fmt.Fprintf(os.Stderr, "WARNING: These git config values clash:\n")
+					fmt.Fprintf(os.Stderr, "  git config %q = %q\n", origKey, vals[key])
+					fmt.Fprintf(os.Stderr, "  git config %q = %q\n", pieces[0], val)
+				}
+			} else {
+				uniqKeys[key] = pieces[0]
+			}
+
+			parts := strings.Split(key, ".")
+			if len(parts) == 4 && parts[0] == "lfs" && parts[1] == "extension" {
+				// prop: lfs.extension.<name>.<prop>
+				name := parts[2]
+				prop := parts[3]
+
+				ext := extensions[name]
+				ext.Name = name
+
+				switch prop {
+				case "clean":
+					if gc.OnlySafeKeys {
+						continue
+					}
+					ext.Clean = val
+				case "smudge":
+					if gc.OnlySafeKeys {
+						continue
+					}
+					ext.Clean = val
+				case "priority":
+					allowed = true
+					p, err := strconv.Atoi(val)
+					if err == nil && p >= 0 {
+						ext.Priority = p
+					}
+				}
+
+				extensions[name] = ext
+			} else if len(parts) > 1 && parts[0] == "remote" {
+				if gc.OnlySafeKeys && (len(parts) == 3 && parts[2] != "lfsurl") {
+					continue
+				}
+
+				allowed = true
+				remote := parts[1]
+				uniqRemotes[remote] = remote == "origin"
+			} else if len(parts) > 2 && parts[len(parts)-1] == "access" {
+				allowed = true
+			}
+
+			if !allowed && keyIsUnsafe(key) {
+				continue
+			}
+
+			vals[key] = val
+
+			if len(parts) == 2 && parts[0] == "lfs" {
+				switch parts[1] {
+				case "fetchinclude":
+					include = tools.CleanPaths(val, ",")
+				case "fetchexclude":
+					exclude = tools.CleanPaths(val, ",")
+				}
+			}
+		}
+	}
+
+	gf = &GitFetcher{vals: vals}
+
+	return
+}
+
+func (g *GitFetcher) Get(key string) (val string) {
+	g.vmu.RLock()
+	defer g.vmu.RUnlock()
+
+	return g.vals[key]
+}
+
+func keyIsUnsafe(key string) bool {
+	for _, safe := range safeKeys {
+		if safe == key {
+			return false
+		}
+	}
+	return true
+}
+
+var safeKeys = []string{
+	"lfs.fetchexclude",
+	"lfs.fetchinclude",
+	"lfs.gitprotocol",
+	"lfs.url",
+}

--- a/config/map_fetcher.go
+++ b/config/map_fetcher.go
@@ -9,4 +9,7 @@ func MapFetcher(m map[string]string) Fetcher {
 }
 
 // Get implements the func `Fetcher.Get`.
-func (m mapFetcher) Get(key string) (val string) { return m[key] }
+func (m mapFetcher) Get(key string) (val string, ok bool) {
+	val, ok = m[key]
+	return
+}


### PR DESCRIPTION
❗ The relevant diff is contained in [`config-next-prune..config-next-unmarshalling`](https://github.com/github/git-lfs/compare/config-next-prune...config-next-unmarshalling).

-

Calling `Unmarshal` on a struct-pointer will inspect each of that struct's
field's tags, and unmarshal configuration data into said field according to
three parameters:

- The environment specified, either `git` or `os`.
- The name of the key given (in the tag).
- The type of the field (either `string`, `int`, or `bool`).

If there is already a non-zero value stored in the field, then that field will
be skipped, allowing constructors to set up default behavior.

-

/cc @technoweenie @rubyist @sinbad