### PR TITLE
add support for url.*.insteadof in git config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -462,6 +462,9 @@ func (c *Configuration) urlAliases() map[string]string {
 		suffix := ".insteadof"
 		for gitkey, gitval := range c.AllGitConfig() {
 			if strings.HasPrefix(gitkey, prefix) && strings.HasSuffix(gitkey, suffix) {
+				if _, ok := c.urlAliasesMap[gitval]; ok {
+					fmt.Fprintf(os.Stderr, "WARNING: Multiple 'url.*.insteadof' keys with the same alias: %q\n", gitval)
+				}
 				c.urlAliasesMap[gitval] = gitkey[len(prefix) : len(gitkey)-len(suffix)]
 			}
 		}
@@ -483,8 +486,6 @@ func (c *Configuration) ReplaceUrlAlias(rawurl string) string {
 
 		if longestalias < alias {
 			longestalias = alias
-		} else if longestalias == alias {
-			fmt.Fprintf(os.Stderr, "WARNING: Multiple 'url.*.insteadof' keys with the same alias: %q", alias)
 		}
 	}
 

--- a/config/endpoint.go
+++ b/config/endpoint.go
@@ -48,6 +48,13 @@ func NewEndpointFromCloneURLWithConfig(url string, c *Configuration) Endpoint {
 
 // NewEndpointWithConfig initializes a new Endpoint for a given URL.
 func NewEndpointWithConfig(rawurl string, c *Configuration) Endpoint {
+	for alias, replacement := range c.UrlAliases() {
+		if !strings.HasPrefix(rawurl, alias) {
+			continue
+		}
+		rawurl = replacement + rawurl[len(alias):]
+	}
+
 	u, err := url.Parse(rawurl)
 	if err != nil {
 		return Endpoint{Url: EndpointUrlUnknown}

--- a/config/endpoint.go
+++ b/config/endpoint.go
@@ -48,13 +48,7 @@ func NewEndpointFromCloneURLWithConfig(url string, c *Configuration) Endpoint {
 
 // NewEndpointWithConfig initializes a new Endpoint for a given URL.
 func NewEndpointWithConfig(rawurl string, c *Configuration) Endpoint {
-	for alias, replacement := range c.UrlAliases() {
-		if !strings.HasPrefix(rawurl, alias) {
-			continue
-		}
-		rawurl = replacement + rawurl[len(alias):]
-	}
-
+	rawurl = c.ReplaceUrlAlias(rawurl)
 	u, err := url.Parse(rawurl)
 	if err != nil {
 		return Endpoint{Url: EndpointUrlUnknown}

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -149,3 +149,22 @@ begin_test "extension config (with gitconfig)"
   [ "$expected2" = "$(git lfs ext)" ]
 )
 end_test
+
+begin_test "url alias config"
+(
+  set -e
+
+  mkdir url-alias
+  cd url-alias
+
+  git init
+  git config url."http://actual-url/".insteadOf alias:
+  git config lfs.url alias:rest
+  git lfs env | tee env.log
+  grep "Endpoint=http://actual-url/rest (auth=none)" env.log
+
+  git config lfs.url badalias:rest
+  git lfs env | tee env.log
+  grep "Endpoint=badalias:rest (auth=none)" env.log
+)
+end_test

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -150,7 +150,6 @@ begin_test "extension config (with gitconfig)"
 )
 end_test
 
-# https://git-scm.com/docs/git-config
 begin_test "url alias config"
 (
   set -e
@@ -166,8 +165,38 @@ begin_test "url alias config"
   git config lfs.url alias:rest
   git lfs env | tee env.log
   grep "Endpoint=http://actual-url/rest (auth=none)" env.log
+)
+end_test
 
-  # Any URL that starts with this value will be rewritten to start, instead, with <base>
+begin_test "ambiguous url alias"
+(
+  set -e
+
+  mkdir url-alias-ambiguous
+  cd url-alias-ambiguous
+
+  git init
+
+  git config url."http://actual-url/".insteadOf alias:
+  git config url."http://dupe-url".insteadOf alias:
+  git config lfs.url alias:rest
+  git config -l | grep url
+
+  git lfs env 2>&1 | tee env2.log
+  grep "WARNING: Multiple 'url.*.insteadof'" env2.log
+)
+end_test
+
+begin_test "url alias must be prefix"
+(
+  set -e
+
+  mkdir url-alias-bad
+  cd url-alias-bad
+
+  git init
+
+  git config url."http://actual-url/".insteadOf alias:
   git config lfs.url badalias:rest
   git lfs env | tee env.log
   grep "Endpoint=badalias:rest (auth=none)" env.log

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -150,6 +150,7 @@ begin_test "extension config (with gitconfig)"
 )
 end_test
 
+# https://git-scm.com/docs/git-config
 begin_test "url alias config"
 (
   set -e
@@ -158,11 +159,15 @@ begin_test "url alias config"
   cd url-alias
 
   git init
+
+  # When more than one insteadOf strings match a given URL, the longest match is used.
+  git config url."http://wrong-url/".insteadOf alias
   git config url."http://actual-url/".insteadOf alias:
   git config lfs.url alias:rest
   git lfs env | tee env.log
   grep "Endpoint=http://actual-url/rest (auth=none)" env.log
 
+  # Any URL that starts with this value will be rewritten to start, instead, with <base>
   git config lfs.url badalias:rest
   git lfs env | tee env.log
   grep "Endpoint=badalias:rest (auth=none)" env.log


### PR DESCRIPTION
Rewrite of #1117 after the config refactoring in #1425. There's no `readGitInsteadOfConfig()` anymore to hook into anymore.

We can't easily support `pushinsteadof` without bigger changes. `config.NewEndpointWithConfig()` doesn't know if the request is a push or pull.