### PR TITLE
config-next: remove `SetConfig` from package `api`, `lfs`, `httputil`

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -66,7 +66,7 @@ func Batch(cfg *config.Configuration, objects []*ObjectResource, operation strin
 		return nil, "", errutil.Error(err)
 	}
 
-	req, err := NewBatchRequest(operation)
+	req, err := NewBatchRequest(cfg, operation)
 	if err != nil {
 		return nil, "", errutil.Error(err)
 	}
@@ -78,7 +78,7 @@ func Batch(cfg *config.Configuration, objects []*ObjectResource, operation strin
 
 	tracerx.Printf("api: batch %d files", len(objects))
 
-	res, bresp, err := DoBatchRequest(req)
+	res, bresp, err := DoBatchRequest(cfg, req)
 
 	if err != nil {
 
@@ -143,7 +143,7 @@ func DownloadCheck(cfg *config.Configuration, oid string) (*ObjectResource, erro
 		return nil, errutil.Error(err)
 	}
 
-	res, obj, err := DoLegacyRequest(req)
+	res, obj, err := DoLegacyRequest(cfg, req)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func UploadCheck(cfg *config.Configuration, oid string, size int64) (*ObjectReso
 	req.Body = tools.NewReadSeekCloserWrapper(bytes.NewReader(by))
 
 	tracerx.Printf("api: uploading (%s)", oid)
-	res, obj, err := DoLegacyRequest(req)
+	res, obj, err := DoLegacyRequest(cfg, req)
 
 	if err != nil {
 		if errutil.IsAuthError(err) {

--- a/api/api.go
+++ b/api/api.go
@@ -20,17 +20,16 @@ import (
 // BatchOrLegacy calls the Batch API and falls back on the Legacy API
 // This is for simplicity, legacy route is not most optimal (serial)
 // TODO LEGACY API: remove when legacy API removed
-func BatchOrLegacy(objects []*ObjectResource, operation string, transferAdapters []string) (objs []*ObjectResource, transferAdapter string, e error) {
-	cfg := config.Config
+func BatchOrLegacy(cfg *config.Configuration, objects []*ObjectResource, operation string, transferAdapters []string) (objs []*ObjectResource, transferAdapter string, e error) {
 	if !cfg.BatchTransfer() {
-		objs, err := Legacy(objects, operation)
+		objs, err := Legacy(cfg, objects, operation)
 		return objs, "", err
 	}
-	objs, adapterName, err := Batch(objects, operation, transferAdapters)
+	objs, adapterName, err := Batch(cfg, objects, operation, transferAdapters)
 	if err != nil {
 		if errutil.IsNotImplementedError(err) {
 			git.Config.SetLocal("", "lfs.batch", "false")
-			objs, err := Legacy(objects, operation)
+			objs, err := Legacy(cfg, objects, operation)
 			return objs, "", err
 		}
 		return nil, "", err
@@ -38,8 +37,8 @@ func BatchOrLegacy(objects []*ObjectResource, operation string, transferAdapters
 	return objs, adapterName, nil
 }
 
-func BatchOrLegacySingle(inobj *ObjectResource, operation string, transferAdapters []string) (obj *ObjectResource, transferAdapter string, e error) {
-	objs, adapterName, err := BatchOrLegacy([]*ObjectResource{inobj}, operation, transferAdapters)
+func BatchOrLegacySingle(cfg *config.Configuration, inobj *ObjectResource, operation string, transferAdapters []string) (obj *ObjectResource, transferAdapter string, e error) {
+	objs, adapterName, err := BatchOrLegacy(cfg, []*ObjectResource{inobj}, operation, transferAdapters)
 	if err != nil {
 		return nil, "", err
 	}
@@ -50,12 +49,10 @@ func BatchOrLegacySingle(inobj *ObjectResource, operation string, transferAdapte
 }
 
 // Batch calls the batch API and returns object results
-func Batch(objects []*ObjectResource, operation string, transferAdapters []string) (objs []*ObjectResource, transferAdapter string, e error) {
+func Batch(cfg *config.Configuration, objects []*ObjectResource, operation string, transferAdapters []string) (objs []*ObjectResource, transferAdapter string, e error) {
 	if len(objects) == 0 {
 		return nil, "", nil
 	}
-
-	cfg := config.Config
 
 	// Compatibility; omit transfers list when only basic
 	// older schemas included `additionalproperties=false`
@@ -95,7 +92,7 @@ func Batch(objects []*ObjectResource, operation string, transferAdapters []strin
 
 		if errutil.IsAuthError(err) {
 			httputil.SetAuthType(cfg, req, res)
-			return Batch(objects, operation, transferAdapters)
+			return Batch(cfg, objects, operation, transferAdapters)
 		}
 
 		switch res.StatusCode {
@@ -118,7 +115,7 @@ func Batch(objects []*ObjectResource, operation string, transferAdapters []strin
 
 // Legacy calls the legacy API serially and returns ObjectResources
 // TODO LEGACY API: remove when legacy API removed
-func Legacy(objects []*ObjectResource, operation string) ([]*ObjectResource, error) {
+func Legacy(cfg *config.Configuration, objects []*ObjectResource, operation string) ([]*ObjectResource, error) {
 	retobjs := make([]*ObjectResource, 0, len(objects))
 	dl := operation == "download"
 	var globalErr error
@@ -126,9 +123,9 @@ func Legacy(objects []*ObjectResource, operation string) ([]*ObjectResource, err
 		var ret *ObjectResource
 		var err error
 		if dl {
-			ret, err = DownloadCheck(o.Oid)
+			ret, err = DownloadCheck(cfg, o.Oid)
 		} else {
-			ret, err = UploadCheck(o.Oid, o.Size)
+			ret, err = UploadCheck(cfg, o.Oid, o.Size)
 		}
 		if err != nil {
 			// Store for the end, likely only one
@@ -140,8 +137,8 @@ func Legacy(objects []*ObjectResource, operation string) ([]*ObjectResource, err
 }
 
 // TODO LEGACY API: remove when legacy API removed
-func DownloadCheck(oid string) (*ObjectResource, error) {
-	req, err := NewRequest("GET", oid)
+func DownloadCheck(cfg *config.Configuration, oid string) (*ObjectResource, error) {
+	req, err := NewRequest(cfg, "GET", oid)
 	if err != nil {
 		return nil, errutil.Error(err)
 	}
@@ -151,7 +148,6 @@ func DownloadCheck(oid string) (*ObjectResource, error) {
 		return nil, err
 	}
 
-	cfg := config.Config
 	httputil.LogTransfer(cfg, "lfs.download", res)
 
 	_, err = obj.NewRequest("download", "GET")
@@ -163,8 +159,7 @@ func DownloadCheck(oid string) (*ObjectResource, error) {
 }
 
 // TODO LEGACY API: remove when legacy API removed
-func UploadCheck(oid string, size int64) (*ObjectResource, error) {
-	cfg := config.Config
+func UploadCheck(cfg *config.Configuration, oid string, size int64) (*ObjectResource, error) {
 	reqObj := &ObjectResource{
 		Oid:  oid,
 		Size: size,
@@ -175,7 +170,7 @@ func UploadCheck(oid string, size int64) (*ObjectResource, error) {
 		return nil, errutil.Error(err)
 	}
 
-	req, err := NewRequest("POST", oid)
+	req, err := NewRequest(cfg, "POST", oid)
 	if err != nil {
 		return nil, errutil.Error(err)
 	}
@@ -191,7 +186,7 @@ func UploadCheck(oid string, size int64) (*ObjectResource, error) {
 	if err != nil {
 		if errutil.IsAuthError(err) {
 			httputil.SetAuthType(cfg, req, res)
-			return UploadCheck(oid, size)
+			return UploadCheck(cfg, oid, size)
 		}
 
 		return nil, errutil.NewRetriableError(err)

--- a/api/download_test.go
+++ b/api/download_test.go
@@ -73,11 +73,14 @@ func TestSuccessfulDownload(t *testing.T) {
 		w.Write(by)
 	})
 
-	defer config.Config.ResetConfig()
-	config.Config.SetConfig("lfs.batch", "false")
-	config.Config.SetConfig("lfs.url", server.URL+"/media")
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.batch": "false",
+			"lfs.url":   server.URL + "/media",
+		},
+	})
 
-	obj, _, err := api.BatchOrLegacySingle(&api.ObjectResource{Oid: "oid"}, "download", []string{"basic"})
+	obj, _, err := api.BatchOrLegacySingle(cfg, &api.ObjectResource{Oid: "oid"}, "download", []string{"basic"})
 	if err != nil {
 		if isDockerConnectionError(err) {
 			return
@@ -179,12 +182,15 @@ func TestSuccessfulDownloadWithRedirects(t *testing.T) {
 		w.Write(by)
 	})
 
-	defer config.Config.ResetConfig()
-	config.Config.SetConfig("lfs.batch", "false")
-	config.Config.SetConfig("lfs.url", server.URL+"/redirect")
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.batch": "false",
+			"lfs.url":   server.URL + "/redirect",
+		},
+	})
 
 	for _, redirect := range redirectCodes {
-		obj, _, err := api.BatchOrLegacySingle(&api.ObjectResource{Oid: "oid"}, "download", []string{"basic"})
+		obj, _, err := api.BatchOrLegacySingle(cfg, &api.ObjectResource{Oid: "oid"}, "download", []string{"basic"})
 		if err != nil {
 			if isDockerConnectionError(err) {
 				return
@@ -257,10 +263,14 @@ func TestSuccessfulDownloadWithAuthorization(t *testing.T) {
 		w.Write(by)
 	})
 
-	defer config.Config.ResetConfig()
-	config.Config.SetConfig("lfs.batch", "false")
-	config.Config.SetConfig("lfs.url", server.URL+"/media")
-	obj, _, err := api.BatchOrLegacySingle(&api.ObjectResource{Oid: "oid"}, "download", []string{"basic"})
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.batch": "false",
+			"lfs.url":   server.URL + "/media",
+		},
+	})
+
+	obj, _, err := api.BatchOrLegacySingle(cfg, &api.ObjectResource{Oid: "oid"}, "download", []string{"basic"})
 	if err != nil {
 		if isDockerConnectionError(err) {
 			return
@@ -291,10 +301,14 @@ func TestDownloadAPIError(t *testing.T) {
 		w.WriteHeader(404)
 	})
 
-	defer config.Config.ResetConfig()
-	config.Config.SetConfig("lfs.batch", "false")
-	config.Config.SetConfig("lfs.url", server.URL+"/media")
-	_, _, err := api.BatchOrLegacySingle(&api.ObjectResource{Oid: "oid"}, "download", []string{"basic"})
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.batch": "false",
+			"lfs.url":   server.URL + "/media",
+		},
+	})
+
+	_, _, err := api.BatchOrLegacySingle(cfg, &api.ObjectResource{Oid: "oid"}, "download", []string{"basic"})
 	if err == nil {
 		t.Fatal("no error?")
 	}

--- a/api/upload_test.go
+++ b/api/upload_test.go
@@ -101,8 +101,11 @@ func TestExistingUpload(t *testing.T) {
 		w.Write(by)
 	})
 
-	defer config.Config.ResetConfig()
-	config.Config.SetConfig("lfs.url", server.URL+"/media")
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.url": server.URL + "/media",
+		},
+	})
 
 	oidPath, _ := lfs.LocalMediaPath("988881adc9fc3655077dc2d4d757d480b5ea0e11")
 	if err := ioutil.WriteFile(oidPath, []byte("test"), 0744); err != nil {
@@ -111,7 +114,7 @@ func TestExistingUpload(t *testing.T) {
 
 	oid := filepath.Base(oidPath)
 	stat, _ := os.Stat(oidPath)
-	o, _, err := api.BatchOrLegacySingle(&api.ObjectResource{Oid: oid, Size: stat.Size()}, "upload", []string{"basic"})
+	o, _, err := api.BatchOrLegacySingle(cfg, &api.ObjectResource{Oid: oid, Size: stat.Size()}, "upload", []string{"basic"})
 	if err != nil {
 		if isDockerConnectionError(err) {
 			return
@@ -227,8 +230,11 @@ func TestUploadWithRedirect(t *testing.T) {
 		w.Write(by)
 	})
 
-	defer config.Config.ResetConfig()
-	config.Config.SetConfig("lfs.url", server.URL+"/redirect")
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.url": server.URL + "/redirect",
+		},
+	})
 
 	oidPath, _ := lfs.LocalMediaPath("988881adc9fc3655077dc2d4d757d480b5ea0e11")
 	if err := ioutil.WriteFile(oidPath, []byte("test"), 0744); err != nil {
@@ -237,7 +243,7 @@ func TestUploadWithRedirect(t *testing.T) {
 
 	oid := filepath.Base(oidPath)
 	stat, _ := os.Stat(oidPath)
-	o, _, err := api.BatchOrLegacySingle(&api.ObjectResource{Oid: oid, Size: stat.Size()}, "upload", []string{"basic"})
+	o, _, err := api.BatchOrLegacySingle(cfg, &api.ObjectResource{Oid: oid, Size: stat.Size()}, "upload", []string{"basic"})
 	if err != nil {
 		if isDockerConnectionError(err) {
 			return
@@ -369,8 +375,11 @@ func TestSuccessfulUploadWithVerify(t *testing.T) {
 		w.WriteHeader(200)
 	})
 
-	defer config.Config.ResetConfig()
-	config.Config.SetConfig("lfs.url", server.URL+"/media")
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.url": server.URL + "/media",
+		},
+	})
 
 	oidPath, _ := lfs.LocalMediaPath("988881adc9fc3655077dc2d4d757d480b5ea0e11")
 	if err := ioutil.WriteFile(oidPath, []byte("test"), 0744); err != nil {
@@ -379,7 +388,7 @@ func TestSuccessfulUploadWithVerify(t *testing.T) {
 
 	oid := filepath.Base(oidPath)
 	stat, _ := os.Stat(oidPath)
-	o, _, err := api.BatchOrLegacySingle(&api.ObjectResource{Oid: oid, Size: stat.Size()}, "upload", []string{"basic"})
+	o, _, err := api.BatchOrLegacySingle(cfg, &api.ObjectResource{Oid: oid, Size: stat.Size()}, "upload", []string{"basic"})
 	if err != nil {
 		if isDockerConnectionError(err) {
 			return
@@ -421,8 +430,11 @@ func TestUploadApiError(t *testing.T) {
 		w.WriteHeader(404)
 	})
 
-	defer config.Config.ResetConfig()
-	config.Config.SetConfig("lfs.url", server.URL+"/media")
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.url": server.URL + "/media",
+		},
+	})
 
 	oidPath, _ := lfs.LocalMediaPath("988881adc9fc3655077dc2d4d757d480b5ea0e11")
 	if err := ioutil.WriteFile(oidPath, []byte("test"), 0744); err != nil {
@@ -431,7 +443,7 @@ func TestUploadApiError(t *testing.T) {
 
 	oid := filepath.Base(oidPath)
 	stat, _ := os.Stat(oidPath)
-	_, _, err := api.BatchOrLegacySingle(&api.ObjectResource{Oid: oid, Size: stat.Size()}, "upload", []string{"basic"})
+	_, _, err := api.BatchOrLegacySingle(cfg, &api.ObjectResource{Oid: oid, Size: stat.Size()}, "upload", []string{"basic"})
 	if err == nil {
 		t.Fatal(err)
 	}
@@ -539,8 +551,11 @@ func TestUploadVerifyError(t *testing.T) {
 		w.WriteHeader(404)
 	})
 
-	defer config.Config.ResetConfig()
-	config.Config.SetConfig("lfs.url", server.URL+"/media")
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.url": server.URL + "/media",
+		},
+	})
 
 	oidPath, _ := lfs.LocalMediaPath("988881adc9fc3655077dc2d4d757d480b5ea0e11")
 	if err := ioutil.WriteFile(oidPath, []byte("test"), 0744); err != nil {
@@ -549,7 +564,7 @@ func TestUploadVerifyError(t *testing.T) {
 
 	oid := filepath.Base(oidPath)
 	stat, _ := os.Stat(oidPath)
-	o, _, err := api.BatchOrLegacySingle(&api.ObjectResource{Oid: oid, Size: stat.Size()}, "upload", []string{"basic"})
+	o, _, err := api.BatchOrLegacySingle(cfg, &api.ObjectResource{Oid: oid, Size: stat.Size()}, "upload", []string{"basic"})
 	if err != nil {
 		if isDockerConnectionError(err) {
 			return

--- a/api/upload_test.go
+++ b/api/upload_test.go
@@ -395,7 +395,7 @@ func TestSuccessfulUploadWithVerify(t *testing.T) {
 		}
 		t.Fatal(err)
 	}
-	api.VerifyUpload(o)
+	api.VerifyUpload(cfg, o)
 
 	if !postCalled {
 		t.Errorf("POST not called")
@@ -571,7 +571,7 @@ func TestUploadVerifyError(t *testing.T) {
 		}
 		t.Fatal(err)
 	}
-	err = api.VerifyUpload(o)
+	err = api.VerifyUpload(cfg, o)
 	if err == nil {
 		t.Fatal("verify should fail")
 	}

--- a/api/v1.go
+++ b/api/v1.go
@@ -81,7 +81,7 @@ func DoRequest(req *http.Request, useCreds bool) (*http.Response, error) {
 	return httputil.DoHttpRequestWithRedirects(config.Config, req, via, useCreds)
 }
 
-func NewRequest(method, oid string) (*http.Request, error) {
+func NewRequest(cfg *config.Configuration, method, oid string) (*http.Request, error) {
 	objectOid := oid
 	operation := "download"
 	if method == "POST" {
@@ -91,7 +91,6 @@ func NewRequest(method, oid string) (*http.Request, error) {
 		}
 	}
 
-	cfg := config.Config
 	res, endpoint, err := auth.SshAuthenticate(cfg, operation, oid)
 	if err != nil {
 		tracerx.Printf("ssh: attempted with %s.  Error: %s",

--- a/api/v1.go
+++ b/api/v1.go
@@ -18,8 +18,7 @@ const (
 )
 
 // doLegacyApiRequest runs the request to the LFS legacy API.
-func DoLegacyRequest(req *http.Request) (*http.Response, *ObjectResource, error) {
-	cfg := config.Config
+func DoLegacyRequest(cfg *config.Configuration, req *http.Request) (*http.Response, *ObjectResource, error) {
 	via := make([]*http.Request, 0, 4)
 	res, err := httputil.DoHttpRequestWithRedirects(cfg, req, via, true)
 	if err != nil {
@@ -51,8 +50,7 @@ type batchResponse struct {
 // 401, the repo will be marked as having private access and the request will be
 // re-run. When the repo is marked as having private access, credentials will
 // be retrieved.
-func DoBatchRequest(req *http.Request) (*http.Response, *batchResponse, error) {
-	cfg := config.Config
+func DoBatchRequest(cfg *config.Configuration, req *http.Request) (*http.Response, *batchResponse, error) {
 	res, err := DoRequest(req, cfg.PrivateAccess(auth.GetOperationForRequest(req)))
 
 	if err != nil {
@@ -117,8 +115,7 @@ func NewRequest(cfg *config.Configuration, method, oid string) (*http.Request, e
 	return req, nil
 }
 
-func NewBatchRequest(operation string) (*http.Request, error) {
-	cfg := config.Config
+func NewBatchRequest(cfg *config.Configuration, operation string) (*http.Request, error) {
 	res, endpoint, err := auth.SshAuthenticate(cfg, operation, "")
 	if err != nil {
 		tracerx.Printf("ssh: %s attempted with %s.  Error: %s",

--- a/api/verify.go
+++ b/api/verify.go
@@ -13,7 +13,7 @@ import (
 )
 
 // VerifyUpload calls the "verify" API link relation on obj if it exists
-func VerifyUpload(obj *ObjectResource) error {
+func VerifyUpload(cfg *config.Configuration, obj *ObjectResource) error {
 	// Do we need to do verify?
 	if _, ok := obj.Rel("verify"); !ok {
 		return nil
@@ -38,7 +38,6 @@ func VerifyUpload(obj *ObjectResource) error {
 		return err
 	}
 
-	cfg := config.Config
 	httputil.LogTransfer(cfg, "lfs.data.verify", res)
 	io.Copy(ioutil.Discard, res.Body)
 	res.Body.Close()

--- a/auth/credentials_test.go
+++ b/auth/credentials_test.go
@@ -206,12 +206,10 @@ func TestNetrcWithBadHost(t *testing.T) {
 func checkGetCredentials(t *testing.T, getCredsFunc func(*config.Configuration, *http.Request) (Creds, error), checks []*getCredentialCheck) {
 	for _, check := range checks {
 		t.Logf("Checking %q", check.Desc)
-		cfg := config.New()
+		cfg := config.NewFrom(config.Values{
+			Git: check.Config,
+		})
 		cfg.CurrentRemote = check.CurrentRemote
-
-		for key, value := range check.Config {
-			cfg.SetConfig(key, value)
-		}
 
 		req, err := http.NewRequest(check.Method, check.Href, nil)
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -509,23 +509,6 @@ func (c *Configuration) SetConfig(key, value string) {
 }
 
 // XXX(taylor): remove mutability
-func (c *Configuration) ClearConfig() {
-	if c.loadGitConfig() {
-		c.loading.Lock()
-		c.origConfig = make(map[string]string)
-		for k, v := range c.gitConfig {
-			c.origConfig[k] = v
-		}
-		c.loading.Unlock()
-	}
-
-	c.gitConfig = make(map[string]string)
-	if gf, ok := c.Git.Fetcher.(*GitFetcher); ok {
-		gf.vals = c.gitConfig
-	}
-}
-
-// XXX(taylor): remove mutability
 func (c *Configuration) ResetConfig() {
 	c.loading.Lock()
 	c.gitConfig = make(map[string]string)

--- a/lfs/download_queue.go
+++ b/lfs/download_queue.go
@@ -2,6 +2,7 @@ package lfs
 
 import (
 	"github.com/github/git-lfs/api"
+	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/transfer"
 )
 
@@ -37,7 +38,7 @@ func (d *Downloadable) SetObject(o *api.ObjectResource) {
 
 // TODO remove this legacy method & only support batch
 func (d *Downloadable) LegacyCheck() (*api.ObjectResource, error) {
-	return api.DownloadCheck(d.pointer.Oid)
+	return api.DownloadCheck(config.Config, d.pointer.Oid)
 }
 
 func NewDownloadable(p *WrappedPointer) *Downloadable {

--- a/lfs/pointer_smudge.go
+++ b/lfs/pointer_smudge.go
@@ -77,7 +77,7 @@ func downloadFile(writer io.Writer, ptr *Pointer, workingfile, mediafile string,
 	fmt.Fprintf(os.Stderr, "Downloading %s (%s)\n", workingfile, pb.FormatBytes(ptr.Size))
 
 	xfers := transfer.GetDownloadAdapterNames()
-	obj, adapterName, err := api.BatchOrLegacySingle(&api.ObjectResource{Oid: ptr.Oid, Size: ptr.Size}, "download", xfers)
+	obj, adapterName, err := api.BatchOrLegacySingle(config.Config, &api.ObjectResource{Oid: ptr.Oid, Size: ptr.Size}, "download", xfers)
 	if err != nil {
 		return errutil.Errorf(err, "Error downloading %s: %s", filepath.Base(mediafile), err)
 	}

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -350,7 +350,7 @@ func (q *TransferQueue) batchApiRoutine() {
 			continue
 		}
 
-		objs, adapterName, err := api.Batch(transfers, q.transferKind(), transferAdapterNames)
+		objs, adapterName, err := api.Batch(config.Config, transfers, q.transferKind(), transferAdapterNames)
 		if err != nil {
 			if errutil.IsNotImplementedError(err) {
 				git.Config.SetLocal("", "lfs.batch", "false")

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -46,7 +46,7 @@ func (u *Uploadable) Path() string {
 
 // TODO LEGACY API: remove when legacy API removed
 func (u *Uploadable) LegacyCheck() (*api.ObjectResource, error) {
-	return api.UploadCheck(u.Oid(), u.Size())
+	return api.UploadCheck(config.Config, u.Oid(), u.Size())
 }
 
 // NewUploadable builds the Uploadable from the given information.

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -250,7 +250,7 @@ func callBatchApi(op string, objs []TestObject) ([]*api.ObjectResource, error) {
 	for _, o := range objs {
 		apiobjs = append(apiobjs, &api.ObjectResource{Oid: o.Oid, Size: o.Size})
 	}
-	o, _, err := api.Batch(apiobjs, op, []string{"basic"})
+	o, _, err := api.Batch(config.Config, apiobjs, op, []string{"basic"})
 	if err != nil {
 		return nil, err
 	}

--- a/transfer/basic_upload.go
+++ b/transfer/basic_upload.go
@@ -116,7 +116,7 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Transfe
 	io.Copy(ioutil.Discard, res.Body)
 	res.Body.Close()
 
-	return api.VerifyUpload(t.Object)
+	return api.VerifyUpload(config.Config, t.Object)
 }
 
 // startCallbackReader is a reader wrapper which calls a function as soon as the

--- a/transfer/custom.go
+++ b/transfer/custom.go
@@ -319,7 +319,7 @@ func (a *customAdapter) DoTransfer(ctx interface{}, t *Transfer, cb TransferProg
 					return fmt.Errorf("Failed to copy downloaded file: %v", err)
 				}
 			} else if a.direction == Upload {
-				if err = api.VerifyUpload(t.Object); err != nil {
+				if err = api.VerifyUpload(config.Config, t.Object); err != nil {
 					return err
 				}
 			}

--- a/transfer/tus_upload.go
+++ b/transfer/tus_upload.go
@@ -153,7 +153,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb TransferP
 	io.Copy(ioutil.Discard, res.Body)
 	res.Body.Close()
 
-	return api.VerifyUpload(t.Object)
+	return api.VerifyUpload(config.Config, t.Object)
 }
 
 func init() {


### PR DESCRIPTION
This pull request removes mutable `.gitconfig` behavior from the `api`, `lfs`, and `httputil` packages. Most of the work involved here is removing calls to `SetConfig` and `ResetConfig`, and also threading an instance of `*config.Configuration` through the `api` package instead of falling back to the `config.Config` global.

To retain the same behavior outside of the tests, the `api` package did gain a few references to `config.Config`, but this is a temporary measure until we remove that package entirely for v2.0. Alternatively, package `api` could own its own private instance of `*config.Configuration`, but I think that's outside the scope of this PR.

Next (and last!) up is the `transfer` package. This requires a little bit more of a fundamental change than just removing calls. The `transfer` package maintains package-global state that is involved with the `config.Config` singleton, so splitting that up is going to be tricky, but doable.

-

/cc @technoweenie @rubyist @sinbad 