### PR TITLE
Test `RetriableReader`

### DIFF
--- a/tools/iotools.go
+++ b/tools/iotools.go
@@ -98,10 +98,16 @@ func NewRetriableReader(r io.Reader) io.Reader {
 
 func (r *RetriableReader) Read(b []byte) (int, error) {
 	n, err := r.reader.Read(b)
-	// EOF is a successful response as it is used to signal a graceful end of input
-	// c.f. https://git.io/v6riQ
-	if err == nil || err == io.EOF {
+
+	// EOF is a successful response as it is used to signal a graceful end
+	// of input c.f. https://git.io/v6riQ
+	//
+	// Otherwise, if the error is non-nill and already retriable (in the
+	// case that the underlying reader `r.reader` is itself a
+	// `*RetriableReader`, return the error wholesale:
+	if err == nil || err == io.EOF || errors.IsRetriableError(err) {
 		return n, err
 	}
+
 	return n, errors.NewRetriableError(err)
 }

--- a/tools/iotools.go
+++ b/tools/iotools.go
@@ -102,7 +102,7 @@ func (r *RetriableReader) Read(b []byte) (int, error) {
 	// EOF is a successful response as it is used to signal a graceful end
 	// of input c.f. https://git.io/v6riQ
 	//
-	// Otherwise, if the error is non-nill and already retriable (in the
+	// Otherwise, if the error is non-nil and already retriable (in the
 	// case that the underlying reader `r.reader` is itself a
 	// `*RetriableReader`, return the error wholesale:
 	if err == nil || err == io.EOF || errors.IsRetriableError(err) {

--- a/tools/iotools_test.go
+++ b/tools/iotools_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 
 	"github.com/github/git-lfs/errors"
-	. "github.com/github/git-lfs/tools"
+	"github.com/github/git-lfs/tools"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRetriableReaderReturnsSuccessfulReads(t *testing.T) {
-	r := NewRetriableReader(bytes.NewBuffer([]byte{0x1, 0x2, 0x3, 0x4}))
+	r := tools.NewRetriableReader(bytes.NewBuffer([]byte{0x1, 0x2, 0x3, 0x4}))
 
 	var buf [4]byte
 	n, err := r.Read(buf[:])
@@ -22,7 +22,7 @@ func TestRetriableReaderReturnsSuccessfulReads(t *testing.T) {
 }
 
 func TestRetriableReaderReturnsEOFs(t *testing.T) {
-	r := NewRetriableReader(bytes.NewBuffer([]byte{ /* empty */ }))
+	r := tools.NewRetriableReader(bytes.NewBuffer([]byte{ /* empty */ }))
 
 	var buf [1]byte
 	n, err := r.Read(buf[:])
@@ -34,7 +34,7 @@ func TestRetriableReaderReturnsEOFs(t *testing.T) {
 func TestRetriableReaderMakesErrorsRetriable(t *testing.T) {
 	expected := errors.New("example error")
 
-	r := NewRetriableReader(&ErrReader{expected})
+	r := tools.NewRetriableReader(&ErrReader{expected})
 
 	var buf [1]byte
 	n, err := r.Read(buf[:])
@@ -50,7 +50,7 @@ func TestRetriableReaderDoesNotRewrap(t *testing.T) {
 	// underlying reader was a *RetriableReader itself.
 	expected := errors.NewRetriableError(errors.New("example error"))
 
-	r := NewRetriableReader(&ErrReader{expected})
+	r := tools.NewRetriableReader(&ErrReader{expected})
 
 	var buf [1]byte
 	n, err := r.Read(buf[:])

--- a/tools/iotools_test.go
+++ b/tools/iotools_test.go
@@ -1,0 +1,76 @@
+package tools_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/github/git-lfs/errors"
+	. "github.com/github/git-lfs/tools"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetriableReaderReturnsSuccessfulReads(t *testing.T) {
+	r := NewRetriableReader(bytes.NewBuffer([]byte{0x1, 0x2, 0x3, 0x4}))
+
+	var buf [4]byte
+	n, err := r.Read(buf[:])
+
+	assert.Nil(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, []byte{0x1, 0x2, 0x3, 0x4}, buf[:])
+}
+
+func TestRetriableReaderReturnsEOFs(t *testing.T) {
+	r := NewRetriableReader(bytes.NewBuffer([]byte{ /* empty */ }))
+
+	var buf [1]byte
+	n, err := r.Read(buf[:])
+
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestRetriableReaderMakesErrorsRetriable(t *testing.T) {
+	expected := errors.New("example error")
+
+	r := NewRetriableReader(&ErrReader{expected})
+
+	var buf [1]byte
+	n, err := r.Read(buf[:])
+
+	assert.Equal(t, 0, n)
+	assert.EqualError(t, err, "LFS: "+expected.Error())
+	assert.True(t, errors.IsRetriableError(err))
+
+}
+
+func TestRetriableReaderDoesNotRewrap(t *testing.T) {
+	// expected is already "retriable", as would be the case if the
+	// underlying reader was a *RetriableReader itself.
+	expected := errors.NewRetriableError(errors.New("example error"))
+
+	r := NewRetriableReader(&ErrReader{expected})
+
+	var buf [1]byte
+	n, err := r.Read(buf[:])
+
+	assert.Equal(t, 0, n)
+	// errors.NewRetriableError wraps the given error with the prefix
+	// message "LFS", so these two errors should be equal, indicating that
+	// the RetriableReader did not re-wrap the error it received.
+	assert.EqualError(t, err, expected.Error())
+	assert.True(t, errors.IsRetriableError(err))
+
+}
+
+// ErrReader implements io.Reader and only returns errors.
+type ErrReader struct {
+	// err is the error that this reader will return.
+	err error
+}
+
+// Read implements io.Reader#Read, and returns (0, e.err).
+func (e *ErrReader) Read(p []byte) (n int, err error) {
+	return 0, e.err
+}


### PR DESCRIPTION
This pull-request is a small addendum to @larsxschneider's #1454 to add tests around the `RetriableReader`.

The only behavior change in this PR is that `RetriableReader` will no longer re-wrap already retriable errors, per https://github.com/github/git-lfs/pull/1454#discussion_r76088729.

-

/cc @technoweenie @larsxschneider for 💭  and 👀 