### PR TITLE
config-next: remove `SetConfig` and `ResetConfig`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,7 +68,6 @@ type Configuration struct {
 	IsLoggingStats  bool
 
 	loading        sync.Mutex // guards initialization of gitConfig and remotes
-	origConfig     map[string]string
 	remotes        []string
 	extensions     map[string]Extension
 	manualEndpoint *Endpoint

--- a/config/config.go
+++ b/config/config.go
@@ -492,30 +492,3 @@ func (c *Configuration) loadGitConfig() bool {
 
 	return true
 }
-
-// XXX(taylor): remove mutability
-func (c *Configuration) SetConfig(key, value string) {
-	if c.loadGitConfig() {
-		c.loading.Lock()
-		c.origConfig = make(map[string]string)
-		for k, v := range c.gitConfig {
-			c.origConfig[k] = v
-		}
-		c.loading.Unlock()
-	}
-
-	c.gitConfig[key] = value
-}
-
-// XXX(taylor): remove mutability
-func (c *Configuration) ResetConfig() {
-	c.loading.Lock()
-	c.gitConfig = make(map[string]string)
-	if gf, ok := c.Git.Fetcher.(*GitFetcher); ok {
-		gf.vals = c.gitConfig
-	}
-	for k, v := range c.origConfig {
-		c.gitConfig[k] = v
-	}
-	c.loading.Unlock()
-}


### PR DESCRIPTION
This pull-request removes the mutable `SetConfig` and `ResetConfig` methods (along with the `origConfig` field, which was a collaborator) from the `*config.Configuration` type. They are no longer used anywhere throughout the LFS codebase 🎉 

-

/cc @technoweenie @rubyist @sinbad 