### PR TITLE
Fetch remote urls

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -228,6 +228,10 @@ func (c *Configuration) GitRemoteUrl(remote string, forpush bool) string {
 		return u
 	}
 
+	if err := git.ValidateRemote(remote); err == nil {
+		return remote
+	}
+
 	return ""
 
 }

--- a/config/endpoint.go
+++ b/config/endpoint.go
@@ -37,12 +37,17 @@ func NewEndpointFromCloneURLWithConfig(url string, c *Configuration) Endpoint {
 		return e
 	}
 
+	if strings.HasSuffix(url, "/") {
+		e.Url = url[0 : len(url)-1]
+	}
+
 	// When using main remote URL for HTTP, append info/lfs
-	if path.Ext(url) == ".git" {
+	if path.Ext(e.Url) == ".git" {
 		e.Url += "/info/lfs"
 	} else {
 		e.Url += ".git/info/lfs"
 	}
+
 	return e
 }
 

--- a/config/endpoint_test.go
+++ b/config/endpoint_test.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestNewEndpointFromCloneURLWithConfig(t *testing.T) {
+	expected := "https://foo/bar.git/info/lfs"
+	tests := []string{
+		"https://foo/bar",
+		"https://foo/bar/",
+		"https://foo/bar.git",
+		"https://foo/bar.git/",
+	}
+
+	cfg := New()
+	for _, actual := range tests {
+		e := NewEndpointFromCloneURLWithConfig(actual, cfg)
+		if e.Url != expected {
+			t.Errorf("%s returned bad endpoint url %s", actual, e.Url)
+		}
+	}
+}

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -503,6 +503,29 @@ begin_test "fetch --prune"
 )
 end_test
 
+begin_test "fetch raw remote url"
+(
+  set -e
+  mkdir raw
+  cd raw
+  git init
+  git lfs install --local --skip-smudge
+
+  git remote add origin $GITSERVER/test-fetch
+  git pull origin master
+
+  # LFS object not downloaded, pointer in working directory
+  refute_local_object "$contents_oid"
+  ack "$content_oid" a.dat
+
+  git lfs fetch "$GITSERVER/test-fetch"
+
+  # LFS object downloaded, pointer still in working directory
+  assert_local_object "$contents_oid" 1
+  grep "$content_oid" a.dat
+)
+end_test
+
 begin_test "fetch with invalid remote"
 (
   set -e

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -516,7 +516,7 @@ begin_test "fetch raw remote url"
 
   # LFS object not downloaded, pointer in working directory
   refute_local_object "$contents_oid"
-  ack "$content_oid" a.dat
+  grep "$content_oid" a.dat
 
   git lfs fetch "$GITSERVER/test-fetch"
 

--- a/test/test-pull.sh
+++ b/test/test-pull.sh
@@ -127,7 +127,7 @@ begin_test "pull with raw remote url"
 
   # LFS object not downloaded, pointer in working directory
   refute_local_object "$contents_oid"
-  ack "$contents_oid" a.dat
+  grep "$contents_oid" a.dat
 
   git lfs pull "$GITSERVER/test-pull"
   echo "pulled!"

--- a/test/test-pull.sh
+++ b/test/test-pull.sh
@@ -111,6 +111,34 @@ begin_test "pull"
 )
 end_test
 
+begin_test "pull with raw remote url"
+(
+  set -e
+  mkdir raw
+  cd raw
+  git init
+  git lfs install --local --skip-smudge
+
+  git remote add origin $GITSERVER/test-pull
+  git pull origin master
+
+  contents="a"
+  contents_oid=$(calc_oid "$contents")
+
+  # LFS object not downloaded, pointer in working directory
+  refute_local_object "$contents_oid"
+  ack "$contents_oid" a.dat
+
+  git lfs pull "$GITSERVER/test-pull"
+  echo "pulled!"
+
+  # LFS object downloaded and in working directory
+  assert_local_object "$contents_oid" 1
+  [ "0" = "$(grep -c "$contents_oid" a.dat)" ]
+  [ "a" = "$(cat a.dat)" ]
+)
+end_test
+
 begin_test "pull: outside git repository"
 (
   set +e

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -512,6 +512,36 @@ begin_test "push (retry with expired actions)"
 )
 end_test
 
+begin_test "push to raw remote url"
+(
+  set -e
+
+  setup_remote_repo "push-raw"
+  mkdir push-raw
+  cd push-raw
+  git init
+
+  git lfs track "*.dat"
+
+  contents="raw"
+  contents_oid=$(calc_oid "$contents")
+
+  printf "$contents" > raw.dat
+  git add raw.dat .gitattributes
+  git commit -m "add" 2>&1 | tee commit.log
+  grep "master (root-commit)" commit.log
+  grep "2 files changed" commit.log
+  grep "create mode 100644 raw.dat" commit.log
+  grep "create mode 100644 .gitattributes" commit.log
+
+  refute_server_object push-raw "$contents_oid"
+
+  git lfs push $GITSERVER/push-raw master
+
+  assert_server_object push-raw "$contents_oid"
+)
+end_test
+
 begin_test "push (with invalid object size)"
 (
   set -e


### PR DESCRIPTION
This adds support for pushing and pulling LFS objects with a raw remote url. This was originally submitting in #1085, and updated for the current master branch. This also adds tests.