### PR TITLE
Add HTTP 507 (Insufficient Storage) to the list of optional statuses

### DIFF
--- a/docs/api/v1/http-v1-batch.md
+++ b/docs/api/v1/http-v1-batch.md
@@ -285,6 +285,7 @@ specify any rate limits, implementors are encouraged to set some for
 availability reasons.
 * 501 - The server has not implemented the current method.  Reserved for future
 use.
+* 507 - The server has insufficient storage capacity to complete the request.
 * 509 - The bandwidth limit for the user or repository has been exceeded.  The
 API does not specify any bandwidth limit, but implementors may track usage.
 

--- a/httputil/request_error_test.go
+++ b/httputil/request_error_test.go
@@ -43,6 +43,7 @@ func TestErrorStatusWithCustomMessage(t *testing.T) {
 		501: "not panic",
 		503: "panic",
 		504: "panic",
+		507: "not panic",
 		509: "not panic",
 	}
 
@@ -99,12 +100,13 @@ func TestErrorStatusWithDefaultMessage(t *testing.T) {
 		404: {defaultErrors[404], "not panic"},
 		405: {defaultErrors[400] + " from HTTP 405", "not panic"},
 		406: {defaultErrors[400] + " from HTTP 406", "not panic"},
-		429: {defaultErrors[400] + " from HTTP 429", "not panic"},
+		429: {defaultErrors[429], "not panic"},
 		500: {defaultErrors[500], "panic"},
 		501: {defaultErrors[500] + " from HTTP 501", "not panic"},
 		503: {defaultErrors[500] + " from HTTP 503", "panic"},
 		504: {defaultErrors[500] + " from HTTP 504", "panic"},
-		509: {defaultErrors[500] + " from HTTP 509", "not panic"},
+		507: {defaultErrors[507], "not panic"},
+		509: {defaultErrors[509], "not panic"},
 	}
 
 	for status, results := range statuses {

--- a/httputil/response.go
+++ b/httputil/response.go
@@ -25,7 +25,10 @@ var (
 		401: "Authorization error: %s\nCheck that you have proper access to the repository",
 		403: "Authorization error: %s\nCheck that you have proper access to the repository",
 		404: "Repository or object not found: %s\nCheck that it exists and that you have proper access to it",
+		429: "Rate limit exceeded: %s",
 		500: "Server error: %s",
+		507: "Insufficient server storage: %s",
+		509: "Bandwidth limit exceeded: %s",
 	}
 )
 
@@ -85,7 +88,7 @@ func handleResponse(cfg *config.Configuration, res *http.Response, creds auth.Cr
 		return errors.NewAuthError(err)
 	}
 
-	if res.StatusCode > 499 && res.StatusCode != 501 && res.StatusCode != 509 {
+	if res.StatusCode > 499 && res.StatusCode != 501 && res.StatusCode != 507 && res.StatusCode != 509 {
 		if err == nil {
 			err = errors.Errorf("api: received status %d", res.StatusCode)
 		}


### PR DESCRIPTION
Mention that the server implementation may optionally return status
code 507.

This does not add any specific handling of 507 in either the client or
the test server implementation. If a server returns this status code,
it will be handled by the client as a generic "Server Error".

See #1327 and #1438.
