### PR TITLE
config-next: remove legacy methods

### DIFF
--- a/auth/credentials.go
+++ b/auth/credentials.go
@@ -212,7 +212,7 @@ func execCredsCommand(cfg *config.Configuration, input Creds, subCommand string)
 	}
 
 	if _, ok := err.(*exec.ExitError); ok {
-		if !cfg.GetenvBool("GIT_TERMINAL_PROMPT", true) {
+		if !cfg.Os.Bool("GIT_TERMINAL_PROMPT", true) {
 			return nil, fmt.Errorf("Change the GIT_TERMINAL_PROMPT env var to be prompted to enter your credentials for %s://%s.",
 				input["protocol"], input["host"])
 		}

--- a/auth/ssh.go
+++ b/auth/ssh.go
@@ -69,8 +69,9 @@ func sshGetExeAndArgs(cfg *config.Configuration, endpoint config.Endpoint) (exe 
 	isPlink := false
 	isTortoise := false
 
-	ssh := cfg.Getenv("GIT_SSH")
-	cmdArgs := strings.Fields(cfg.Getenv("GIT_SSH_COMMAND"))
+	ssh, _ := cfg.Os.Get("GIT_SSH")
+	sshCmd, _ := cfg.Os.Get("GIT_SSH_COMMAND")
+	cmdArgs := strings.Fields(sshCmd)
 	if len(cmdArgs) > 0 {
 		ssh = cmdArgs[0]
 		cmdArgs = cmdArgs[1:]

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -120,7 +120,9 @@ func checkoutWithIncludeExclude(include []string, exclude []string) {
 	for _, pointer := range pointers {
 		totalBytes += pointer.Size
 	}
-	progress := progress.NewProgressMeter(len(pointers), totalBytes, false, cfg.Getenv("GIT_LFS_PROGRESS"))
+
+	logPath, _ := cfg.Os.Get("GIT_LFS_PROGRESS")
+	progress := progress.NewProgressMeter(len(pointers), totalBytes, false, logPath)
 	progress.Start()
 	totalBytes = 0
 	for _, pointer := range pointers {

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -64,7 +64,7 @@ func smudgeCommand(cmd *cobra.Command, args []string) {
 
 	download := lfs.FilenamePassesIncludeExcludeFilter(filename, cfg.FetchIncludePaths(), cfg.FetchExcludePaths())
 
-	if smudgeSkip || cfg.GetenvBool("GIT_LFS_SKIP_SMUDGE", false) {
+	if smudgeSkip || cfg.Os.Bool("GIT_LFS_SKIP_SMUDGE", false) {
 		download = false
 	}
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -275,14 +275,14 @@ func usage(cmd *cobra.Command) error {
 }
 
 // isCommandEnabled returns whether the environment variable GITLFS<CMD>ENABLED
-// is "truthy" according to config.GetenvBool (see
-// github.com/github/git-lfs/config#Configuration.GetenvBool), returning false
+// is "truthy" according to config.Os.Bool (see
+// github.com/github/git-lfs/config#Configuration.Env.Os), returning false
 // by default if the enviornment variable is not specified.
 //
 // This function call should only guard commands that do not yet have stable
 // APIs or solid server implementations.
 func isCommandEnabled(cfg *config.Configuration, cmd string) bool {
-	return cfg.GetenvBool(fmt.Sprintf("GITLFS%sENABLED", strings.ToUpper(cmd)), false)
+	return cfg.Os.Bool(fmt.Sprintf("GITLFS%sENABLED", strings.ToUpper(cmd)), false)
 }
 
 func init() {

--- a/config/config.go
+++ b/config/config.go
@@ -82,9 +82,9 @@ func New() *Configuration {
 		CurrentRemote: defaultRemote,
 		envVars:       make(map[string]string),
 	}
-	c.IsTracingHttp = c.GetenvBool("GIT_CURL_VERBOSE", false)
-	c.IsDebuggingHttp = c.GetenvBool("LFS_DEBUG_HTTP", false)
-	c.IsLoggingStats = c.GetenvBool("GIT_LOG_STATS", false)
+	c.IsTracingHttp = c.Os.Bool("GIT_CURL_VERBOSE", false)
+	c.IsDebuggingHttp = c.Os.Bool("LFS_DEBUG_HTTP", false)
+	c.IsLoggingStats = c.Os.Bool("GIT_LOG_STATS", false)
 	return c
 }
 
@@ -206,11 +206,6 @@ func (c *Configuration) parseTag(tag reflect.StructTag) (key string, env *Enviro
 func (c *Configuration) Getenv(key string) string {
 	v, _ := c.Os.Get(key)
 	return v
-}
-
-// GetenvBool is shorthand for `c.Os.Bool(key, def)`.
-func (c *Configuration) GetenvBool(key string, def bool) bool {
-	return c.Os.Bool(key, def)
 }
 
 // GitRemoteUrl returns the git clone/push url for a given remote (blank if not found)
@@ -465,7 +460,7 @@ func (c *Configuration) FetchPruneConfig() FetchPruneConfig {
 }
 
 func (c *Configuration) SkipDownloadErrors() bool {
-	return c.GetenvBool("GIT_LFS_SKIP_DOWNLOAD_ERRORS", false) || c.GitConfigBool("lfs.skipdownloaderrors", false)
+	return c.Os.Bool("GIT_LFS_SKIP_DOWNLOAD_ERRORS", false) || c.GitConfigBool("lfs.skipdownloaderrors", false)
 }
 
 func (c *Configuration) loadGitConfig() bool {

--- a/config/config.go
+++ b/config/config.go
@@ -202,12 +202,6 @@ func (c *Configuration) parseTag(tag reflect.StructTag) (key string, env *Enviro
 	return
 }
 
-// Getenv is shorthand for `c.Os.Get(key)`.
-func (c *Configuration) Getenv(key string) string {
-	v, _ := c.Os.Get(key)
-	return v
-}
-
 // GitRemoteUrl returns the git clone/push url for a given remote (blank if not found)
 // the forpush argument is to cater for separate remote.name.pushurl settings
 func (c *Configuration) GitRemoteUrl(remote string, forpush bool) string {

--- a/config/config_netrc.go
+++ b/config/config_netrc.go
@@ -18,7 +18,7 @@ func (n *noNetrc) FindMachine(host string) *netrc.Machine {
 }
 
 func (c *Configuration) parseNetrc() (netrcfinder, error) {
-	home := c.Getenv("HOME")
+	home, _ := c.Os.Get("HOME")
 	if len(home) == 0 {
 		return &noNetrc{}, nil
 	}

--- a/httputil/certs.go
+++ b/httputil/certs.go
@@ -48,7 +48,7 @@ func appendRootCAsForHostFromGitconfig(cfg *config.Configuration, pool *x509.Cer
 	// Accumulate certs from all these locations:
 
 	// GIT_SSL_CAINFO first
-	if cafile := cfg.Getenv("GIT_SSL_CAINFO"); len(cafile) > 0 {
+	if cafile, _ := cfg.Os.Get("GIT_SSL_CAINFO"); len(cafile) > 0 {
 		return appendCertsFromFile(pool, cafile)
 	}
 	// http.<url>/.sslcainfo or http.<url>.sslcainfo
@@ -66,7 +66,7 @@ func appendRootCAsForHostFromGitconfig(cfg *config.Configuration, pool *x509.Cer
 		return appendCertsFromFile(pool, cafile)
 	}
 	// GIT_SSL_CAPATH
-	if cadir := cfg.Getenv("GIT_SSL_CAPATH"); len(cadir) > 0 {
+	if cadir, _ := cfg.Os.Get("GIT_SSL_CAPATH"); len(cadir) > 0 {
 		return appendCertsFromFilesInDir(pool, cadir)
 	}
 	// http.sslcapath

--- a/httputil/certs.go
+++ b/httputil/certs.go
@@ -19,7 +19,7 @@ func isCertVerificationDisabledForHost(cfg *config.Configuration, host string) b
 	}
 
 	globalSslVerify, _ := cfg.GitConfig("http.sslverify")
-	if globalSslVerify == "false" || cfg.GetenvBool("GIT_SSL_NO_VERIFY", false) {
+	if globalSslVerify == "false" || cfg.Os.Bool("GIT_SSL_NO_VERIFY", false) {
 		return true
 	}
 

--- a/httputil/proxy.go
+++ b/httputil/proxy.go
@@ -20,24 +20,24 @@ func ProxyFromGitConfigOrEnvironment(c *config.Configuration) func(req *http.Req
 	}
 
 	if len(https_proxy) == 0 {
-		https_proxy = c.Getenv("HTTPS_PROXY")
+		https_proxy, _ = c.Os.Get("HTTPS_PROXY")
 	}
 
 	if len(https_proxy) == 0 {
-		https_proxy = c.Getenv("https_proxy")
+		https_proxy, _ = c.Os.Get("https_proxy")
 	}
 
 	if len(http_proxy) == 0 {
-		http_proxy = c.Getenv("HTTP_PROXY")
+		http_proxy, _ = c.Os.Get("HTTP_PROXY")
 	}
 
 	if len(http_proxy) == 0 {
-		http_proxy = c.Getenv("http_proxy")
+		http_proxy, _ = c.Os.Get("http_proxy")
 	}
 
-	no_proxy := c.Getenv("NO_PROXY")
+	no_proxy, _ := c.Os.Get("NO_PROXY")
 	if len(no_proxy) == 0 {
-		no_proxy = c.Getenv("no_proxy")
+		no_proxy, _ = c.Os.Get("no_proxy")
 	}
 
 	return func(req *http.Request) (*url.URL, error) {

--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -58,10 +58,12 @@ type TransferQueue struct {
 
 // newTransferQueue builds a TransferQueue, direction and underlying mechanism determined by adapter
 func newTransferQueue(files int, size int64, dryRun bool, dir transfer.Direction) *TransferQueue {
+	logPath, _ := config.Config.Os.Get("GIT_LFS_PROGRESS")
+
 	q := &TransferQueue{
 		direction:     dir,
 		dryRun:        dryRun,
-		meter:         progress.NewProgressMeter(files, size, dryRun, config.Config.Getenv("GIT_LFS_PROGRESS")),
+		meter:         progress.NewProgressMeter(files, size, dryRun, logPath),
 		apic:          make(chan Transferable, batchSize),
 		retriesc:      make(chan Transferable, batchSize),
 		errorc:        make(chan error),

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -27,7 +27,7 @@ const (
 var currentPlatform = PlatformUndetermined
 
 func CopyCallbackFile(event, filename string, index, totalFiles int) (progress.CopyCallback, *os.File, error) {
-	logPath := config.Config.Getenv("GIT_LFS_PROGRESS")
+	logPath, _ := config.Config.Os.Get("GIT_LFS_PROGRESS")
 	if len(logPath) == 0 || len(filename) == 0 || len(event) == 0 {
 		return nil, nil, nil
 	}


### PR DESCRIPTION
🚧  This pull-request removes legacy methods from the `*config.Configuration` object such as:

|       | Was | Becomes |
| --- | :---- | :---------- |
| ✅   | `*config.Configuration.GetEnv` | `cfg.Os.Get` |
| ✅  | `*config.Configuration.GetEnvBool` | `cfg.Os.Bool` |
| ⬜  | `*config.Configuration.GitConfig` | `cfg.Git.Get` |
| ⬜  | `*config.Configuration.GitConfigInt` | `cfg.Git.Int` |
| ⬜  | `*config.Configuration.GitConfigBool` | `cfg.Git.Bool` |

-