### PR TITLE
Add a .mailmap to make the output of `git shortlog` look nicer

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+Evan Priestley <epriestley@javelinjs.com> epriestley <git@epriestley.com>
+Josh Vera <josh@joshvera.com>             joshvera <vera@github.com>
+Rick Olson <technoweenie@gmail.com>       rick <technoweenie@gmail.com>
+Rick Olson <technoweenie@gmail.com>       risk danger olson <technoweenie@gmail.com>
+Scott Barron <scott.barron@github.com>    rubyist <scott.barron@github.com>
+William Hipschman <willhi@microsoft.com>  Will <willhi@microsoft.com>


### PR DESCRIPTION
When the repository has lots of commits by authors with incomplete
or inconsistent names, the output of `git shortlog` is not much use:

```
$ git shortlog -n -c -s | head -10
   922  risk danger olson
   673  Rick Olson
   601  Steve Streeting
   412  rubyist
   280  Taylor Blau
   102  Andy Neff
   101  rick
    82  Michael Käufl
    75  Scott Barron
    34  William Hipschman
```
Adding a mailmap makes the output look better:

```
$ git shortlog -n -c -s | head -10
  1696	Rick Olson
   601	Steve Streeting
   487	Scott Barron
   280	Taylor Blau
   102	Andy Neff
    82	Michael Käufl
    39	William Hipschman
    23	Lars Schneider
    21	Brett Randall
    20	Brandon Keepers
```
