### PR TITLE
add object Authenticated property

### DIFF
--- a/api/object.go
+++ b/api/object.go
@@ -19,11 +19,12 @@ func (e *ObjectError) Error() string {
 }
 
 type ObjectResource struct {
-	Oid     string                   `json:"oid,omitempty"`
-	Size    int64                    `json:"size"`
-	Actions map[string]*LinkRelation `json:"actions,omitempty"`
-	Links   map[string]*LinkRelation `json:"_links,omitempty"`
-	Error   *ObjectError             `json:"error,omitempty"`
+	Oid           string                   `json:"oid,omitempty"`
+	Size          int64                    `json:"size"`
+	Authenticated bool                     `json:"authenticated,omitempty"`
+	Actions       map[string]*LinkRelation `json:"actions,omitempty"`
+	Links         map[string]*LinkRelation `json:"_links,omitempty"`
+	Error         *ObjectError             `json:"error,omitempty"`
 }
 
 // TODO LEGACY API: remove when legacy API removed
@@ -71,6 +72,10 @@ func (o *ObjectResource) IsExpired(now time.Time) bool {
 	}
 
 	return false
+}
+
+func (o *ObjectResource) NeedsAuth() bool {
+	return !o.Authenticated
 }
 
 type LinkRelation struct {

--- a/docs/api/v1.3/http-v1.3-batch-request-schema.json
+++ b/docs/api/v1.3/http-v1.3-batch-request-schema.json
@@ -22,7 +22,10 @@
           },
           "size": {
             "type": "number"
-          }
+          },
+          "authenticated": {
+            "type": "boolean"
+          },
         },
         "required": ["oid", "size"],
         "additionalProperties": false

--- a/docs/api/v1.3/http-v1.3-batch-response-schema.json
+++ b/docs/api/v1.3/http-v1.3-batch-response-schema.json
@@ -39,6 +39,9 @@
             "type": "number",
             "minimum": 0
           },
+          "authenticated": {
+            "type": "boolean"
+          },
           "actions": {
             "type": "object",
             "properties": {

--- a/test/test-object-authenticated.sh
+++ b/test/test-object-authenticated.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+# these tests rely on GIT_TERMINAL_PROMPT to test properly
+ensure_git_version_isnt $VERSION_LOWER "2.3.0"
+
+# if there is a system cred helper we can't run this test
+# can't disable without changing state outside test & probably don't have permission
+# this is common on OS X with certain versions of Git installed, default cred helper
+if [[ -n "$(git config --system credential.helper)" ]]; then
+  echo "skip: $0 (system cred helper we can't disable)"
+  exit
+fi
+
+begin_test "download authenticated object"
+(
+  set -e
+  reponame="$(basename "$0" ".sh")"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" without-creds
+
+  git lfs track "*.dat"
+  printf "object-authenticated" > hi.dat
+  git add hi.dat
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  GIT_CURL_VERBOSE=1 GIT_TERMINAL_PROMPT=0 git lfs push origin master
+)
+end_test

--- a/transfer/basic_download.go
+++ b/transfer/basic_download.go
@@ -110,7 +110,7 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb TransferProgressCallback
 		req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", fromByte, t.Object.Size-1))
 	}
 
-	res, err := httputil.DoHttpRequest(config.Config, req, true)
+	res, err := httputil.DoHttpRequest(config.Config, req, t.Object.NeedsAuth())
 	if err != nil {
 		// Special-case status code 416 () - fall back
 		if fromByte > 0 && dlFile != nil && res.StatusCode == 416 {

--- a/transfer/basic_upload.go
+++ b/transfer/basic_upload.go
@@ -97,7 +97,7 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Transfe
 
 	req.Body = ioutil.NopCloser(reader)
 
-	res, err := httputil.DoHttpRequest(config.Config, req, true)
+	res, err := httputil.DoHttpRequest(config.Config, req, t.Object.NeedsAuth())
 	if err != nil {
 		return errutil.NewRetriableError(err)
 	}


### PR DESCRIPTION
This lets servers set an `Authenticated` property on objects, that the client uses to determine if it needs to call `git-credential` or not. This is a forward compatible API change, and won't affect existing implementations.

When a client hits the batch api, it sends a payload like this:

```js
{
  "operation": "download",
  "objects": [{"oid": "SOMEOID", "size": 123}]
}
```

A typical server response returns a URL to transfer the object with any values for the HTTP request header.

```js
{"objects": [{
  "oid": "SOMEOID",
  "size": 123,
  "actions": {
    "download": {
      "href": "https://download-this-object",
      "header": {
        "Authorization": "Basic ..."
      }
    }
  }
}
```

Git LFS will use `git-credential` to find the user and pass for that download unless the `Authorization` header is set. What if the service uses a non-standard header, or what if the file requires no authentication? This is where the `authenticated` property comes in:

```js
{"objects": [{
  "oid": "SOMEOID",
  "size": 123,
  "authenticated": false,
  "actions": {
    "download": {
      "href": "https://download-this-object",
      "header": {
        "Custom-Token": "Basic ..."
      }
    }
  }
}
```