### PR TITLE
Support wrapped clone in current directory

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -233,8 +233,9 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		return &cobra.Command{
-			Use: "checkout",
-			Run: checkoutCommand,
+			Use:    "checkout",
+			Run:    checkoutCommand,
+			PreRun: resolveLocalStorage,
 		}
 	})
 }

--- a/commands/command_clean.go
+++ b/commands/command_clean.go
@@ -77,8 +77,9 @@ func cleanCommand(cmd *cobra.Command, args []string) {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		return &cobra.Command{
-			Use: "clean",
-			Run: cleanCommand,
+			Use:    "clean",
+			Run:    cleanCommand,
+			PreRun: resolveLocalStorage,
 		}
 	})
 }

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/github/git-lfs/localstorage"
 	"github.com/github/git-lfs/subprocess"
 
 	"github.com/github/git-lfs/git"
-	"github.com/github/git-lfs/localstorage"
 	"github.com/github/git-lfs/tools"
 	"github.com/spf13/cobra"
 )

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -48,8 +48,9 @@ func envCommand(cmd *cobra.Command, args []string) {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		return &cobra.Command{
-			Use: "env",
-			Run: envCommand,
+			Use:    "env",
+			PreRun: resolveLocalStorage,
+			Run:    envCommand,
 		}
 	})
 }

--- a/commands/command_ext.go
+++ b/commands/command_ext.go
@@ -45,14 +45,16 @@ func printExt(ext config.Extension) {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "ext",
-			Run: extCommand,
+			Use:    "ext",
+			PreRun: resolveLocalStorage,
+			Run:    extCommand,
 		}
 
 		cmd.AddCommand(&cobra.Command{
-			Use:   "list",
-			Short: "View details for specified extensions",
-			Run:   extListCommand,
+			Use:    "list",
+			Short:  "View details for specified extensions",
+			PreRun: resolveLocalStorage,
+			Run:    extListCommand,
 		})
 		return cmd
 	})

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -333,8 +333,9 @@ func readyAndMissingPointers(allpointers []*lfs.WrappedPointer, include, exclude
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "fetch",
-			Run: fetchCommand,
+			Use:    "fetch",
+			PreRun: resolveLocalStorage,
+			Run:    fetchCommand,
 		}
 
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -117,8 +117,9 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "fsck",
-			Run: fsckCommand,
+			Use:    "fsck",
+			PreRun: resolveLocalStorage,
+			Run:    fsckCommand,
 		}
 
 		cmd.Flags().BoolVarP(&fsckDryRun, "dry-run", "d", false, "List corrupt objects without deleting them.")

--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -21,16 +21,18 @@ func initHooksCommand(cmd *cobra.Command, args []string) {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "init",
-			Run: initCommand,
+			Use:    "init",
+			PreRun: resolveLocalStorage,
+			Run:    initCommand,
 		}
 
 		cmd.Flags().BoolVarP(&forceInstall, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
 		cmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
 		cmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
 		cmd.AddCommand(&cobra.Command{
-			Use: "hooks",
-			Run: initHooksCommand,
+			Use:    "hooks",
+			PreRun: resolveLocalStorage,
+			Run:    initHooksCommand,
 		})
 		return cmd
 	})

--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -55,8 +55,9 @@ func installHooksCommand(cmd *cobra.Command, args []string) {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "install",
-			Run: installCommand,
+			Use:    "install",
+			PreRun: resolveLocalStorage,
+			Run:    installCommand,
 		}
 
 		cmd.Flags().BoolVarP(&forceInstall, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
@@ -64,8 +65,9 @@ func init() {
 		cmd.Flags().BoolVarP(&systemInstall, "system", "", false, "Set the Git LFS config in system-wide scope.")
 		cmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
 		cmd.AddCommand(&cobra.Command{
-			Use: "hooks",
-			Run: installHooksCommand,
+			Use:    "hooks",
+			PreRun: resolveLocalStorage,
+			Run:    installHooksCommand,
 		})
 		return cmd
 	})

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -108,8 +108,9 @@ func init() {
 		}
 
 		cmd := &cobra.Command{
-			Use: "lock",
-			Run: lockCommand,
+			Use:    "lock",
+			PreRun: resolveLocalStorage,
+			Run:    lockCommand,
 		}
 
 		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -92,8 +92,9 @@ func init() {
 			return nil
 		}
 		cmd := &cobra.Command{
-			Use: "locks",
-			Run: locksCommand,
+			Use:    "locks",
+			PreRun: resolveLocalStorage,
+			Run:    locksCommand,
 		}
 
 		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)

--- a/commands/command_logs.go
+++ b/commands/command_logs.go
@@ -78,26 +78,31 @@ func sortedLogs() []string {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "logs",
-			Run: logsCommand,
+			Use:    "logs",
+			PreRun: resolveLocalStorage,
+			Run:    logsCommand,
 		}
 
 		cmd.AddCommand(
 			&cobra.Command{
-				Use: "last",
-				Run: logsLastCommand,
+				Use:    "last",
+				PreRun: resolveLocalStorage,
+				Run:    logsLastCommand,
 			},
 			&cobra.Command{
-				Use: "show",
-				Run: logsShowCommand,
+				Use:    "show",
+				PreRun: resolveLocalStorage,
+				Run:    logsShowCommand,
 			},
 			&cobra.Command{
-				Use: "clear",
-				Run: logsClearCommand,
+				Use:    "clear",
+				PreRun: resolveLocalStorage,
+				Run:    logsClearCommand,
 			},
 			&cobra.Command{
-				Use: "boomtown",
-				Run: logsBoomtownCommand,
+				Use:    "boomtown",
+				PreRun: resolveLocalStorage,
+				Run:    logsBoomtownCommand,
 			},
 		)
 		return cmd

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -55,8 +55,9 @@ func lsFilesMarker(p *lfs.WrappedPointer) string {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "ls-files",
-			Run: lsFilesCommand,
+			Use:    "ls-files",
+			PreRun: resolveLocalStorage,
+			Run:    lsFilesCommand,
 		}
 
 		cmd.Flags().BoolVarP(&longOIDs, "long", "l", false, "")

--- a/commands/command_pointer.go
+++ b/commands/command_pointer.go
@@ -131,8 +131,9 @@ func gitHashObject(by []byte) string {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "pointer",
-			Run: pointerCommand,
+			Use:    "pointer",
+			PreRun: resolveLocalStorage,
+			Run:    pointerCommand,
 		}
 
 		cmd.Flags().StringVarP(&pointerFile, "file", "f", "", "Path to a local file to generate the pointer from.")

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -100,8 +100,9 @@ func decodeRefs(input string) (string, string) {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "pre-push",
-			Run: prePushCommand,
+			Use:    "pre-push",
+			PreRun: resolveLocalStorage,
+			Run:    prePushCommand,
 		}
 
 		cmd.Flags().BoolVarP(&prePushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -476,9 +476,10 @@ func pruneTaskGetReachableObjects(outObjectSet *tools.StringSet, errorChan chan 
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "prune",
-			Short: "Deletes old LFS files from the local store",
-			Run:   pruneCommand,
+			Use:    "prune",
+			Short:  "Deletes old LFS files from the local store",
+			PreRun: resolveLocalStorage,
+			Run:    pruneCommand,
 		}
 
 		cmd.Flags().BoolVarP(&pruneDryRunArg, "dry-run", "d", false, "Don't delete anything, just report")

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -46,8 +46,9 @@ func pull(includePaths, excludePaths []string) {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "pull",
-			Run: pullCommand,
+			Use:    "pull",
+			PreRun: resolveLocalStorage,
+			Run:    pullCommand,
 		}
 
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -165,8 +165,9 @@ func pushCommand(cmd *cobra.Command, args []string) {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "push",
-			Run: pushCommand,
+			Use:    "push",
+			PreRun: resolveLocalStorage,
+			Run:    pushCommand,
 		}
 
 		cmd.Flags().BoolVarP(&pushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -95,8 +95,9 @@ func smudgeFilename(args []string, err error) string {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "smudge",
-			Run: smudgeCommand,
+			Use:    "smudge",
+			PreRun: resolveLocalStorage,
+			Run:    smudgeCommand,
 		}
 
 		cmd.Flags().BoolVarP(&smudgeInfo, "info", "i", false, "")

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -99,8 +99,9 @@ func humanizeBytes(bytes int64) string {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "status",
-			Run: statusCommand,
+			Use:    "status",
+			PreRun: resolveLocalStorage,
+			Run:    statusCommand,
 		}
 
 		cmd.Flags().BoolVarP(&porcelain, "porcelain", "p", false, "Give the output in an easy-to-parse format for scripts.")

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -233,8 +233,9 @@ func blocklistItem(name string) string {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "track",
-			Run: trackCommand,
+			Use:    "track",
+			PreRun: resolveLocalStorage,
+			Run:    trackCommand,
 		}
 
 		cmd.Flags().BoolVarP(&trackVerboseLoggingFlag, "verbose", "v", false, "log which files are being tracked and modified")

--- a/commands/command_uninit.go
+++ b/commands/command_uninit.go
@@ -24,13 +24,15 @@ func uninitHooksCommand(cmd *cobra.Command, args []string) {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "uninit",
-			Run: uninitCommand,
+			Use:    "uninit",
+			PreRun: resolveLocalStorage,
+			Run:    uninitCommand,
 		}
 
 		cmd.AddCommand(&cobra.Command{
-			Use: "hooks",
-			Run: uninitHooksCommand,
+			Use:    "hooks",
+			PreRun: resolveLocalStorage,
+			Run:    uninitHooksCommand,
 		})
 		return cmd
 	})

--- a/commands/command_uninstall.go
+++ b/commands/command_uninstall.go
@@ -30,13 +30,15 @@ func uninstallHooksCommand(cmd *cobra.Command, args []string) {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "uninstall",
-			Run: uninstallCommand,
+			Use:    "uninstall",
+			PreRun: resolveLocalStorage,
+			Run:    uninstallCommand,
 		}
 
 		cmd.AddCommand(&cobra.Command{
-			Use: "hooks",
-			Run: uninstallHooksCommand,
+			Use:    "hooks",
+			PreRun: resolveLocalStorage,
+			Run:    uninstallHooksCommand,
 		})
 		return cmd
 	})

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -99,8 +99,9 @@ func init() {
 		}
 
 		cmd := &cobra.Command{
-			Use: "unlock",
-			Run: unlockCommand,
+			Use:    "unlock",
+			PreRun: resolveLocalStorage,
+			Run:    unlockCommand,
 		}
 
 		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)

--- a/commands/command_untrack.go
+++ b/commands/command_untrack.go
@@ -77,8 +77,9 @@ func removePath(path string, args []string) bool {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		return &cobra.Command{
-			Use: "untrack",
-			Run: untrackCommand,
+			Use:    "untrack",
+			PreRun: resolveLocalStorage,
+			Run:    untrackCommand,
 		}
 	})
 }

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -57,8 +57,9 @@ func updateCommand(cmd *cobra.Command, args []string) {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "update",
-			Run: updateCommand,
+			Use:    "update",
+			PreRun: resolveLocalStorage,
+			Run:    updateCommand,
 		}
 		cmd.Flags().BoolVarP(&updateForce, "force", "f", false, "Overwrite existing hooks.")
 		cmd.Flags().BoolVarP(&updateManual, "manual", "m", false, "Print instructions for manual install.")

--- a/commands/command_version.go
+++ b/commands/command_version.go
@@ -20,8 +20,9 @@ func versionCommand(cmd *cobra.Command, args []string) {
 func init() {
 	RegisterSubcommand(func() *cobra.Command {
 		cmd := &cobra.Command{
-			Use: "version",
-			Run: versionCommand,
+			Use:    "version",
+			PreRun: resolveLocalStorage,
+			Run:    versionCommand,
 		}
 
 		cmd.Flags().BoolVarP(&lovesComics, "comics", "c", false, "easter egg")

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -18,6 +18,7 @@ import (
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/httputil"
 	"github.com/github/git-lfs/lfs"
+	"github.com/github/git-lfs/localstorage"
 	"github.com/github/git-lfs/tools"
 	"github.com/github/git-lfs/transfer"
 	"github.com/spf13/cobra"
@@ -332,6 +333,13 @@ func requireGitVersion() {
 		}
 		Exit("git version >= %s is required for Git LFS, your version: %s", minimumGit, gitver)
 	}
+}
+
+// resolveLocalStorage implements the `func(*cobra.Command, []string)` signature
+// necessary to wire it up via `cobra.Command.PreRun`. When run, this function
+// will resolve the localstorage directories.
+func resolveLocalStorage(cmd *cobra.Command, args []string) {
+	localstorage.ResolveDirs()
 }
 
 func init() {

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -140,8 +140,6 @@ func ScanObjectsChan() <-chan localstorage.Object {
 func init() {
 	tracerx.DefaultKey = "GIT"
 	tracerx.Prefix = "trace git-lfs: "
-
-	localstorage.ResolveDirs()
 }
 
 const (

--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -443,3 +443,40 @@ begin_test "clone with submodules"
 
 )
 end_test
+
+begin_test "clone in current directory"
+(
+  set -e
+
+  reponame="clone_in_current_dir"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" $reponame
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \*.dat" track.log
+
+  contents="contents"
+  contents_oid="$(calc_oid "$contents")"
+
+  printf "$contents" > a.dat
+
+  git add .gitattributes a.dat
+
+  git commit -m "initial commit" 2>&1 | tee commit.log
+  grep "master (root-commit)" commit.log
+  grep "2 files changed" commit.log
+  grep "create mode 100644 a.dat" commit.log
+  grep "create mode 100644 .gitattributes" commit.log
+
+  git push origin master 2>&1 | tee push.log
+
+  pushd $TRASHDIR
+    mkdir "$reponame-clone"
+    cd "$reponame-clone"
+
+    git lfs clone $GITSERVER/$reponame "." 2>&1 | grep "Git LFS"
+
+    assert_local_object "$contents_oid" 8
+  popd
+)
+end_test

--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -58,6 +58,7 @@ begin_test "clone"
   [ $(wc -c < "file1.dat") -eq 110 ] 
   [ $(wc -c < "file2.dat") -eq 75 ] 
   [ $(wc -c < "file3.dat") -eq 66 ] 
+  [ ! -e "lfs" ]
   popd
   # Now check clone with implied dir
   rm -rf "$reponame"
@@ -73,6 +74,7 @@ begin_test "clone"
   [ $(wc -c < "file1.dat") -eq 110 ] 
   [ $(wc -c < "file2.dat") -eq 75 ] 
   [ $(wc -c < "file3.dat") -eq 66 ] 
+  [ ! -e "lfs" ]
   popd
 
 )
@@ -477,6 +479,7 @@ begin_test "clone in current directory"
     git lfs clone $GITSERVER/$reponame "." 2>&1 | grep "Git LFS"
 
     assert_local_object "$contents_oid" 8
+    [ ! -f ./lfs ]
   popd
 )
 end_test


### PR DESCRIPTION
This PR supports cloning into the current directory, `"."`, a-la:

```bash
$ git lfs clone git@github.com:foo/bar.git .
```

Previously, this was broken because an invocation to the `git-lfs clone` command would create a `localstorage` directory due to a call to the [`localstorage.ResolveDirs`](https://github.com/github/git-lfs/blob/c21de411141a7536689a63e1f82bcc02f46fdf83/localstorage/currentstore.go#L28-L47) function causing both of [these](https://github.com/github/git-lfs/blob/c21de411141a7536689a63e1f82bcc02f46fdf83/localstorage/currentstore.go#L34-L35) files to be created. The presence of those files violated a `git-clone` invariant that the clone target must be empty. That source of that call is from the `init()` function in the `lfs` package, [here](https://github.com/github/git-lfs/blob/68c0e18d05de0e60c8ce774b5b3163062b47e5a0/lfs/lfs.go#L144).

In https://github.com/github/git-lfs/commit/e447be2172b4b767089516432065003f31ccf9d2, I removed that call, and instead replaced it with a `PreRun` hook on all of our commands, except `clone`. `PreRun` hooks, as dictated by the `cobra` package will run before the actual `Run` function of the command.

In a further PR, we should definitely take a look at which commands _actually_ need to have the `localstorage` stuff initialized.

--

/cc @technoweenie @rubyist @sinbad for review
/cc @tarka #1431 for a heads-up