### PR TITLE
Update fetch include/exclude docs for pattern matching

### DIFF
--- a/docs/man/git-lfs-fetch.1.ronn
+++ b/docs/man/git-lfs-fetch.1.ronn
@@ -41,9 +41,9 @@ paths of the repo, and/or to exclude certain paths of the repo, to reduce the
 time you spend downloading things you do not use.
 
 In gitconfig, set lfs.fetchinclude and lfs.fetchexclude to comma-separated lists
-of paths to include/exclude in the fetch (wildcard matching as per gitignore).
-Only paths which are matched by fetchinclude and not matched by fetchexclude
-will have objects fetched for them.
+of paths to include/exclude in the fetch (pattern matching as per golang's
+`filepath.Match()`).  Only paths which are matched by fetchinclude and not
+matched by fetchexclude will have objects fetched for them.
 
 ### Examples:
 


### PR DESCRIPTION
Previously the docs indicated that pattern matching was per gitignore, but actually it is done per golang's `filepath.Match()`.  Ideally it will eventually mirror gitignore, but until then the docs should be corrected.

This will help with user frustration regarding https://github.com/github/git-lfs/issues/912