### PR TITLE
fix duplicate error reporting

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,10 +8,10 @@ Git LFS. If you have an idea for a new feature, open an issue for discussion.
 | | Name | Ref |
 | ------ | ---- | --- |
 | | git index issues | [#937](https://github.com/github/git-lfs/issues/937) |
-| :soon: | `authenticated` property on urls | [#960](https://github.com/github/git-lfs/issues/960) |
+| :soon: | `authenticated` property on urls | [#960](https://github.com/github/git-lfs/issues/960), [#1452](https://github.com/github/git-lfs/pull/1452) |
 | :soon: | Add ref information to upload request | [#969](https://github.com/github/git-lfs/issues/969) |
-| :soon: | Accept raw remote URLs as valid | [#1085](https://github.com/github/git-lfs/issues/1085) |
-| :construction: | `config` refactoring | [#1425](https://github.com/github/git-lfs/issues/1425) |
+| :ship: | Accept raw remote URLs as valid | [#1085](https://github.com/github/git-lfs/issues/1085), [#1451](https://github.com/github/git-lfs/issues/1451) |
+| :ship: | `config` refactoring | [#1425](https://github.com/github/git-lfs/issues/1425) |
 | :soon: | Socks proxy support | [#1424](https://github.com/github/git-lfs/issues/1424) |
 | :no_entry_sign: | Not following 301 redirect | [#1129](https://github.com/github/git-lfs/issues/1129) |
 | | add all lfs.\* git config keys to git lfs env output | |

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -313,7 +313,7 @@ func fetchAndReportToChan(pointers []*lfs.WrappedPointer, include, exclude []str
 	ok := true
 	for _, err := range q.Errors() {
 		ok = false
-		ExitWithError(err)
+		FullError(err)
 	}
 	return ok
 }

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -143,19 +143,7 @@ func upload(c *uploadContext, unfiltered []*lfs.WrappedPointer) {
 	q.Wait()
 
 	for _, err := range q.Errors() {
-		if Debugging || errutil.IsFatalError(err) {
-			LoggedError(err, err.Error())
-		} else {
-			var innermsg string = ""
-			if inner := errutil.GetInnerError(err); inner != nil {
-				innermsg = inner.Error()
-				Error(innermsg)
-			}
-			var msg string = err.Error()
-			if msg != innermsg {
-				Error(msg)
-			}
-		}
+		FullError(err)
 	}
 
 	if len(q.Errors()) > 0 {


### PR DESCRIPTION
This is an extension to #1445 which also cleans up some of the duplicate logic from `commands.ExitWithError()`.  /cc @dpursehouse