### PR TITLE
retry if file download failed

### DIFF
--- a/tools/iotools.go
+++ b/tools/iotools.go
@@ -6,6 +6,7 @@ import (
 	"hash"
 	"io"
 
+	"github.com/github/git-lfs/errutil"
 	"github.com/github/git-lfs/progress"
 )
 
@@ -84,4 +85,23 @@ func (r *HashingReader) Read(b []byte) (int, error) {
 	}
 
 	return w, err
+}
+
+// RetriableReader wraps a error response of reader as RetriableError()
+type RetriableReader struct {
+	reader io.Reader
+}
+
+func NewRetriableReader(r io.Reader) io.Reader {
+	return &RetriableReader{r}
+}
+
+func (r *RetriableReader) Read(b []byte) (int, error) {
+	n, err := r.reader.Read(b)
+	// EOF is a successful response as it is used to signal a graceful end of input
+	// c.f. https://git.io/v6riQ
+	if err == nil || err == io.EOF {
+		return n, err
+	}
+	return n, errutil.NewRetriableError(err)
 }

--- a/tools/iotools.go
+++ b/tools/iotools.go
@@ -6,7 +6,7 @@ import (
 	"hash"
 	"io"
 
-	"github.com/github/git-lfs/errutil"
+	"github.com/github/git-lfs/errors"
 	"github.com/github/git-lfs/progress"
 )
 
@@ -103,5 +103,5 @@ func (r *RetriableReader) Read(b []byte) (int, error) {
 	if err == nil || err == io.EOF {
 		return n, err
 	}
-	return n, errutil.NewRetriableError(err)
+	return n, errors.NewRetriableError(err)
 }

--- a/transfer/basic_download.go
+++ b/transfer/basic_download.go
@@ -204,11 +204,7 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb TransferProgressCallback
 	}
 	written, err := tools.CopyWithCallback(dlFile, hasher, res.ContentLength, ccb)
 	if err != nil {
-		wrappedErr := fmt.Errorf("cannot write data to tempfile %q: %v", dlfilename, err)
-		if errutil.IsRetriableError(err) {
-			return errutil.NewRetriableError(wrappedErr)
-		}
-		return wrappedErr
+		return errors.Wrapf(err, "cannot write data to tempfile %q", dlfilename)
 	}
 	if err := dlFile.Close(); err != nil {
 		return fmt.Errorf("can't close tempfile %q: %v", dlfilename, err)

--- a/transfer/basic_download.go
+++ b/transfer/basic_download.go
@@ -177,11 +177,13 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb TransferProgressCallback
 	}
 
 	var hasher *tools.HashingReader
+	httpReader := tools.NewRetriableReader(res.Body)
+
 	if fromByte > 0 && hash != nil {
 		// pre-load hashing reader with previous content
-		hasher = tools.NewHashingReaderPreloadHash(res.Body, hash)
+		hasher = tools.NewHashingReaderPreloadHash(httpReader, hash)
 	} else {
-		hasher = tools.NewHashingReader(res.Body)
+		hasher = tools.NewHashingReader(httpReader)
 	}
 
 	if dlFile == nil {
@@ -202,7 +204,11 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb TransferProgressCallback
 	}
 	written, err := tools.CopyWithCallback(dlFile, hasher, res.ContentLength, ccb)
 	if err != nil {
-		return fmt.Errorf("cannot write data to tempfile %q: %v", dlfilename, err)
+		wrappedErr := fmt.Errorf("cannot write data to tempfile %q: %v", dlfilename, err)
+		if errutil.IsRetriableError(err) {
+			return errutil.NewRetriableError(wrappedErr)
+		}
+		return wrappedErr
 	}
 	if err := dlFile.Close(); err != nil {
 		return fmt.Errorf("can't close tempfile %q: %v", dlfilename, err)


### PR DESCRIPTION
A file download can fail for multiple reasons, e.g. due to various
network errors. Use the `TransferQueue` retry mechansim to try it again.

Possible errors due to spotty network connections:
https://github.com/golang/go/blob/64214792e214bbacb8c00ffea92a7131e30fa59e/src/io/io.go#L26-L47