### PR TITLE
config-next: Wrapped `gitEnvironment`

### DIFF
--- a/api/lock_api.go
+++ b/api/lock_api.go
@@ -149,8 +149,8 @@ type Committer struct {
 // "user.name" and "user.email" configuration values are used from the
 // config.Config singleton.
 func CurrentCommitter() Committer {
-	name, _ := config.Config.GitConfig("user.name")
-	email, _ := config.Config.GitConfig("user.email")
+	name, _ := config.Config.Git.Get("user.name")
+	email, _ := config.Config.Git.Get("user.email")
 
 	return Committer{name, email}
 }

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -40,7 +40,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 	}
 
 	for _, key := range []string{"filter.lfs.smudge", "filter.lfs.clean"} {
-		value, _ := cfg.GitConfig(key)
+		value, _ := cfg.Git.Get(key)
 		Print("git config %s = %q", key, value)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -50,14 +50,13 @@ type Configuration struct {
 	// Os provides a `*Environment` used to access to the system's
 	// environment through os.Getenv. It is the point of entry for all
 	// system environment configuration.
-	Os *Environment
+	Os Environment
 
 	// Git provides a `*Environment` used to access to the various levels of
 	// `.gitconfig`'s. It is the point of entry for all Git environment
 	// configuration.
-	Git *Environment
+	Git Environment
 
-	//
 	gitConfig map[string]string
 
 	CurrentRemote   string
@@ -187,7 +186,7 @@ func (c *Configuration) Unmarshal(v interface{}) error {
 // both is not.
 //
 // If neither field was found, then a nil environment will be returned.
-func (c *Configuration) parseTag(tag reflect.StructTag) (key string, env *Environment, err error) {
+func (c *Configuration) parseTag(tag reflect.StructTag) (key string, env Environment, err error) {
 	git, os := tag.Get("git"), tag.Get("os")
 
 	if len(git) != 0 && len(os) != 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -216,12 +216,12 @@ func (c *Configuration) GetenvBool(key string, def bool) bool {
 // the forpush argument is to cater for separate remote.name.pushurl settings
 func (c *Configuration) GitRemoteUrl(remote string, forpush bool) string {
 	if forpush {
-		if u, ok := c.GitConfig("remote." + remote + ".pushurl"); ok {
+		if u, ok := c.Git.Get("remote." + remote + ".pushurl"); ok {
 			return u
 		}
 	}
 
-	if u, ok := c.GitConfig("remote." + remote + ".url"); ok {
+	if u, ok := c.Git.Get("remote." + remote + ".url"); ok {
 		return u
 	}
 
@@ -240,12 +240,12 @@ func (c *Configuration) Endpoint(operation string) Endpoint {
 	}
 
 	if operation == "upload" {
-		if url, ok := c.GitConfig("lfs.pushurl"); ok {
+		if url, ok := c.Git.Get("lfs.pushurl"); ok {
 			return NewEndpointWithConfig(url, c)
 		}
 	}
 
-	if url, ok := c.GitConfig("lfs.url"); ok {
+	if url, ok := c.Git.Get("lfs.url"); ok {
 		return NewEndpointWithConfig(url, c)
 	}
 
@@ -265,7 +265,7 @@ func (c *Configuration) ConcurrentTransfers() int {
 
 	uploads := 3
 
-	if v, ok := c.GitConfig("lfs.concurrenttransfers"); ok {
+	if v, ok := c.Git.Get("lfs.concurrenttransfers"); ok {
 		n, err := strconv.Atoi(v)
 		if err == nil && n > 0 {
 			uploads = n
@@ -278,17 +278,17 @@ func (c *Configuration) ConcurrentTransfers() int {
 // BasicTransfersOnly returns whether to only allow "basic" HTTP transfers.
 // Default is false, including if the lfs.basictransfersonly is invalid
 func (c *Configuration) BasicTransfersOnly() bool {
-	return c.GitConfigBool("lfs.basictransfersonly", false)
+	return c.Git.Bool("lfs.basictransfersonly", false)
 }
 
 // TusTransfersAllowed returns whether to only use "tus.io" HTTP transfers.
 // Default is false, including if the lfs.tustransfers is invalid
 func (c *Configuration) TusTransfersAllowed() bool {
-	return c.GitConfigBool("lfs.tustransfers", false)
+	return c.Git.Bool("lfs.tustransfers", false)
 }
 
 func (c *Configuration) BatchTransfer() bool {
-	return c.GitConfigBool("lfs.batch", true)
+	return c.Git.Bool("lfs.batch", true)
 }
 
 func (c *Configuration) NtlmAccess(operation string) bool {
@@ -334,7 +334,7 @@ func (c *Configuration) SetNetrc(n netrcfinder) {
 
 func (c *Configuration) EndpointAccess(e Endpoint) string {
 	key := fmt.Sprintf("lfs.%s.access", e.Url)
-	if v, ok := c.GitConfig(key); ok && len(v) > 0 {
+	if v, ok := c.Git.Get(key); ok && len(v) > 0 {
 		lower := strings.ToLower(v)
 		if lower == "private" {
 			return "basic"
@@ -385,11 +385,11 @@ func (c *Configuration) RemoteEndpoint(remote, operation string) Endpoint {
 
 	// Support separate push URL if specified and pushing
 	if operation == "upload" {
-		if url, ok := c.GitConfig("remote." + remote + ".lfspushurl"); ok {
+		if url, ok := c.Git.Get("remote." + remote + ".lfspushurl"); ok {
 			return NewEndpointWithConfig(url, c)
 		}
 	}
-	if url, ok := c.GitConfig("remote." + remote + ".lfsurl"); ok {
+	if url, ok := c.Git.Get("remote." + remote + ".lfsurl"); ok {
 		return NewEndpointWithConfig(url, c)
 	}
 
@@ -410,7 +410,7 @@ func (c *Configuration) Remotes() []string {
 // GitProtocol returns the protocol for the LFS API when converting from a
 // git:// remote url.
 func (c *Configuration) GitProtocol() string {
-	if value, ok := c.GitConfig("lfs.gitprotocol"); ok {
+	if value, ok := c.Git.Get("lfs.gitprotocol"); ok {
 		return value
 	}
 	return "https"
@@ -425,21 +425,6 @@ func (c *Configuration) Extensions() map[string]Extension {
 // SortedExtensions gets the list of extensions ordered by Priority
 func (c *Configuration) SortedExtensions() ([]Extension, error) {
 	return SortExtensions(c.Extensions())
-}
-
-// GitConfigInt parses a git config value and returns it as an integer.
-func (c *Configuration) GitConfigInt(key string, def int) int {
-	return c.Git.Int(strings.ToLower(key), def)
-}
-
-// GitConfigBool parses a git config value and returns true if defined as
-// true, 1, on, yes, or def if not defined
-func (c *Configuration) GitConfigBool(key string, def bool) bool {
-	return c.Git.Bool(strings.ToLower(key), def)
-}
-
-func (c *Configuration) GitConfig(key string) (string, bool) {
-	return c.Git.Get(strings.ToLower(key))
 }
 
 func (c *Configuration) AllGitConfig() map[string]string {
@@ -507,7 +492,7 @@ func (c *Configuration) FetchPruneConfig() FetchPruneConfig {
 }
 
 func (c *Configuration) SkipDownloadErrors() bool {
-	return c.GetenvBool("GIT_LFS_SKIP_DOWNLOAD_ERRORS", false) || c.GitConfigBool("lfs.skipdownloaderrors", false)
+	return c.GetenvBool("GIT_LFS_SKIP_DOWNLOAD_ERRORS", false) || c.Git.Bool("lfs.skipdownloaderrors", false)
 }
 
 // loadGitConfig is a temporary measure to support legacy behavior dependent on

--- a/config/environment.go
+++ b/config/environment.go
@@ -11,33 +11,50 @@ import (
 // `Environment`s are the primary way to communicate with various configuration
 // sources, such as the OS environment variables, the `.gitconfig`, and even
 // `map[string]string`s.
-type Environment struct {
-	// Fetcher is the `Environment`'s source of data.
+type Environment interface {
+	// Get is shorthand for calling `e.Fetcher.Get(key)`.
+	Get(key string) (val string, ok bool)
+
+	// Bool returns the boolean state associated with a given key, or the
+	// value "def", if no value was associated.
+	//
+	// The "boolean state associated with a given key" is defined as the
+	// case-insensitive string comparison with the following:
+	//
+	// 1) true if...
+	//   "true", "1", "on", "yes", or "t"
+	// 2) false if...
+	//   "false", "0", "off", "no", "f", or otherwise.
+	Bool(key string, def bool) (val bool)
+
+	// Int returns the int value associated with a given key, or the value
+	// "def", if no value was associated.
+	//
+	// To convert from a the string value attached to a given key,
+	// `strconv.Atoi(val)` is called. If `Atoi` returned a non-nil error,
+	// then the value "def" will be returned instead.
+	//
+	// Otherwise, if the value was converted `string -> int` successfully,
+	// then it will be returned wholesale.
+	Int(key string, def int) (val int)
+}
+
+type environment struct {
+	// Fetcher is the `environment`'s source of data.
 	Fetcher Fetcher
 }
 
-// EnvironmentOf creates a new `*Environment` initialized with the givne
+// EnvironmentOf creates a new `Environment` initialized with the givne
 // `Fetcher`, "f".
-func EnvironmentOf(f Fetcher) *Environment {
-	return &Environment{f}
+func EnvironmentOf(f Fetcher) Environment {
+	return &environment{f}
 }
 
-// Get is shorthand for calling `e.Fetcher.Get(key)`.
-func (e *Environment) Get(key string) (val string, ok bool) {
+func (e *environment) Get(key string) (val string, ok bool) {
 	return e.Fetcher.Get(key)
 }
 
-// Bool returns the boolean state associated with a given key, or the value
-// "def", if no value was associated.
-//
-// The "boolean state associated with a given key" is defined as the
-// case-insensitive string comparison with the following:
-//
-// 1) true if...
-//   "true", "1", "on", "yes", or "t"
-// 2) false if...
-//   "false", "0", "off", "no", "f", or otherwise.
-func (e *Environment) Bool(key string, def bool) (val bool) {
+func (e *environment) Bool(key string, def bool) (val bool) {
 	s, _ := e.Fetcher.Get(key)
 	if len(s) == 0 {
 		return def
@@ -53,16 +70,7 @@ func (e *Environment) Bool(key string, def bool) (val bool) {
 	}
 }
 
-// Int returns the int value associated with a given key, or the value "def",
-// if no value was associated.
-//
-// To convert from a the string value attached to a given key,
-// `strconv.Atoi(val)` is called. If `Atoi` returned a non-nil error, then the
-// value "def" will be returned instead.
-//
-// Otherwise, if the value was converted `string -> int` successfully, then it
-// will be returned wholesale.
-func (e *Environment) Int(key string, def int) (val int) {
+func (e *environment) Int(key string, def int) (val int) {
 	s, _ := e.Fetcher.Get(key)
 	if len(s) == 0 {
 		return def

--- a/config/environment_test.go
+++ b/config/environment_test.go
@@ -7,13 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEnvironmentOfReturnsCorrectlyInitializedEnvironment(t *testing.T) {
-	fetcher := MapFetcher(map[string]string{})
-	env := EnvironmentOf(fetcher)
-
-	assert.Equal(t, fetcher, env.Fetcher)
-}
-
 func TestEnvironmentGetDelegatesToFetcher(t *testing.T) {
 	fetcher := MapFetcher(map[string]string{
 		"foo": "bar",
@@ -68,18 +61,18 @@ type EnvironmentConversionTestCase struct {
 	Val      string
 	Expected interface{}
 
-	GotFn func(env *Environment, key string) interface{}
+	GotFn func(env Environment, key string) interface{}
 }
 
 var (
-	GetBoolDefault = func(def bool) func(e *Environment, key string) interface{} {
-		return func(e *Environment, key string) interface{} {
+	GetBoolDefault = func(def bool) func(e Environment, key string) interface{} {
+		return func(e Environment, key string) interface{} {
 			return e.Bool(key, def)
 		}
 	}
 
-	GetIntDefault = func(def int) func(e *Environment, key string) interface{} {
-		return func(e *Environment, key string) interface{} {
+	GetIntDefault = func(def int) func(e Environment, key string) interface{} {
+		return func(e Environment, key string) interface{} {
 			return e.Int(key, def)
 		}
 	}

--- a/config/git_environment.go
+++ b/config/git_environment.go
@@ -1,0 +1,71 @@
+package config
+
+// gitEnvironment is an implementation of the Environment which wraps the legacy
+// behavior or `*config.Configuration.loadGitConfig()`.
+//
+// It is functionally equivelant to call `cfg.loadGitConfig()` before calling
+// methods on the Environment type.
+type gitEnvironment struct {
+	// git is the Environment which gitEnvironment wraps.
+	git Environment
+	// config is the *Configuration instance which is mutated by
+	// `loadGitConfig`.
+	config *Configuration
+}
+
+// Get is shorthand for calling the loadGitConfig, and then returning
+// `g.git.Get(key)`.
+func (g *gitEnvironment) Get(key string) (val string, ok bool) {
+	g.loadGitConfig()
+
+	return g.git.Get(key)
+}
+
+// Get is shorthand for calling the loadGitConfig, and then returning
+// `g.git.Bool(key, def)`.
+func (g *gitEnvironment) Bool(key string, def bool) (val bool) {
+	g.loadGitConfig()
+
+	return g.git.Bool(key, def)
+}
+
+// Get is shorthand for calling the loadGitConfig, and then returning
+// `g.git.Int(key, def)`.
+func (g *gitEnvironment) Int(key string, def int) (val int) {
+	g.loadGitConfig()
+
+	return g.git.Int(key, def)
+}
+
+// loadGitConfig reads and parses the .gitconfig by calling ReadGitConfig. It
+// also sets values on the configuration instance `g.config`.
+//
+// If loadGitConfig has already been called, this method will bail out early,
+// and return false. Otherwise it will preform the entire parse and return true.
+//
+// loadGitConfig is safe to call across multiple goroutines.
+func (g *gitEnvironment) loadGitConfig() bool {
+	g.config.loading.Lock()
+	defer g.config.loading.Unlock()
+
+	if g.git != nil {
+		return false
+	}
+
+	gf, extensions, uniqRemotes := ReadGitConfig(getGitConfigs()...)
+
+	g.git = EnvironmentOf(gf)
+
+	g.config.gitConfig = gf.vals // XXX TERRIBLE
+	g.config.extensions = extensions
+
+	g.config.remotes = make([]string, 0, len(uniqRemotes))
+	for remote, isOrigin := range uniqRemotes {
+		if isOrigin {
+			continue
+		}
+		g.config.remotes = append(g.config.remotes, remote)
+	}
+
+	return true
+}

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -110,11 +110,19 @@ func ReadGitConfig(configs ...*GitConfig) (gf *GitFetcher, extensions map[string
 	return
 }
 
+// Get implements the Fetcher interface, and returns the value associated with
+// a given key and true, signaling that the value was present. Otherwise, an
+// empty string and false will be returned, signaling that the value was
+// absent.
+//
+// Map lookup by key is case-insensitive, as per the .gitconfig specification.
+//
+// Get is safe to call across multiple goroutines.
 func (g *GitFetcher) Get(key string) (val string, ok bool) {
 	g.vmu.RLock()
 	defer g.vmu.RUnlock()
 
-	val, ok = g.vals[key]
+	val, ok = g.vals[strings.ToLower(key)]
 	return
 }
 

--- a/httputil/certs.go
+++ b/httputil/certs.go
@@ -13,12 +13,12 @@ import (
 // isCertVerificationDisabledForHost returns whether SSL certificate verification
 // has been disabled for the given host, or globally
 func isCertVerificationDisabledForHost(cfg *config.Configuration, host string) bool {
-	hostSslVerify, _ := cfg.GitConfig(fmt.Sprintf("http.https://%v/.sslverify", host))
+	hostSslVerify, _ := cfg.Git.Get(fmt.Sprintf("http.https://%v/.sslverify", host))
 	if hostSslVerify == "false" {
 		return true
 	}
 
-	globalSslVerify, _ := cfg.GitConfig("http.sslverify")
+	globalSslVerify, _ := cfg.Git.Get("http.sslverify")
 	if globalSslVerify == "false" || cfg.GetenvBool("GIT_SSL_NO_VERIFY", false) {
 		return true
 	}
@@ -54,15 +54,15 @@ func appendRootCAsForHostFromGitconfig(cfg *config.Configuration, pool *x509.Cer
 	// http.<url>/.sslcainfo or http.<url>.sslcainfo
 	// we know we have simply "host" or "host:port"
 	hostKeyWithSlash := fmt.Sprintf("http.https://%v/.sslcainfo", host)
-	if cafile, ok := cfg.GitConfig(hostKeyWithSlash); ok {
+	if cafile, ok := cfg.Git.Get(hostKeyWithSlash); ok {
 		return appendCertsFromFile(pool, cafile)
 	}
 	hostKeyWithoutSlash := fmt.Sprintf("http.https://%v.sslcainfo", host)
-	if cafile, ok := cfg.GitConfig(hostKeyWithoutSlash); ok {
+	if cafile, ok := cfg.Git.Get(hostKeyWithoutSlash); ok {
 		return appendCertsFromFile(pool, cafile)
 	}
 	// http.sslcainfo
-	if cafile, ok := cfg.GitConfig("http.sslcainfo"); ok {
+	if cafile, ok := cfg.Git.Get("http.sslcainfo"); ok {
 		return appendCertsFromFile(pool, cafile)
 	}
 	// GIT_SSL_CAPATH
@@ -70,7 +70,7 @@ func appendRootCAsForHostFromGitconfig(cfg *config.Configuration, pool *x509.Cer
 		return appendCertsFromFilesInDir(pool, cadir)
 	}
 	// http.sslcapath
-	if cadir, ok := cfg.GitConfig("http.sslcapath"); ok {
+	if cadir, ok := cfg.Git.Get("http.sslcapath"); ok {
 		return appendCertsFromFilesInDir(pool, cadir)
 	}
 

--- a/httputil/http.go
+++ b/httputil/http.go
@@ -117,9 +117,9 @@ func NewHttpClient(c *config.Configuration, host string) *HttpClient {
 		return client
 	}
 
-	dialtime := c.GitConfigInt("lfs.dialtimeout", 30)
-	keepalivetime := c.GitConfigInt("lfs.keepalive", 1800) // 30 minutes
-	tlstime := c.GitConfigInt("lfs.tlstimeout", 30)
+	dialtime := c.Git.Int("lfs.dialtimeout", 30)
+	keepalivetime := c.Git.Int("lfs.keepalive", 1800) // 30 minutes
+	tlstime := c.Git.Int("lfs.tlstimeout", 30)
 
 	tr := &http.Transport{
 		Proxy: ProxyFromGitConfigOrEnvironment(c),

--- a/httputil/proxy.go
+++ b/httputil/proxy.go
@@ -14,7 +14,7 @@ import (
 // Logic is copied, with small changes, from "net/http".ProxyFromEnvironment in the go std lib.
 func ProxyFromGitConfigOrEnvironment(c *config.Configuration) func(req *http.Request) (*url.URL, error) {
 	var https_proxy string
-	http_proxy, _ := c.GitConfig("http.proxy")
+	http_proxy, _ := c.Git.Get("http.proxy")
 	if strings.HasPrefix(http_proxy, "https://") {
 		https_proxy = http_proxy
 	}

--- a/lfs/hook.go
+++ b/lfs/hook.go
@@ -39,7 +39,7 @@ func (h *Hook) Path() string {
 // greater than "2.9.0"), it will return that instead.
 func (h *Hook) Dir() string {
 	customHooksSupported := git.Config.IsGitVersionAtLeast("2.9.0")
-	if hp, ok := config.Config.GitConfig("core.hooksPath"); ok && customHooksSupported {
+	if hp, ok := config.Config.Git.Get("core.hooksPath"); ok && customHooksSupported {
 		return hp
 	}
 

--- a/transfer/custom.go
+++ b/transfer/custom.go
@@ -358,9 +358,9 @@ func configureCustomAdapters(cfg *config.Configuration, m *Manifest) {
 		name := match[1]
 		path := v
 		// retrieve other values
-		args, _ := cfg.GitConfig(fmt.Sprintf("lfs.customtransfer.%s.args", name))
-		concurrent := cfg.GitConfigBool(fmt.Sprintf("lfs.customtransfer.%s.concurrent", name), true)
-		direction, _ := cfg.GitConfig(fmt.Sprintf("lfs.customtransfer.%s.direction", name))
+		args, _ := cfg.Git.Get(fmt.Sprintf("lfs.customtransfer.%s.args", name))
+		concurrent := cfg.Git.Bool(fmt.Sprintf("lfs.customtransfer.%s.concurrent", name), true)
+		direction, _ := cfg.Git.Get(fmt.Sprintf("lfs.customtransfer.%s.direction", name))
 		if len(direction) == 0 {
 			direction = "both"
 		} else {


### PR DESCRIPTION
This pull-request introduces a wrapped `gitEnvironment` to support the legacy behavior found in `loadGitConfig` in order to make #1436 possible.

-

In order to support lazily loading the values stored in a user's `.gitconfig`,
we must wait until calling `*config.Configuration.loadGitConfig()` until it is
_absolutely necessary_.

To accomplish this, it was proposed that we introduce a wrapped variant of the
`*Environment` type, only for interacting with the `GitFetcher` that was
capable of supporting such beahvior.

As such, a new implementation of the `Environment` type must be defined. Since
previously there only existed the concrete type `*Environment`, this commit
demotes that down to `*enviornment`, and introduces the interface
`Environment`, which it implements.

-

To wrap the old behavior found in `*config.Configuration.loadGitConfig`, a
`*gitEnvironment` implementation was introduced to wrap the behavior of another
Environment wholesale while at the same time prepending a call to
`loadGitConfig()`.

It should be noted that in order to preserve legacy behavior with using certain
member variables in `*config.Configuration`, there is a circular dependency
between the two types.

-

/cc @technoweenie 