### PR TITLE
config-next: use `Unmarshal` to fill out `FetchPruneConfig`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,21 +28,21 @@ var (
 type FetchPruneConfig struct {
 	// The number of days prior to current date for which (local) refs other than HEAD
 	// will be fetched with --recent (default 7, 0 = only fetch HEAD)
-	FetchRecentRefsDays int
+	FetchRecentRefsDays int `git:"lfs.fetchrecentrefsdays"`
 	// Makes the FetchRecentRefsDays option apply to remote refs from fetch source as well (default true)
-	FetchRecentRefsIncludeRemotes bool
+	FetchRecentRefsIncludeRemotes bool `git:"lfs.fetchrecentremoterefs"`
 	// number of days prior to latest commit on a ref that we'll fetch previous
 	// LFS changes too (default 0 = only fetch at ref)
-	FetchRecentCommitsDays int
+	FetchRecentCommitsDays int `git:"lfs.fetchrecentcommitsdays"`
 	// Whether to always fetch recent even without --recent
-	FetchRecentAlways bool
+	FetchRecentAlways bool `git:"lfs.fetchrecentalways"`
 	// Number of days added to FetchRecent*; data outside combined window will be
 	// deleted when prune is run. (default 3)
-	PruneOffsetDays int
+	PruneOffsetDays int `git:"lfs.pruneoffsetdays"`
 	// Always verify with remote before pruning
-	PruneVerifyRemoteAlways bool
+	PruneVerifyRemoteAlways bool `git:"lfs.pruneverifyremotealways"`
 	// Name of remote to check for unpushed and verify checks
-	PruneRemoteName string
+	PruneRemoteName string `git:"lfs.pruneremotetocheck"`
 }
 
 type Configuration struct {
@@ -450,21 +450,18 @@ func (c *Configuration) AllGitConfig() map[string]string {
 	return c.gitConfig
 }
 
-func (c *Configuration) FetchPruneConfig() (fetchconf FetchPruneConfig) {
-	fetchconf.FetchRecentRefsDays = c.GitConfigInt("lfs.fetchrecentrefsdays", 7)
-	fetchconf.FetchRecentRefsIncludeRemotes = c.GitConfigBool("lfs.fetchrecentremoterefs", true)
-	fetchconf.FetchRecentCommitsDays = c.GitConfigInt("lfs.fetchrecentcommitsdays", 0)
-	fetchconf.FetchRecentAlways = c.GitConfigBool("lfs.fetchrecentalways", false)
-	fetchconf.PruneOffsetDays = c.GitConfigInt("lfs.pruneoffsetdays", 3)
-	fetchconf.PruneVerifyRemoteAlways = c.GitConfigBool("lfs.pruneverifyremotealways", false)
-
-	if v, ok := c.GitConfig("lfs.pruneremotetocheck"); ok {
-		fetchconf.PruneRemoteName = v
-	} else {
-		fetchconf.PruneRemoteName = "origin"
+func (c *Configuration) FetchPruneConfig() FetchPruneConfig {
+	f := &FetchPruneConfig{
+		FetchRecentRefsDays:           7,
+		FetchRecentRefsIncludeRemotes: true,
+		PruneOffsetDays:               3,
+		PruneRemoteName:               "origin",
 	}
 
-	return fetchconf
+	if err := c.Unmarshal(f); err != nil {
+		panic(err.Error())
+	}
+	return *f
 }
 
 func (c *Configuration) SkipDownloadErrors() bool {

--- a/config/config.go
+++ b/config/config.go
@@ -131,6 +131,8 @@ func NewFrom(v Values) *Configuration {
 // Otherwise, the field will be set to the value of calling the
 // appropriately-typed method on the specified environment.
 func (c *Configuration) Unmarshal(v interface{}) error {
+	c.loadGitConfig()
+
 	into := reflect.ValueOf(v)
 	if into.Kind() != reflect.Ptr {
 		return fmt.Errorf("lfs/config: unable to parse non-pointer type of %T", v)


### PR DESCRIPTION
❗ The relevant diff is contained in: [`config-next-load-unmarshal..config-next-fetch-unmarshal`](https://github.com/github/git-lfs/compare/config-next-load-unmarshal...config-next-fetch-unmarshal).

-

This pull request uses the new `Unmarshal(v interface{}) error` function to fill out the result of calling `FetchPruneConfig`.

It adds the relevant `git:"lfs.foo"` tags to the `FetchPruneConfig` type definition, and sets the defaults during the struct initialization. Currently, it `panic`s on any errors being returned from `Unmarshal`, but those errors are all internal, and the presence of one would indicate a state wherein LFS is not able to function properly (thus they are panic-able).

-

/cc @technoweenie @rubyist @sinbad 