### PR TITLE
Technoweenie/errors next

### DIFF
--- a/api/download_test.go
+++ b/api/download_test.go
@@ -321,8 +321,9 @@ func TestDownloadAPIError(t *testing.T) {
 		return
 	}
 
-	if err.Error() != fmt.Sprintf(httputil.GetDefaultError(404), server.URL+"/media/objects/oid") {
-		t.Fatalf("Unexpected error: %s", err.Error())
+	expected := "LFS: " + fmt.Sprintf(httputil.GetDefaultError(404), server.URL+"/media/objects/oid")
+	if err.Error() != expected {
+		t.Fatalf("Expected: %s\nGot: %s", expected, err.Error())
 	}
 
 }

--- a/api/upload_test.go
+++ b/api/upload_test.go
@@ -456,8 +456,9 @@ func TestUploadApiError(t *testing.T) {
 		return
 	}
 
-	if err.Error() != fmt.Sprintf(httputil.GetDefaultError(404), server.URL+"/media/objects") {
-		t.Fatalf("Unexpected error: %s", err.Error())
+	expected := "LFS: " + fmt.Sprintf(httputil.GetDefaultError(404), server.URL+"/media/objects")
+	if err.Error() != expected {
+		t.Fatalf("Expected: %s\nGot: %s", expected, err.Error())
 	}
 
 	if !postCalled {
@@ -580,8 +581,9 @@ func TestUploadVerifyError(t *testing.T) {
 		t.Fatal("should not panic")
 	}
 
-	if err.Error() != fmt.Sprintf(httputil.GetDefaultError(404), server.URL+"/verify") {
-		t.Fatalf("Unexpected error: %s", err.Error())
+	expected := "LFS: " + fmt.Sprintf(httputil.GetDefaultError(404), server.URL+"/verify")
+	if err.Error() != expected {
+		t.Fatalf("Expected: %s\nGot: %s", expected, err.Error())
 	}
 
 	if !postCalled {

--- a/errutil/errors.go
+++ b/errutil/errors.go
@@ -465,7 +465,7 @@ func (e notAPointerError) NotAPointerError() bool {
 }
 
 func NewNotAPointerError(err error) error {
-	return notAPointerError{newWrappedError(err, "Not a valid Git LFS pointer file.")}
+	return notAPointerError{newWrappedError(err, "Pointer file error")}
 }
 
 type badPointerKeyError struct {

--- a/errutil/errors.go
+++ b/errutil/errors.go
@@ -51,7 +51,6 @@ package errutil
 
 import (
 	"fmt"
-	"reflect"
 	"runtime"
 
 	"github.com/pkg/errors"
@@ -73,7 +72,6 @@ func parentOf(err error) error {
 // IsFatalError indicates that the error is fatal and the process should exit
 // immediately after handling the error.
 func IsFatalError(err error) bool {
-	fmt.Println(err, reflect.TypeOf(err))
 	if e, ok := err.(interface {
 		Fatal() bool
 	}); ok {

--- a/errutil/errors_test.go
+++ b/errutil/errors_test.go
@@ -73,15 +73,3 @@ func TestContextOnWrappedErrors(t *testing.T) {
 		t.Errorf("expected to delete from error context")
 	}
 }
-
-func TestStack(t *testing.T) {
-	s := ErrorStack(errors.New("Go error"))
-	if len(s) > 0 {
-		t.Error("expected to get no stack from a Go error")
-	}
-
-	s = ErrorStack(NewFatalError(errors.New("Go error")))
-	if len(s) == 0 {
-		t.Error("expected to get a stack from a wrapped error")
-	}
-}

--- a/httputil/request_error_test.go
+++ b/httputil/request_error_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/github/git-lfs/config"
@@ -71,7 +72,7 @@ func TestErrorStatusWithCustomMessage(t *testing.T) {
 		}
 
 		expected := fmt.Sprintf("custom error for %d", status)
-		if actual := err.Error(); actual != expected {
+		if actual := err.Error(); !strings.HasSuffix(actual, expected) {
 			t.Errorf("Expected for HTTP %d:\n%s\nACTUAL:\n%s", status, expected, actual)
 			continue
 		}
@@ -134,8 +135,7 @@ func TestErrorStatusWithDefaultMessage(t *testing.T) {
 		}
 
 		expected := fmt.Sprintf(results[0], rawurl)
-
-		if actual := err.Error(); actual != expected {
+		if actual := err.Error(); !strings.HasSuffix(actual, expected) {
 			t.Errorf("Expected for HTTP %d:\n%s\nACTUAL:\n%s", status, expected, actual)
 			continue
 		}

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -3,7 +3,6 @@ package lfs
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,6 +14,7 @@ import (
 	"github.com/github/git-lfs/errutil"
 	"github.com/github/git-lfs/progress"
 	"github.com/github/git-lfs/transfer"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -95,7 +95,7 @@ func DecodePointerFromFile(file string) (*Pointer, error) {
 		return nil, err
 	}
 	if stat.Size() > blobSizeCutoff {
-		return nil, errutil.NewNotAPointerError(nil)
+		return nil, errutil.NewNotAPointerError(errors.New("file size exceeds lfs pointer size cutoff"))
 	}
 	f, err := os.OpenFile(file, os.O_RDONLY, 0644)
 	if err != nil {
@@ -234,7 +234,7 @@ func decodeKVData(data []byte) (kvps map[string]string, exts map[string]string, 
 	kvps = make(map[string]string)
 
 	if !matcherRE.Match(data) {
-		err = errutil.NewNotAPointerError(err)
+		err = errutil.NewNotAPointerError(errors.New("invalid header"))
 		return
 	}
 

--- a/test/test-pointer.sh
+++ b/test/test-pointer.sh
@@ -120,9 +120,9 @@ begin_test "pointer --stdin with bad pointer"
 
   expected="Pointer from STDIN
 
-Not a valid Git LFS pointer file."
+Pointer file error: invalid header"
 
-  [ "$expected" = "$output" ]
+  diff -u <(printf "$expected") <(printf "$output")
 
   [ "1" = "$status" ]
 )
@@ -239,7 +239,9 @@ begin_test "pointer invalid --pointer"
 
   expected="Pointer from some-pointer
 
-Not a valid Git LFS pointer file."
+Pointer file error: invalid header
+
+  diff -u <(printf "$expected") <(printf "$output")
 
   [ "$expected" = "$output" ]
 )


### PR DESCRIPTION
@ttaylorr: Once I fixed `errorWrapper` to embed an `errorWithCause`, it was just a matter of fixing up some error messages:

* the http errors are being wrapped with no `message`. Since `errorWrapper` needs an `errorWithCause`, I added a default `"LFS"` context message.
* Fixed a few spots during lfs pointer parsing where a `nil` error was being passed. I think the new pointer error messages are better.

Those two issues are because `errors.Wrap()` is fundamentally different from the current error wrapper:

## OLD

```golang
err := errors.New("fatal error writing to disk blah blah")
wrapped := newWrappedError(err, "error writing to .git/lfs/objects")
```

It currently replaces the error message with a message more applicable to LFS. Seeing LFS die with some internal io error or whatever is not helpful. Seeing something like this was my original intention:

```
error writing to .git/lfs/objects
fatal error writing to disk blah blah
```

For whatever dumb reason, the old pointer code passed a nil error, resulting in a message like:

```
Not a valid Git LFS pointer file.
<nil> # just a blank space, but this is where an inner error should be
```

## NEW

The new `errors.Wrap()` adds the context as a prefix. So, the pointer errors in my failing test looked like this:

```
Not a valid Git LFS pointer file.: Error
```

At first I thought something was weirdly reversing the string. Instead, I sent real error messages, and shortened the new error prefix in a09c4642b4b730fe179e58eb57da65aff39c9e89.

## TODO

I think this is good to merge into `errors-next`. I think we should also review all the errors and clean up the other spots that are passing `nil` errors.

Also, probably always import `github.com/pkg/errors` instead of just `errors` for consistency.