### PR TITLE
Command var scope

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -165,6 +165,8 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 
 	// As files come in, write them to the wd and update the index
 
+	manifest := TransferManifest()
+
 	for pointer := range in {
 
 		// Check the content - either missing or still this pointer (not exist is ok)
@@ -187,7 +189,7 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 		repopathchan <- pointer.Name
 		cwdfilepath := <-cwdpathchan
 
-		err = lfs.PointerSmudgeToFile(cwdfilepath, pointer.Pointer, false, transfermanifest, nil)
+		err = lfs.PointerSmudgeToFile(cwdfilepath, pointer.Pointer, false, manifest, nil)
 		if err != nil {
 			if errutil.IsDownloadDeclinedError(err) {
 				// acceptable error, data not local (fetch not run or include/exclude)

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -16,13 +16,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	checkoutCmd = &cobra.Command{
-		Use: "checkout",
-		Run: checkoutCommand,
-	}
-)
-
 func checkoutCommand(cmd *cobra.Command, args []string) {
 	requireInRepo()
 
@@ -41,10 +34,6 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 	}
 	close(inchan)
 	checkoutWithIncludeExclude(rootedpaths, nil)
-}
-
-func init() {
-	RootCmd.AddCommand(checkoutCmd)
 }
 
 // Checkout from items reported from the fetch process (in parallel)
@@ -238,4 +227,13 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 			LoggedError(err, "Error updating the git index:\n%s", updateIdxOut.String())
 		}
 	}
+}
+
+func init() {
+	RegisterSubcommand(func() *cobra.Command {
+		return &cobra.Command{
+			Use: "checkout",
+			Run: checkoutCommand,
+		}
+	})
 }

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -11,7 +11,6 @@ import (
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/progress"
-	"github.com/github/git-lfs/transfer"
 	"github.com/rubyist/tracerx"
 	"github.com/spf13/cobra"
 )
@@ -166,8 +165,6 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 
 	// As files come in, write them to the wd and update the index
 
-	manifest := transfer.ConfigureManifest(transfer.NewManifest(), cfg)
-
 	for pointer := range in {
 
 		// Check the content - either missing or still this pointer (not exist is ok)
@@ -190,7 +187,7 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 		repopathchan <- pointer.Name
 		cwdfilepath := <-cwdpathchan
 
-		err = lfs.PointerSmudgeToFile(cwdfilepath, pointer.Pointer, false, manifest, nil)
+		err = lfs.PointerSmudgeToFile(cwdfilepath, pointer.Pointer, false, transfermanifest, nil)
 		if err != nil {
 			if errutil.IsDownloadDeclinedError(err) {
 				// acceptable error, data not local (fetch not run or include/exclude)

--- a/commands/command_clean.go
+++ b/commands/command_clean.go
@@ -9,13 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	cleanCmd = &cobra.Command{
-		Use: "clean",
-		Run: cleanCommand,
-	}
-)
-
 func cleanCommand(cmd *cobra.Command, args []string) {
 	requireStdin("This command should be run by the Git 'clean' filter")
 	lfs.InstallHooks(false)
@@ -82,5 +75,10 @@ func cleanCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RootCmd.AddCommand(cleanCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		return &cobra.Command{
+			Use: "clean",
+			Run: cleanCommand,
+		}
+	})
 }

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -15,11 +15,6 @@ import (
 )
 
 var (
-	cloneCmd = &cobra.Command{
-		Use: "clone",
-		Run: cloneCommand,
-	}
-
 	cloneFlags git.CloneFlags
 )
 
@@ -112,34 +107,40 @@ func postCloneSubmodules(args []string) error {
 }
 
 func init() {
-	// Mirror all git clone flags
-	cloneCmd.Flags().StringVarP(&cloneFlags.TemplateDirectory, "template", "", "", "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.Local, "local", "l", false, "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.Shared, "shared", "s", false, "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.NoHardlinks, "no-hardlinks", "", false, "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.Quiet, "quiet", "q", false, "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.NoCheckout, "no-checkout", "n", false, "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.Progress, "progress", "", false, "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.Bare, "bare", "", false, "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.Mirror, "mirror", "", false, "See 'git clone --help'")
-	cloneCmd.Flags().StringVarP(&cloneFlags.Origin, "origin", "o", "", "See 'git clone --help'")
-	cloneCmd.Flags().StringVarP(&cloneFlags.Branch, "branch", "b", "", "See 'git clone --help'")
-	cloneCmd.Flags().StringVarP(&cloneFlags.Upload, "upload-pack", "u", "", "See 'git clone --help'")
-	cloneCmd.Flags().StringVarP(&cloneFlags.Reference, "reference", "", "", "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.Dissociate, "dissociate", "", false, "See 'git clone --help'")
-	cloneCmd.Flags().StringVarP(&cloneFlags.SeparateGit, "separate-git-dir", "", "", "See 'git clone --help'")
-	cloneCmd.Flags().StringVarP(&cloneFlags.Depth, "depth", "", "", "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.Recursive, "recursive", "", false, "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.RecurseSubmodules, "recurse-submodules", "", false, "See 'git clone --help'")
-	cloneCmd.Flags().StringVarP(&cloneFlags.Config, "config", "c", "", "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.SingleBranch, "single-branch", "", false, "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.NoSingleBranch, "no-single-branch", "", false, "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.Verbose, "verbose", "", false, "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.Ipv4, "ipv4", "", false, "See 'git clone --help'")
-	cloneCmd.Flags().BoolVarP(&cloneFlags.Ipv6, "ipv6", "", false, "See 'git clone --help'")
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "clone",
+			Run: cloneCommand,
+		}
 
-	cloneCmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
-	cloneCmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
+		// Mirror all git clone flags
+		cmd.Flags().StringVarP(&cloneFlags.TemplateDirectory, "template", "", "", "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.Local, "local", "l", false, "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.Shared, "shared", "s", false, "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.NoHardlinks, "no-hardlinks", "", false, "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.Quiet, "quiet", "q", false, "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.NoCheckout, "no-checkout", "n", false, "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.Progress, "progress", "", false, "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.Bare, "bare", "", false, "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.Mirror, "mirror", "", false, "See 'git clone --help'")
+		cmd.Flags().StringVarP(&cloneFlags.Origin, "origin", "o", "", "See 'git clone --help'")
+		cmd.Flags().StringVarP(&cloneFlags.Branch, "branch", "b", "", "See 'git clone --help'")
+		cmd.Flags().StringVarP(&cloneFlags.Upload, "upload-pack", "u", "", "See 'git clone --help'")
+		cmd.Flags().StringVarP(&cloneFlags.Reference, "reference", "", "", "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.Dissociate, "dissociate", "", false, "See 'git clone --help'")
+		cmd.Flags().StringVarP(&cloneFlags.SeparateGit, "separate-git-dir", "", "", "See 'git clone --help'")
+		cmd.Flags().StringVarP(&cloneFlags.Depth, "depth", "", "", "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.Recursive, "recursive", "", false, "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.RecurseSubmodules, "recurse-submodules", "", false, "See 'git clone --help'")
+		cmd.Flags().StringVarP(&cloneFlags.Config, "config", "c", "", "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.SingleBranch, "single-branch", "", false, "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.NoSingleBranch, "no-single-branch", "", false, "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.Verbose, "verbose", "", false, "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.Ipv4, "ipv4", "", false, "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.Ipv6, "ipv6", "", false, "See 'git clone --help'")
 
-	RootCmd.AddCommand(cloneCmd)
+		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
+		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
+		return cmd
+	})
 }

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -35,7 +35,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	for _, env := range lfs.Environ(cfg, transfermanifest) {
+	for _, env := range lfs.Environ(cfg, TransferManifest()) {
 		Print(env)
 	}
 

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -7,13 +7,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	envCmd = &cobra.Command{
-		Use: "env",
-		Run: envCommand,
-	}
-)
-
 func envCommand(cmd *cobra.Command, args []string) {
 	config.ShowConfigWarnings = true
 	endpoint := cfg.Endpoint("download")
@@ -53,5 +46,10 @@ func envCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RootCmd.AddCommand(envCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		return &cobra.Command{
+			Use: "env",
+			Run: envCommand,
+		}
+	})
 }

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -35,7 +35,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	for _, env := range lfs.Environ() {
+	for _, env := range lfs.Environ(cfg, transfermanifest) {
 		Print(env)
 	}
 

--- a/commands/command_ext.go
+++ b/commands/command_ext.go
@@ -7,19 +7,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	extCmd = &cobra.Command{
-		Use: "ext",
-		Run: extCommand,
-	}
-
-	extListCmd = &cobra.Command{
-		Use:   "list",
-		Short: "View details for specified extensions",
-		Run:   extListCommand,
-	}
-)
-
 func extCommand(cmd *cobra.Command, args []string) {
 	printAllExts()
 }
@@ -56,6 +43,17 @@ func printExt(ext config.Extension) {
 }
 
 func init() {
-	extCmd.AddCommand(extListCmd)
-	RootCmd.AddCommand(extCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "ext",
+			Run: extCommand,
+		}
+
+		cmd.AddCommand(&cobra.Command{
+			Use:   "list",
+			Short: "View details for specified extensions",
+			Run:   extListCommand,
+		})
+		return cmd
+	})
 }

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -12,10 +12,6 @@ import (
 )
 
 var (
-	fetchCmd = &cobra.Command{
-		Use: "fetch",
-		Run: fetchCommand,
-	}
 	fetchRecentArg bool
 	fetchAllArg    bool
 	fetchPruneArg  bool
@@ -109,15 +105,6 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 	if !success {
 		Exit("Warning: errors occurred")
 	}
-}
-
-func init() {
-	fetchCmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
-	fetchCmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
-	fetchCmd.Flags().BoolVarP(&fetchRecentArg, "recent", "r", false, "Fetch recent refs & commits")
-	fetchCmd.Flags().BoolVarP(&fetchAllArg, "all", "a", false, "Fetch all LFS files ever referenced")
-	fetchCmd.Flags().BoolVarP(&fetchPruneArg, "prune", "p", false, "After fetching, prune old data")
-	RootCmd.AddCommand(fetchCmd)
 }
 
 func pointersToFetchForRef(ref string) ([]*lfs.WrappedPointer, error) {
@@ -329,4 +316,20 @@ func fetchAndReportToChan(pointers []*lfs.WrappedPointer, include, exclude []str
 		ExitWithError(err)
 	}
 	return ok
+}
+
+func init() {
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "fetch",
+			Run: fetchCommand,
+		}
+
+		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
+		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
+		cmd.Flags().BoolVarP(&fetchRecentArg, "recent", "r", false, "Fetch recent refs & commits")
+		cmd.Flags().BoolVarP(&fetchAllArg, "all", "a", false, "Fetch all LFS files ever referenced")
+		cmd.Flags().BoolVarP(&fetchPruneArg, "prune", "p", false, "After fetching, prune old data")
+		return cmd
+	})
 }

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -15,11 +15,6 @@ import (
 
 var (
 	fsckDryRun bool
-
-	fsckCmd = &cobra.Command{
-		Use: "fsck",
-		Run: fsckCommand,
-	}
 )
 
 func doFsck() (bool, error) {
@@ -120,6 +115,13 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	fsckCmd.Flags().BoolVarP(&fsckDryRun, "dry-run", "d", false, "List corrupt objects without deleting them.")
-	RootCmd.AddCommand(fsckCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "fsck",
+			Run: fsckCommand,
+		}
+
+		cmd.Flags().BoolVarP(&fsckDryRun, "dry-run", "d", false, "List corrupt objects without deleting them.")
+		return cmd
+	})
 }

--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -8,19 +8,6 @@ import (
 )
 
 // TODO: Remove for Git LFS v2.0 https://github.com/github/git-lfs/issues/839
-
-var (
-	initCmd = &cobra.Command{
-		Use: "init",
-		Run: initCommand,
-	}
-
-	initHooksCmd = &cobra.Command{
-		Use: "hooks",
-		Run: initHooksCommand,
-	}
-)
-
 func initCommand(cmd *cobra.Command, args []string) {
 	fmt.Fprintf(os.Stderr, "WARNING: 'git lfs init' is deprecated. Use 'git lfs install' now.\n")
 	installCommand(cmd, args)
@@ -32,9 +19,19 @@ func initHooksCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	initCmd.Flags().BoolVarP(&forceInstall, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
-	initCmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
-	initCmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
-	initCmd.AddCommand(initHooksCmd)
-	RootCmd.AddCommand(initCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "init",
+			Run: initCommand,
+		}
+
+		cmd.Flags().BoolVarP(&forceInstall, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
+		cmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
+		cmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
+		cmd.AddCommand(&cobra.Command{
+			Use: "hooks",
+			Run: initHooksCommand,
+		})
+		return cmd
+	})
 }

--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -6,16 +6,6 @@ import (
 )
 
 var (
-	installCmd = &cobra.Command{
-		Use: "install",
-		Run: installCommand,
-	}
-
-	installHooksCmd = &cobra.Command{
-		Use: "hooks",
-		Run: installHooksCommand,
-	}
-
 	forceInstall      = false
 	localInstall      = false
 	skipSmudgeInstall = false
@@ -50,9 +40,19 @@ func installHooksCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	installCmd.Flags().BoolVarP(&forceInstall, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
-	installCmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
-	installCmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
-	installCmd.AddCommand(installHooksCmd)
-	RootCmd.AddCommand(installCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "install",
+			Run: installCommand,
+		}
+
+		cmd.Flags().BoolVarP(&forceInstall, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
+		cmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
+		cmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
+		cmd.AddCommand(&cobra.Command{
+			Use: "hooks",
+			Run: installHooksCommand,
+		})
+		return cmd
+	})
 }

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -22,11 +22,6 @@ var (
 	setLockRemoteFor = func(c *config.Configuration) {
 		c.CurrentRemote = lockRemote
 	}
-
-	lockCmd = &cobra.Command{
-		Use: "lock",
-		Run: lockCommand,
-	}
 )
 
 func lockCommand(cmd *cobra.Command, args []string) {
@@ -107,9 +102,17 @@ func lockPath(file string) (string, error) {
 }
 
 func init() {
-	lockCmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
+	RegisterSubcommand(func() *cobra.Command {
+		if !isCommandEnabled(cfg, "locks") {
+			return nil
+		}
 
-	if isCommandEnabled(cfg, "locks") {
-		RootCmd.AddCommand(lockCmd)
-	}
+		cmd := &cobra.Command{
+			Use: "lock",
+			Run: lockCommand,
+		}
+
+		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
+		return cmd
+	})
 }

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -7,10 +7,6 @@ import (
 
 var (
 	locksCmdFlags = new(locksFlags)
-	locksCmd      = &cobra.Command{
-		Use: "locks",
-		Run: locksCommand,
-	}
 )
 
 func locksCommand(cmd *cobra.Command, args []string) {
@@ -55,18 +51,6 @@ func locksCommand(cmd *cobra.Command, args []string) {
 	}
 }
 
-func init() {
-	locksCmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
-
-	locksCmd.Flags().StringVarP(&locksCmdFlags.Path, "path", "p", "", "filter locks results matching a particular path")
-	locksCmd.Flags().StringVarP(&locksCmdFlags.Id, "id", "i", "", "filter locks results matching a particular ID")
-	locksCmd.Flags().IntVarP(&locksCmdFlags.Limit, "limit", "l", 0, "optional limit for number of results to return")
-
-	if isCommandEnabled(cfg, "locks") {
-		RootCmd.AddCommand(locksCmd)
-	}
-}
-
 // locksFlags wraps up and holds all of the flags that can be given to the
 // `git lfs locks` command.
 type locksFlags struct {
@@ -100,4 +84,22 @@ func (l *locksFlags) Filters() ([]api.Filter, error) {
 	}
 
 	return filters, nil
+}
+
+func init() {
+	RegisterSubcommand(func() *cobra.Command {
+		if !isCommandEnabled(cfg, "locks") {
+			return nil
+		}
+		cmd := &cobra.Command{
+			Use: "locks",
+			Run: locksCommand,
+		}
+
+		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
+		cmd.Flags().StringVarP(&locksCmdFlags.Path, "path", "p", "", "filter locks results matching a particular path")
+		cmd.Flags().StringVarP(&locksCmdFlags.Id, "id", "i", "", "filter locks results matching a particular ID")
+		cmd.Flags().IntVarP(&locksCmdFlags.Limit, "limit", "l", 0, "optional limit for number of results to return")
+		return cmd
+	})
 }

--- a/commands/command_logs.go
+++ b/commands/command_logs.go
@@ -11,33 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	logsCmd = &cobra.Command{
-		Use: "logs",
-		Run: logsCommand,
-	}
-
-	logsLastCmd = &cobra.Command{
-		Use: "last",
-		Run: logsLastCommand,
-	}
-
-	logsShowCmd = &cobra.Command{
-		Use: "show",
-		Run: logsShowCommand,
-	}
-
-	logsClearCmd = &cobra.Command{
-		Use: "clear",
-		Run: logsClearCommand,
-	}
-
-	logsBoomtownCmd = &cobra.Command{
-		Use: "boomtown",
-		Run: logsBoomtownCommand,
-	}
-)
-
 func logsCommand(cmd *cobra.Command, args []string) {
 	for _, path := range sortedLogs() {
 		Print(path)
@@ -104,6 +77,30 @@ func sortedLogs() []string {
 }
 
 func init() {
-	logsCmd.AddCommand(logsLastCmd, logsShowCmd, logsClearCmd, logsBoomtownCmd)
-	RootCmd.AddCommand(logsCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "logs",
+			Run: logsCommand,
+		}
+
+		cmd.AddCommand(
+			&cobra.Command{
+				Use: "last",
+				Run: logsLastCommand,
+			},
+			&cobra.Command{
+				Use: "show",
+				Run: logsShowCommand,
+			},
+			&cobra.Command{
+				Use: "clear",
+				Run: logsClearCommand,
+			},
+			&cobra.Command{
+				Use: "boomtown",
+				Run: logsBoomtownCommand,
+			},
+		)
+		return cmd
+	})
 }

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -9,11 +9,7 @@ import (
 )
 
 var (
-	longOIDs   = false
-	lsFilesCmd = &cobra.Command{
-		Use: "ls-files",
-		Run: lsFilesCommand,
-	}
+	longOIDs = false
 )
 
 func lsFilesCommand(cmd *cobra.Command, args []string) {
@@ -57,6 +53,13 @@ func lsFilesMarker(p *lfs.WrappedPointer) string {
 }
 
 func init() {
-	lsFilesCmd.Flags().BoolVarP(&longOIDs, "long", "l", false, "")
-	RootCmd.AddCommand(lsFilesCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "ls-files",
+			Run: lsFilesCommand,
+		}
+
+		cmd.Flags().BoolVarP(&longOIDs, "long", "l", false, "")
+		return cmd
+	})
 }

--- a/commands/command_pointer.go
+++ b/commands/command_pointer.go
@@ -18,10 +18,6 @@ var (
 	pointerFile    string
 	pointerCompare string
 	pointerStdin   bool
-	pointerCmd     = &cobra.Command{
-		Use: "pointer",
-		Run: pointerCommand,
-	}
 )
 
 func pointerCommand(cmd *cobra.Command, args []string) {
@@ -133,9 +129,15 @@ func gitHashObject(by []byte) string {
 }
 
 func init() {
-	flags := pointerCmd.Flags()
-	flags.StringVarP(&pointerFile, "file", "f", "", "Path to a local file to generate the pointer from.")
-	flags.StringVarP(&pointerCompare, "pointer", "p", "", "Path to a local file containing a pointer built by another Git LFS implementation.")
-	flags.BoolVarP(&pointerStdin, "stdin", "", false, "Read a pointer built by another Git LFS implementation through STDIN.")
-	RootCmd.AddCommand(pointerCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "pointer",
+			Run: pointerCommand,
+		}
+
+		cmd.Flags().StringVarP(&pointerFile, "file", "f", "", "Path to a local file to generate the pointer from.")
+		cmd.Flags().StringVarP(&pointerCompare, "pointer", "p", "", "Path to a local file containing a pointer built by another Git LFS implementation.")
+		cmd.Flags().BoolVarP(&pointerStdin, "stdin", "", false, "Read a pointer built by another Git LFS implementation through STDIN.")
+		return cmd
+	})
 }

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -11,10 +11,6 @@ import (
 )
 
 var (
-	prePushCmd = &cobra.Command{
-		Use: "pre-push",
-		Run: prePushCommand,
-	}
 	prePushDryRun       = false
 	prePushDeleteBranch = strings.Repeat("0", 40)
 )
@@ -100,6 +96,13 @@ func decodeRefs(input string) (string, string) {
 }
 
 func init() {
-	prePushCmd.Flags().BoolVarP(&prePushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")
-	RootCmd.AddCommand(prePushCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "pre-push",
+			Run: prePushCommand,
+		}
+
+		cmd.Flags().BoolVarP(&prePushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")
+		return cmd
+	})
 }

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -18,11 +18,6 @@ import (
 )
 
 var (
-	pruneCmd = &cobra.Command{
-		Use:   "prune",
-		Short: "Deletes old LFS files from the local store",
-		Run:   pruneCommand,
-	}
 	pruneDryRunArg      bool
 	pruneVerboseArg     bool
 	pruneVerifyArg      bool
@@ -479,9 +474,17 @@ func pruneTaskGetReachableObjects(outObjectSet *tools.StringSet, errorChan chan 
 }
 
 func init() {
-	pruneCmd.Flags().BoolVarP(&pruneDryRunArg, "dry-run", "d", false, "Don't delete anything, just report")
-	pruneCmd.Flags().BoolVarP(&pruneVerboseArg, "verbose", "v", false, "Print full details of what is/would be deleted")
-	pruneCmd.Flags().BoolVarP(&pruneVerifyArg, "verify-remote", "c", false, "Verify that remote has LFS files before deleting")
-	pruneCmd.Flags().BoolVar(&pruneDoNotVerifyArg, "no-verify-remote", false, "Override lfs.pruneverifyremotealways and don't verify")
-	RootCmd.AddCommand(pruneCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use:   "prune",
+			Short: "Deletes old LFS files from the local store",
+			Run:   pruneCommand,
+		}
+
+		cmd.Flags().BoolVarP(&pruneDryRunArg, "dry-run", "d", false, "Don't delete anything, just report")
+		cmd.Flags().BoolVarP(&pruneVerboseArg, "verbose", "v", false, "Print full details of what is/would be deleted")
+		cmd.Flags().BoolVarP(&pruneVerifyArg, "verify-remote", "c", false, "Verify that remote has LFS files before deleting")
+		cmd.Flags().BoolVar(&pruneDoNotVerifyArg, "no-verify-remote", false, "Override lfs.pruneverifyremotealways and don't verify")
+		return cmd
+	})
 }

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -7,13 +7,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	pullCmd = &cobra.Command{
-		Use: "pull",
-		Run: pullCommand,
-	}
-)
-
 func pullCommand(cmd *cobra.Command, args []string) {
 	requireInRepo()
 
@@ -50,7 +43,14 @@ func pull(includePaths, excludePaths []string) {
 }
 
 func init() {
-	pullCmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
-	pullCmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
-	RootCmd.AddCommand(pullCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "pull",
+			Run: pullCommand,
+		}
+
+		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
+		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
+		return cmd
+	})
 }

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -11,10 +11,6 @@ import (
 )
 
 var (
-	pushCmd = &cobra.Command{
-		Use: "push",
-		Run: pushCommand,
-	}
 	pushDryRun    = false
 	pushObjectIDs = false
 	pushAll       = false
@@ -165,10 +161,16 @@ func pushCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	pushCmd.Flags().BoolVarP(&pushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")
-	pushCmd.Flags().BoolVarP(&useStdin, "stdin", "s", false, "Take refs on stdin (for pre-push hook)")
-	pushCmd.Flags().BoolVarP(&pushObjectIDs, "object-id", "o", false, "Push LFS object ID(s)")
-	pushCmd.Flags().BoolVarP(&pushAll, "all", "a", false, "Push all objects for the current ref to the remote.")
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "push",
+			Run: pushCommand,
+		}
 
-	RootCmd.AddCommand(pushCmd)
+		cmd.Flags().BoolVarP(&pushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")
+		cmd.Flags().BoolVarP(&useStdin, "stdin", "s", false, "Take refs on stdin (for pre-push hook)")
+		cmd.Flags().BoolVarP(&pushObjectIDs, "object-id", "o", false, "Push LFS object ID(s)")
+		cmd.Flags().BoolVarP(&pushAll, "all", "a", false, "Push all objects for the current ref to the remote.")
+		return cmd
+	})
 }

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -63,7 +63,7 @@ func smudgeCommand(cmd *cobra.Command, args []string) {
 		download = false
 	}
 
-	err = ptr.Smudge(os.Stdout, filename, download, transfermanifest, cb)
+	err = ptr.Smudge(os.Stdout, filename, download, TransferManifest(), cb)
 	if file != nil {
 		file.Close()
 	}

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -15,10 +15,6 @@ import (
 var (
 	smudgeInfo = false
 	smudgeSkip = false
-	smudgeCmd  = &cobra.Command{
-		Use: "smudge",
-		Run: smudgeCommand,
-	}
 )
 
 func smudgeCommand(cmd *cobra.Command, args []string) {
@@ -99,8 +95,14 @@ func smudgeFilename(args []string, err error) string {
 }
 
 func init() {
-	// update man page
-	smudgeCmd.Flags().BoolVarP(&smudgeInfo, "info", "i", false, "")
-	smudgeCmd.Flags().BoolVarP(&smudgeSkip, "skip", "s", false, "")
-	RootCmd.AddCommand(smudgeCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "smudge",
+			Run: smudgeCommand,
+		}
+
+		cmd.Flags().BoolVarP(&smudgeInfo, "info", "i", false, "")
+		cmd.Flags().BoolVarP(&smudgeSkip, "skip", "s", false, "")
+		return cmd
+	})
 }

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/github/git-lfs/errutil"
 	"github.com/github/git-lfs/lfs"
-	"github.com/github/git-lfs/transfer"
 	"github.com/spf13/cobra"
 )
 
@@ -64,8 +63,7 @@ func smudgeCommand(cmd *cobra.Command, args []string) {
 		download = false
 	}
 
-	manifest := transfer.ConfigureManifest(transfer.NewManifest(), cfg)
-	err = ptr.Smudge(os.Stdout, filename, download, manifest, cb)
+	err = ptr.Smudge(os.Stdout, filename, download, transfermanifest, cb)
 	if file != nil {
 		file.Close()
 	}

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -9,10 +9,6 @@ import (
 )
 
 var (
-	statusCmd = &cobra.Command{
-		Use: "status",
-		Run: statusCommand,
-	}
 	porcelain = false
 )
 
@@ -101,6 +97,13 @@ func humanizeBytes(bytes int64) string {
 }
 
 func init() {
-	statusCmd.Flags().BoolVarP(&porcelain, "porcelain", "p", false, "Give the output in an easy-to-parse format for scripts.")
-	RootCmd.AddCommand(statusCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "status",
+			Run: statusCommand,
+		}
+
+		cmd.Flags().BoolVarP(&porcelain, "porcelain", "p", false, "Give the output in an easy-to-parse format for scripts.")
+		return cmd
+	})
 }

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -21,11 +21,6 @@ var (
 		".git", ".lfs",
 	}
 
-	trackCmd = &cobra.Command{
-		Use: "track",
-		Run: trackCommand,
-	}
-
 	trackVerboseLoggingFlag bool
 	trackDryRunFlag         bool
 )
@@ -234,8 +229,14 @@ func blocklistItem(name string) string {
 }
 
 func init() {
-	trackCmd.Flags().BoolVarP(&trackVerboseLoggingFlag, "verbose", "v", false, "log which files are being tracked and modified")
-	trackCmd.Flags().BoolVarP(&trackDryRunFlag, "dry-run", "d", false, "preview results of running `git lfs track`")
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "track",
+			Run: trackCommand,
+		}
 
-	RootCmd.AddCommand(trackCmd)
+		cmd.Flags().BoolVarP(&trackVerboseLoggingFlag, "verbose", "v", false, "log which files are being tracked and modified")
+		cmd.Flags().BoolVarP(&trackDryRunFlag, "dry-run", "d", false, "preview results of running `git lfs track`")
+		return cmd
+	})
 }

--- a/commands/command_uninit.go
+++ b/commands/command_uninit.go
@@ -9,31 +9,29 @@ import (
 
 // TODO: Remove for Git LFS v2.0 https://github.com/github/git-lfs/issues/839
 
-var (
-	// uninitCmd removes any configuration and hooks set by Git LFS.
-	uninitCmd = &cobra.Command{
-		Use: "uninit",
-		Run: uninitCommand,
-	}
-
-	// uninitHooksCmd removes any hooks created by Git LFS.
-	uninitHooksCmd = &cobra.Command{
-		Use: "hooks",
-		Run: uninitHooksCommand,
-	}
-)
-
+// uninitCmd removes any configuration and hooks set by Git LFS.
 func uninitCommand(cmd *cobra.Command, args []string) {
 	fmt.Fprintf(os.Stderr, "WARNING: 'git lfs uninit' is deprecated. Use 'git lfs uninstall' now.\n")
 	uninstallCommand(cmd, args)
 }
 
+// uninitHooksCmd removes any hooks created by Git LFS.
 func uninitHooksCommand(cmd *cobra.Command, args []string) {
 	fmt.Fprintf(os.Stderr, "WARNING: 'git lfs uninit' is deprecated. Use 'git lfs uninstall' now.\n")
 	uninstallHooksCommand(cmd, args)
 }
 
 func init() {
-	uninitCmd.AddCommand(uninitHooksCmd)
-	RootCmd.AddCommand(uninitCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "uninit",
+			Run: uninitCommand,
+		}
+
+		cmd.AddCommand(&cobra.Command{
+			Use: "hooks",
+			Run: uninitHooksCommand,
+		})
+		return cmd
+	})
 }

--- a/commands/command_uninstall.go
+++ b/commands/command_uninstall.go
@@ -5,20 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	// uninstallCmd removes any configuration and hooks set by Git LFS.
-	uninstallCmd = &cobra.Command{
-		Use: "uninstall",
-		Run: uninstallCommand,
-	}
-
-	// uninstallHooksCmd removes any hooks created by Git LFS.
-	uninstallHooksCmd = &cobra.Command{
-		Use: "hooks",
-		Run: uninstallHooksCommand,
-	}
-)
-
+// uninstallCmd removes any configuration and hooks set by Git LFS.
 func uninstallCommand(cmd *cobra.Command, args []string) {
 	if err := lfs.UninstallFilters(); err != nil {
 		Error(err.Error())
@@ -31,6 +18,7 @@ func uninstallCommand(cmd *cobra.Command, args []string) {
 	}
 }
 
+// uninstallHooksCmd removes any hooks created by Git LFS.
 func uninstallHooksCommand(cmd *cobra.Command, args []string) {
 	if err := lfs.UninstallHooks(); err != nil {
 		Error(err.Error())
@@ -40,6 +28,16 @@ func uninstallHooksCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	uninstallCmd.AddCommand(uninstallHooksCmd)
-	RootCmd.AddCommand(uninstallCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "uninstall",
+			Run: uninstallCommand,
+		}
+
+		cmd.AddCommand(&cobra.Command{
+			Use: "hooks",
+			Run: uninstallHooksCommand,
+		})
+		return cmd
+	})
 }

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -16,10 +16,6 @@ var (
 	errLockAmbiguous = errors.New("lfs: multiple locks found; ambiguous")
 
 	unlockCmdFlags unlockFlags
-	unlockCmd      = &cobra.Command{
-		Use: "unlock",
-		Run: unlockCommand,
-	}
 )
 
 // unlockFlags holds the flags given to the `git lfs unlock` command
@@ -97,12 +93,19 @@ func lockIdFromPath(path string) (string, error) {
 }
 
 func init() {
-	unlockCmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
+	RegisterSubcommand(func() *cobra.Command {
+		if !isCommandEnabled(cfg, "locks") {
+			return nil
+		}
 
-	unlockCmd.Flags().StringVarP(&unlockCmdFlags.Id, "id", "i", "", "unlock a lock by its ID")
-	unlockCmd.Flags().BoolVarP(&unlockCmdFlags.Force, "force", "f", false, "forcibly break another user's lock(s)")
+		cmd := &cobra.Command{
+			Use: "unlock",
+			Run: unlockCommand,
+		}
 
-	if isCommandEnabled(cfg, "locks") {
-		RootCmd.AddCommand(unlockCmd)
-	}
+		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
+		cmd.Flags().StringVarP(&unlockCmdFlags.Id, "id", "i", "", "unlock a lock by its ID")
+		cmd.Flags().BoolVarP(&unlockCmdFlags.Force, "force", "f", false, "forcibly break another user's lock(s)")
+		return cmd
+	})
 }

--- a/commands/command_untrack.go
+++ b/commands/command_untrack.go
@@ -11,13 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	untrackCmd = &cobra.Command{
-		Use: "untrack",
-		Run: untrackCommand,
-	}
-)
-
 // untrackCommand takes a list of paths as an argument, and removes each path from the
 // default attributes file (.gitattributes), if it exists.
 func untrackCommand(cmd *cobra.Command, args []string) {
@@ -82,5 +75,10 @@ func removePath(path string, args []string) bool {
 }
 
 func init() {
-	RootCmd.AddCommand(untrackCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		return &cobra.Command{
+			Use: "untrack",
+			Run: untrackCommand,
+		}
+	})
 }

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -9,11 +9,6 @@ import (
 )
 
 var (
-	updateCmd = &cobra.Command{
-		Use: "update",
-		Run: updateCommand,
-	}
-
 	updateForce  = false
 	updateManual = false
 )
@@ -59,7 +54,13 @@ func updateCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	updateCmd.Flags().BoolVarP(&updateForce, "force", "f", false, "Overwrite existing hooks.")
-	updateCmd.Flags().BoolVarP(&updateManual, "manual", "m", false, "Print instructions for manual install.")
-	RootCmd.AddCommand(updateCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "update",
+			Run: updateCommand,
+		}
+		cmd.Flags().BoolVarP(&updateForce, "force", "f", false, "Overwrite existing hooks.")
+		cmd.Flags().BoolVarP(&updateManual, "manual", "m", false, "Print instructions for manual install.")
+		return cmd
+	})
 }

--- a/commands/command_version.go
+++ b/commands/command_version.go
@@ -7,11 +7,6 @@ import (
 
 var (
 	lovesComics bool
-
-	versionCmd = &cobra.Command{
-		Use: "version",
-		Run: versionCommand,
-	}
 )
 
 func versionCommand(cmd *cobra.Command, args []string) {
@@ -23,6 +18,13 @@ func versionCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	versionCmd.Flags().BoolVarP(&lovesComics, "comics", "c", false, "easter egg")
-	RootCmd.AddCommand(versionCmd)
+	RegisterSubcommand(func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "version",
+			Run: versionCommand,
+		}
+
+		cmd.Flags().BoolVarP(&lovesComics, "comics", "c", false, "easter egg")
+		return cmd
+	})
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -252,7 +252,7 @@ func logPanicToWriter(w io.Writer, loggedError error) {
 	fmt.Fprintln(w, "\nENV:")
 
 	// log the environment
-	for _, env := range lfs.Environ() {
+	for _, env := range lfs.Environ(cfg, transfermanifest) {
 		fmt.Fprintln(w, env)
 	}
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/github/git-lfs/api"
@@ -18,6 +19,7 @@ import (
 	"github.com/github/git-lfs/httputil"
 	"github.com/github/git-lfs/lfs"
 	"github.com/github/git-lfs/tools"
+	"github.com/github/git-lfs/transfer"
 	"github.com/spf13/cobra"
 )
 
@@ -29,23 +31,53 @@ var (
 	// various command implementations.
 	API = api.NewClient(nil)
 
-	Debugging    = false
-	ErrorBuffer  = &bytes.Buffer{}
-	ErrorWriter  = io.MultiWriter(os.Stderr, ErrorBuffer)
-	OutputWriter = io.MultiWriter(os.Stdout, ErrorBuffer)
-	RootCmd      = &cobra.Command{
+	Debugging        = false
+	ErrorBuffer      = &bytes.Buffer{}
+	ErrorWriter      = io.MultiWriter(os.Stderr, ErrorBuffer)
+	OutputWriter     = io.MultiWriter(os.Stdout, ErrorBuffer)
+	ManPages         = make(map[string]string, 20)
+	cfg              *config.Configuration
+	transfermanifest *transfer.Manifest
+	subcommandFuncs  []func() *cobra.Command
+	subcommandMu     sync.Mutex
+
+	includeArg string
+	excludeArg string
+)
+
+func Run() {
+	cfg = config.Config
+	transfermanifest = transfer.NewManifest()
+	transfer.ConfigureManifest(transfermanifest, cfg)
+
+	root := &cobra.Command{
 		Use: "git-lfs",
 		Run: func(cmd *cobra.Command, args []string) {
 			versionCommand(cmd, args)
 			cmd.Usage()
 		},
 	}
-	ManPages = make(map[string]string, 20)
-	cfg      = config.Config
 
-	includeArg string
-	excludeArg string
-)
+	// Set up help/usage funcs based on manpage text
+	root.SetHelpFunc(help)
+	root.SetHelpTemplate("{{.UsageString}}")
+	root.SetUsageFunc(usage)
+
+	for _, f := range subcommandFuncs {
+		if cmd := f(); cmd != nil {
+			root.AddCommand(cmd)
+		}
+	}
+
+	root.Execute()
+	httputil.LogHttpStats(cfg)
+}
+
+func RegisterSubcommand(fn func() *cobra.Command) {
+	subcommandMu.Lock()
+	subcommandFuncs = append(subcommandFuncs, fn)
+	subcommandMu.Unlock()
+}
 
 // Error prints a formatted message to Stderr.  It also gets printed to the
 // panic log if one is created for this command.
@@ -106,11 +138,6 @@ func LoggedError(err error, format string, args ...interface{}) {
 func Panic(err error, format string, args ...interface{}) {
 	LoggedError(err, format, args...)
 	os.Exit(2)
-}
-
-func Run() {
-	RootCmd.Execute()
-	httputil.LogHttpStats(cfg)
 }
 
 func Cleanup() {
@@ -287,8 +314,4 @@ func isCommandEnabled(cfg *config.Configuration, cmd string) bool {
 
 func init() {
 	log.SetOutput(ErrorWriter)
-	// Set up help/usage funcs based on manpage text
-	RootCmd.SetHelpFunc(help)
-	RootCmd.SetHelpTemplate("{{.UsageString}}")
-	RootCmd.SetUsageFunc(usage)
 }

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -67,14 +67,16 @@ func ObjectExistsOfSize(oid string, size int64) bool {
 	return tools.FileExistsOfSize(path, size)
 }
 
-func Environ() []string {
-	manifest := transfer.ConfigureManifest(transfer.NewManifest(), config.Config)
+func Environ(cfg *config.Configuration, manifest *transfer.Manifest) []string {
 	osEnviron := os.Environ()
 	env := make([]string, 0, len(osEnviron)+7)
+
 	dltransfers := manifest.GetDownloadAdapterNames()
 	sort.Strings(dltransfers)
 	ultransfers := manifest.GetUploadAdapterNames()
 	sort.Strings(ultransfers)
+
+	fetchPruneConfig := cfg.FetchPruneConfig()
 
 	env = append(env,
 		fmt.Sprintf("LocalWorkingDir=%s", config.LocalWorkingDir),
@@ -83,30 +85,30 @@ func Environ() []string {
 		fmt.Sprintf("LocalMediaDir=%s", LocalMediaDir()),
 		fmt.Sprintf("LocalReferenceDir=%s", config.LocalReferenceDir),
 		fmt.Sprintf("TempDir=%s", TempDir()),
-		fmt.Sprintf("ConcurrentTransfers=%d", config.Config.ConcurrentTransfers()),
-		fmt.Sprintf("TusTransfers=%v", config.Config.TusTransfersAllowed()),
-		fmt.Sprintf("BasicTransfersOnly=%v", config.Config.BasicTransfersOnly()),
-		fmt.Sprintf("BatchTransfer=%v", config.Config.BatchTransfer()),
-		fmt.Sprintf("SkipDownloadErrors=%v", config.Config.SkipDownloadErrors()),
-		fmt.Sprintf("FetchRecentAlways=%v", config.Config.FetchPruneConfig().FetchRecentAlways),
-		fmt.Sprintf("FetchRecentRefsDays=%d", config.Config.FetchPruneConfig().FetchRecentRefsDays),
-		fmt.Sprintf("FetchRecentCommitsDays=%d", config.Config.FetchPruneConfig().FetchRecentCommitsDays),
-		fmt.Sprintf("FetchRecentRefsIncludeRemotes=%v", config.Config.FetchPruneConfig().FetchRecentRefsIncludeRemotes),
-		fmt.Sprintf("PruneOffsetDays=%d", config.Config.FetchPruneConfig().PruneOffsetDays),
-		fmt.Sprintf("PruneVerifyRemoteAlways=%v", config.Config.FetchPruneConfig().PruneVerifyRemoteAlways),
-		fmt.Sprintf("PruneRemoteName=%s", config.Config.FetchPruneConfig().PruneRemoteName),
-		fmt.Sprintf("AccessDownload=%s", config.Config.Access("download")),
-		fmt.Sprintf("AccessUpload=%s", config.Config.Access("upload")),
+		fmt.Sprintf("ConcurrentTransfers=%d", cfg.ConcurrentTransfers()),
+		fmt.Sprintf("TusTransfers=%v", cfg.TusTransfersAllowed()),
+		fmt.Sprintf("BasicTransfersOnly=%v", cfg.BasicTransfersOnly()),
+		fmt.Sprintf("BatchTransfer=%v", cfg.BatchTransfer()),
+		fmt.Sprintf("SkipDownloadErrors=%v", cfg.SkipDownloadErrors()),
+		fmt.Sprintf("FetchRecentAlways=%v", fetchPruneConfig.FetchRecentAlways),
+		fmt.Sprintf("FetchRecentRefsDays=%d", fetchPruneConfig.FetchRecentRefsDays),
+		fmt.Sprintf("FetchRecentCommitsDays=%d", fetchPruneConfig.FetchRecentCommitsDays),
+		fmt.Sprintf("FetchRecentRefsIncludeRemotes=%v", fetchPruneConfig.FetchRecentRefsIncludeRemotes),
+		fmt.Sprintf("PruneOffsetDays=%d", fetchPruneConfig.PruneOffsetDays),
+		fmt.Sprintf("PruneVerifyRemoteAlways=%v", fetchPruneConfig.PruneVerifyRemoteAlways),
+		fmt.Sprintf("PruneRemoteName=%s", fetchPruneConfig.PruneRemoteName),
+		fmt.Sprintf("AccessDownload=%s", cfg.Access("download")),
+		fmt.Sprintf("AccessUpload=%s", cfg.Access("upload")),
 		fmt.Sprintf("DownloadTransfers=%s", strings.Join(dltransfers, ",")),
 		fmt.Sprintf("UploadTransfers=%s", strings.Join(ultransfers, ",")),
 	)
-	if len(config.Config.FetchExcludePaths()) > 0 {
-		env = append(env, fmt.Sprintf("FetchExclude=%s", strings.Join(config.Config.FetchExcludePaths(), ", ")))
+	if len(cfg.FetchExcludePaths()) > 0 {
+		env = append(env, fmt.Sprintf("FetchExclude=%s", strings.Join(cfg.FetchExcludePaths(), ", ")))
 	}
-	if len(config.Config.FetchIncludePaths()) > 0 {
-		env = append(env, fmt.Sprintf("FetchInclude=%s", strings.Join(config.Config.FetchIncludePaths(), ", ")))
+	if len(cfg.FetchIncludePaths()) > 0 {
+		env = append(env, fmt.Sprintf("FetchInclude=%s", strings.Join(cfg.FetchIncludePaths(), ", ")))
 	}
-	for _, ext := range config.Config.Extensions() {
+	for _, ext := range cfg.Extensions() {
 		env = append(env, fmt.Sprintf("Extension[%d]=%s", ext.Priority, ext.Name))
 	}
 


### PR DESCRIPTION
I thought changing `lfs.Environ()` to accept a `*config.Configuration` and `*transfer.Manifest` (instead of using global values) would be easy.  However, I wanted a spot for various "global" config objects to be created for all commands, so I picked `commands.Run()`. I may look for a way to pass some kind of context to each command and remove those too.

I built this PR off #1430, so view this diff instead: [transfer-manifest...command-var-scope](https://github.com/github/git-lfs/compare/transfer-manifest...command-var-scope)