### PR TITLE
config-next: ensure .gitconfig is loaded before Unmarshal call

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -131,6 +131,8 @@ func NewFrom(v Values) *Configuration {
 // Otherwise, the field will be set to the value of calling the
 // appropriately-typed method on the specified environment.
 func (c *Configuration) Unmarshal(v interface{}) error {
+	c.loadGitConfig()
+
 	into := reflect.ValueOf(v)
 	if into.Kind() != reflect.Ptr {
 		return fmt.Errorf("lfs/config: unable to parse non-pointer type of %T", v)


### PR DESCRIPTION
This pull request ensures that the `.gitconfig` is loaded before calling `Unmarshal()`.

Previously, the `.gitconfig` would go unloaded causing [this](https://github.com/github/git-lfs/blob/1845c0bf9c3b77c52484ee4e7f9b15f7eab6edce/config/config.go#L196) line to return a `nil` `*Environment`, causing `Unmarshal` to skip its operation on that field per [this](https://github.com/github/git-lfs/blob/1845c0bf9c3b77c52484ee4e7f9b15f7eab6edce/config/config.go#L151-L153) block.

The reason that this wasn't caught before is that it was only being tested by `config.NewFrom()`, which uses the `mapFetcher` implementation, instead of doing actual `.gitconfig` parsing. I don't think it's needed to add a test guarding this behavior, since the `New` constructor should be simplified shortly.

-

/cc @technoweenie @rubyist @sinbad 