### PR TITLE
transfer/custom: encode "event" as lowercase

### DIFF
--- a/transfer/custom.go
+++ b/transfer/custom.go
@@ -63,7 +63,7 @@ type customAdapterWorkerContext struct {
 }
 
 type customAdapterInitRequest struct {
-	Event               string `json:"Event"`
+	Event               string `json:"event"`
 	Operation           string `json:"operation"`
 	Concurrent          bool   `json:"concurrent"`
 	ConcurrentTransfers int    `json:"concurrenttransfers"`


### PR DESCRIPTION
As pointed out by @ericfrederich in #1439, the `Event` field of the custom transfer "init request" is encoded as `"Event":`, not `"event":` as it should be.

Running the custom transfer integration tests confirm that this is OK to do 👍 

I'm also thinking that per @technoweenie's suggestion, we backport this to our `release-1.3` branch and get this out as a part of the `v1.3.2` release.

-

/cc @technoweenie @sinbad @ericfrederich