### PR TITLE
Allow lfs.pushurl in .lfsconfig

### DIFF
--- a/config/config_windows.go
+++ b/config/config_windows.go
@@ -1,4 +1,5 @@
 // +build windows
+
 package config
 
 var netrcBasename = "_netrc"

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -179,5 +179,6 @@ var safeKeys = []string{
 	"lfs.fetchexclude",
 	"lfs.fetchinclude",
 	"lfs.gitprotocol",
+	"lfs.pushurl",
 	"lfs.url",
 }


### PR DESCRIPTION
This adds `lfs.pushurl` to the safelist for `.lfsconfig` files. Fixes #1488