### PR TITLE
commands: try out RegisterCommand()

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -231,11 +231,5 @@ func checkoutWithChan(in <-chan *lfs.WrappedPointer) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		return &cobra.Command{
-			Use:    "checkout",
-			Run:    checkoutCommand,
-			PreRun: resolveLocalStorage,
-		}
-	})
+	RegisterCommand("checkout", checkoutCommand, nil)
 }

--- a/commands/command_clean.go
+++ b/commands/command_clean.go
@@ -75,11 +75,5 @@ func cleanCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		return &cobra.Command{
-			Use:    "clean",
-			Run:    cleanCommand,
-			PreRun: resolveLocalStorage,
-		}
-	})
+	RegisterCommand("clean", cleanCommand, nil)
 }

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -108,11 +108,8 @@ func postCloneSubmodules(args []string) error {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use: "clone",
-			Run: cloneCommand,
-		}
+	RegisterCommand("clone", cloneCommand, func(cmd *cobra.Command) bool {
+		cmd.PreRun = nil
 
 		// Mirror all git clone flags
 		cmd.Flags().StringVarP(&cloneFlags.TemplateDirectory, "template", "", "", "See 'git clone --help'")
@@ -142,6 +139,6 @@ func init() {
 
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
-		return cmd
+		return true
 	})
 }

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -108,7 +108,7 @@ func postCloneSubmodules(args []string) error {
 }
 
 func init() {
-	RegisterCommand("clone", cloneCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("clone", cloneCommand, func(cmd *cobra.Command) {
 		cmd.PreRun = nil
 
 		// Mirror all git clone flags
@@ -139,6 +139,5 @@ func init() {
 
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
-		return true
 	})
 }

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -46,11 +46,8 @@ func envCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		return &cobra.Command{
-			Use:    "env",
-			PreRun: resolveLocalStorage,
-			Run:    envCommand,
-		}
+	RegisterCommand("env", envCommand, func(cmd *cobra.Command) bool {
+		cmd.PreRun = nil
+		return true
 	})
 }

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -47,7 +47,6 @@ func envCommand(cmd *cobra.Command, args []string) {
 
 func init() {
 	RegisterCommand("env", envCommand, func(cmd *cobra.Command) bool {
-		cmd.PreRun = nil
 		return true
 	})
 }

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -46,7 +46,5 @@ func envCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterCommand("env", envCommand, func(cmd *cobra.Command) bool {
-		return true
-	})
+	RegisterCommand("env", envCommand, nil)
 }

--- a/commands/command_ext.go
+++ b/commands/command_ext.go
@@ -43,19 +43,8 @@ func printExt(ext config.Extension) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "ext",
-			PreRun: resolveLocalStorage,
-			Run:    extCommand,
-		}
-
-		cmd.AddCommand(&cobra.Command{
-			Use:    "list",
-			Short:  "View details for specified extensions",
-			PreRun: resolveLocalStorage,
-			Run:    extListCommand,
-		})
-		return cmd
+	RegisterCommand("ext", extCommand, func(cmd *cobra.Command) bool {
+		cmd.AddCommand(NewCommand("list", extListCommand))
+		return true
 	})
 }

--- a/commands/command_ext.go
+++ b/commands/command_ext.go
@@ -43,8 +43,7 @@ func printExt(ext config.Extension) {
 }
 
 func init() {
-	RegisterCommand("ext", extCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("ext", extCommand, func(cmd *cobra.Command) {
 		cmd.AddCommand(NewCommand("list", extListCommand))
-		return true
 	})
 }

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -331,12 +331,11 @@ func readyAndMissingPointers(allpointers []*lfs.WrappedPointer, include, exclude
 }
 
 func init() {
-	RegisterCommand("fetch", fetchCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("fetch", fetchCommand, func(cmd *cobra.Command) {
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
 		cmd.Flags().BoolVarP(&fetchRecentArg, "recent", "r", false, "Fetch recent refs & commits")
 		cmd.Flags().BoolVarP(&fetchAllArg, "all", "a", false, "Fetch all LFS files ever referenced")
 		cmd.Flags().BoolVarP(&fetchPruneArg, "prune", "p", false, "After fetching, prune old data")
-		return true
 	})
 }

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -331,18 +331,12 @@ func readyAndMissingPointers(allpointers []*lfs.WrappedPointer, include, exclude
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "fetch",
-			PreRun: resolveLocalStorage,
-			Run:    fetchCommand,
-		}
-
+	RegisterCommand("fetch", fetchCommand, func(cmd *cobra.Command) bool {
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
 		cmd.Flags().BoolVarP(&fetchRecentArg, "recent", "r", false, "Fetch recent refs & commits")
 		cmd.Flags().BoolVarP(&fetchAllArg, "all", "a", false, "Fetch all LFS files ever referenced")
 		cmd.Flags().BoolVarP(&fetchPruneArg, "prune", "p", false, "After fetching, prune old data")
-		return cmd
+		return true
 	})
 }

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -115,14 +115,8 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "fsck",
-			PreRun: resolveLocalStorage,
-			Run:    fsckCommand,
-		}
-
+	RegisterCommand("fsck", fsckCommand, func(cmd *cobra.Command) bool {
 		cmd.Flags().BoolVarP(&fsckDryRun, "dry-run", "d", false, "List corrupt objects without deleting them.")
-		return cmd
+		return true
 	})
 }

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -115,8 +115,7 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterCommand("fsck", fsckCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("fsck", fsckCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&fsckDryRun, "dry-run", "d", false, "List corrupt objects without deleting them.")
-		return true
 	})
 }

--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -19,21 +19,11 @@ func initHooksCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "init",
-			PreRun: resolveLocalStorage,
-			Run:    initCommand,
-		}
-
+	RegisterCommand("init", initCommand, func(cmd *cobra.Command) bool {
 		cmd.Flags().BoolVarP(&forceInstall, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
 		cmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
 		cmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
-		cmd.AddCommand(&cobra.Command{
-			Use:    "hooks",
-			PreRun: resolveLocalStorage,
-			Run:    initHooksCommand,
-		})
-		return cmd
+		cmd.AddCommand(NewCommand("hooks", initHooksCommand))
+		return true
 	})
 }

--- a/commands/command_init.go
+++ b/commands/command_init.go
@@ -19,11 +19,10 @@ func initHooksCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterCommand("init", initCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("init", initCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&forceInstall, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
 		cmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
 		cmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
 		cmd.AddCommand(NewCommand("hooks", initHooksCommand))
-		return true
 	})
 }

--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -53,12 +53,11 @@ func installHooksCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterCommand("install", installCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("install", installCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&forceInstall, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
 		cmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
 		cmd.Flags().BoolVarP(&systemInstall, "system", "", false, "Set the Git LFS config in system-wide scope.")
 		cmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
 		cmd.AddCommand(NewCommand("hooks", installHooksCommand))
-		return true
 	})
 }

--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -53,22 +53,12 @@ func installHooksCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "install",
-			PreRun: resolveLocalStorage,
-			Run:    installCommand,
-		}
-
+	RegisterCommand("install", installCommand, func(cmd *cobra.Command) bool {
 		cmd.Flags().BoolVarP(&forceInstall, "force", "f", false, "Set the Git LFS global config, overwriting previous values.")
 		cmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
 		cmd.Flags().BoolVarP(&systemInstall, "system", "", false, "Set the Git LFS config in system-wide scope.")
 		cmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
-		cmd.AddCommand(&cobra.Command{
-			Use:    "hooks",
-			PreRun: resolveLocalStorage,
-			Run:    installHooksCommand,
-		})
-		return cmd
+		cmd.AddCommand(NewCommand("hooks", installHooksCommand))
+		return true
 	})
 }

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -102,18 +102,12 @@ func lockPath(file string) (string, error) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
+	RegisterCommand("lock", lockCommand, func(cmd *cobra.Command) bool {
 		if !isCommandEnabled(cfg, "locks") {
-			return nil
-		}
-
-		cmd := &cobra.Command{
-			Use:    "lock",
-			PreRun: resolveLocalStorage,
-			Run:    lockCommand,
+			return false
 		}
 
 		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
-		return cmd
+		return true
 	})
 }

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -102,12 +102,11 @@ func lockPath(file string) (string, error) {
 }
 
 func init() {
-	RegisterCommand("lock", lockCommand, func(cmd *cobra.Command) bool {
-		if !isCommandEnabled(cfg, "locks") {
-			return false
-		}
+	if !isCommandEnabled(cfg, "locks") {
+		return
+	}
 
+	RegisterCommand("lock", lockCommand, func(cmd *cobra.Command) {
 		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
-		return true
 	})
 }

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -87,20 +87,15 @@ func (l *locksFlags) Filters() ([]api.Filter, error) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
+	RegisterCommand("locks", locksCommand, func(cmd *cobra.Command) bool {
 		if !isCommandEnabled(cfg, "locks") {
-			return nil
-		}
-		cmd := &cobra.Command{
-			Use:    "locks",
-			PreRun: resolveLocalStorage,
-			Run:    locksCommand,
+			return false
 		}
 
 		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
 		cmd.Flags().StringVarP(&locksCmdFlags.Path, "path", "p", "", "filter locks results matching a particular path")
 		cmd.Flags().StringVarP(&locksCmdFlags.Id, "id", "i", "", "filter locks results matching a particular ID")
 		cmd.Flags().IntVarP(&locksCmdFlags.Limit, "limit", "l", 0, "optional limit for number of results to return")
-		return cmd
+		return true
 	})
 }

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -87,15 +87,14 @@ func (l *locksFlags) Filters() ([]api.Filter, error) {
 }
 
 func init() {
-	RegisterCommand("locks", locksCommand, func(cmd *cobra.Command) bool {
-		if !isCommandEnabled(cfg, "locks") {
-			return false
-		}
+	if !isCommandEnabled(cfg, "locks") {
+		return
+	}
 
+	RegisterCommand("locks", locksCommand, func(cmd *cobra.Command) {
 		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
 		cmd.Flags().StringVarP(&locksCmdFlags.Path, "path", "p", "", "filter locks results matching a particular path")
 		cmd.Flags().StringVarP(&locksCmdFlags.Id, "id", "i", "", "filter locks results matching a particular ID")
 		cmd.Flags().IntVarP(&locksCmdFlags.Limit, "limit", "l", 0, "optional limit for number of results to return")
-		return true
 	})
 }

--- a/commands/command_logs.go
+++ b/commands/command_logs.go
@@ -76,13 +76,7 @@ func sortedLogs() []string {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "logs",
-			PreRun: resolveLocalStorage,
-			Run:    logsCommand,
-		}
-
+	RegisterCommand("logs", logsCommand, func(cmd *cobra.Command) bool {
 		cmd.AddCommand(
 			&cobra.Command{
 				Use:    "last",
@@ -105,6 +99,6 @@ func init() {
 				Run:    logsBoomtownCommand,
 			},
 		)
-		return cmd
+		return true
 	})
 }

--- a/commands/command_logs.go
+++ b/commands/command_logs.go
@@ -78,26 +78,10 @@ func sortedLogs() []string {
 func init() {
 	RegisterCommand("logs", logsCommand, func(cmd *cobra.Command) bool {
 		cmd.AddCommand(
-			&cobra.Command{
-				Use:    "last",
-				PreRun: resolveLocalStorage,
-				Run:    logsLastCommand,
-			},
-			&cobra.Command{
-				Use:    "show",
-				PreRun: resolveLocalStorage,
-				Run:    logsShowCommand,
-			},
-			&cobra.Command{
-				Use:    "clear",
-				PreRun: resolveLocalStorage,
-				Run:    logsClearCommand,
-			},
-			&cobra.Command{
-				Use:    "boomtown",
-				PreRun: resolveLocalStorage,
-				Run:    logsBoomtownCommand,
-			},
+			NewCommand("last", logsLastCommand),
+			NewCommand("show", logsShowCommand),
+			NewCommand("clear", logsClearCommand),
+			NewCommand("boomtown", logsBoomtownCommand),
 		)
 		return true
 	})

--- a/commands/command_logs.go
+++ b/commands/command_logs.go
@@ -76,13 +76,12 @@ func sortedLogs() []string {
 }
 
 func init() {
-	RegisterCommand("logs", logsCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("logs", logsCommand, func(cmd *cobra.Command) {
 		cmd.AddCommand(
 			NewCommand("last", logsLastCommand),
 			NewCommand("show", logsShowCommand),
 			NewCommand("clear", logsClearCommand),
 			NewCommand("boomtown", logsBoomtownCommand),
 		)
-		return true
 	})
 }

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -53,14 +53,8 @@ func lsFilesMarker(p *lfs.WrappedPointer) string {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "ls-files",
-			PreRun: resolveLocalStorage,
-			Run:    lsFilesCommand,
-		}
-
+	RegisterCommand("ls-files", lsFilesCommand, func(cmd *cobra.Command) bool {
 		cmd.Flags().BoolVarP(&longOIDs, "long", "l", false, "")
-		return cmd
+		return true
 	})
 }

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -53,8 +53,7 @@ func lsFilesMarker(p *lfs.WrappedPointer) string {
 }
 
 func init() {
-	RegisterCommand("ls-files", lsFilesCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("ls-files", lsFilesCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&longOIDs, "long", "l", false, "")
-		return true
 	})
 }

--- a/commands/command_pointer.go
+++ b/commands/command_pointer.go
@@ -129,10 +129,9 @@ func gitHashObject(by []byte) string {
 }
 
 func init() {
-	RegisterCommand("pointer", pointerCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("pointer", pointerCommand, func(cmd *cobra.Command) {
 		cmd.Flags().StringVarP(&pointerFile, "file", "f", "", "Path to a local file to generate the pointer from.")
 		cmd.Flags().StringVarP(&pointerCompare, "pointer", "p", "", "Path to a local file containing a pointer built by another Git LFS implementation.")
 		cmd.Flags().BoolVarP(&pointerStdin, "stdin", "", false, "Read a pointer built by another Git LFS implementation through STDIN.")
-		return true
 	})
 }

--- a/commands/command_pointer.go
+++ b/commands/command_pointer.go
@@ -129,16 +129,10 @@ func gitHashObject(by []byte) string {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "pointer",
-			PreRun: resolveLocalStorage,
-			Run:    pointerCommand,
-		}
-
+	RegisterCommand("pointer", pointerCommand, func(cmd *cobra.Command) bool {
 		cmd.Flags().StringVarP(&pointerFile, "file", "f", "", "Path to a local file to generate the pointer from.")
 		cmd.Flags().StringVarP(&pointerCompare, "pointer", "p", "", "Path to a local file containing a pointer built by another Git LFS implementation.")
 		cmd.Flags().BoolVarP(&pointerStdin, "stdin", "", false, "Read a pointer built by another Git LFS implementation through STDIN.")
-		return cmd
+		return true
 	})
 }

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -98,14 +98,8 @@ func decodeRefs(input string) (string, string) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "pre-push",
-			PreRun: resolveLocalStorage,
-			Run:    prePushCommand,
-		}
-
+	RegisterCommand("pre-push", prePushCommand, func(cmd *cobra.Command) bool {
 		cmd.Flags().BoolVarP(&prePushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")
-		return cmd
+		return true
 	})
 }

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -98,8 +98,7 @@ func decodeRefs(input string) (string, string) {
 }
 
 func init() {
-	RegisterCommand("pre-push", prePushCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("pre-push", prePushCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&prePushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")
-		return true
 	})
 }

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -474,11 +474,10 @@ func pruneTaskGetReachableObjects(outObjectSet *tools.StringSet, errorChan chan 
 }
 
 func init() {
-	RegisterCommand("prune", pruneCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("prune", pruneCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&pruneDryRunArg, "dry-run", "d", false, "Don't delete anything, just report")
 		cmd.Flags().BoolVarP(&pruneVerboseArg, "verbose", "v", false, "Print full details of what is/would be deleted")
 		cmd.Flags().BoolVarP(&pruneVerifyArg, "verify-remote", "c", false, "Verify that remote has LFS files before deleting")
 		cmd.Flags().BoolVar(&pruneDoNotVerifyArg, "no-verify-remote", false, "Override lfs.pruneverifyremotealways and don't verify")
-		return true
 	})
 }

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -474,18 +474,11 @@ func pruneTaskGetReachableObjects(outObjectSet *tools.StringSet, errorChan chan 
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "prune",
-			Short:  "Deletes old LFS files from the local store",
-			PreRun: resolveLocalStorage,
-			Run:    pruneCommand,
-		}
-
+	RegisterCommand("prune", pruneCommand, func(cmd *cobra.Command) bool {
 		cmd.Flags().BoolVarP(&pruneDryRunArg, "dry-run", "d", false, "Don't delete anything, just report")
 		cmd.Flags().BoolVarP(&pruneVerboseArg, "verbose", "v", false, "Print full details of what is/would be deleted")
 		cmd.Flags().BoolVarP(&pruneVerifyArg, "verify-remote", "c", false, "Verify that remote has LFS files before deleting")
 		cmd.Flags().BoolVar(&pruneDoNotVerifyArg, "no-verify-remote", false, "Override lfs.pruneverifyremotealways and don't verify")
-		return cmd
+		return true
 	})
 }

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -44,9 +44,8 @@ func pull(includePaths, excludePaths []string) {
 }
 
 func init() {
-	RegisterCommand("pull", pullCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("pull", pullCommand, func(cmd *cobra.Command) {
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
-		return true
 	})
 }

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -44,15 +44,9 @@ func pull(includePaths, excludePaths []string) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "pull",
-			PreRun: resolveLocalStorage,
-			Run:    pullCommand,
-		}
-
+	RegisterCommand("pull", pullCommand, func(cmd *cobra.Command) bool {
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
-		return cmd
+		return true
 	})
 }

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -163,11 +163,10 @@ func pushCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterCommand("push", pushCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("push", pushCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&pushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")
 		cmd.Flags().BoolVarP(&useStdin, "stdin", "s", false, "Take refs on stdin (for pre-push hook)")
 		cmd.Flags().BoolVarP(&pushObjectIDs, "object-id", "o", false, "Push LFS object ID(s)")
 		cmd.Flags().BoolVarP(&pushAll, "all", "a", false, "Push all objects for the current ref to the remote.")
-		return true
 	})
 }

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -163,17 +163,11 @@ func pushCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "push",
-			PreRun: resolveLocalStorage,
-			Run:    pushCommand,
-		}
-
+	RegisterCommand("push", pushCommand, func(cmd *cobra.Command) bool {
 		cmd.Flags().BoolVarP(&pushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")
 		cmd.Flags().BoolVarP(&useStdin, "stdin", "s", false, "Take refs on stdin (for pre-push hook)")
 		cmd.Flags().BoolVarP(&pushObjectIDs, "object-id", "o", false, "Push LFS object ID(s)")
 		cmd.Flags().BoolVarP(&pushAll, "all", "a", false, "Push all objects for the current ref to the remote.")
-		return cmd
+		return true
 	})
 }

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -93,9 +93,8 @@ func smudgeFilename(args []string, err error) string {
 }
 
 func init() {
-	RegisterCommand("smudge", smudgeCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("smudge", smudgeCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&smudgeInfo, "info", "i", false, "")
 		cmd.Flags().BoolVarP(&smudgeSkip, "skip", "s", false, "")
-		return true
 	})
 }

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -93,15 +93,9 @@ func smudgeFilename(args []string, err error) string {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "smudge",
-			PreRun: resolveLocalStorage,
-			Run:    smudgeCommand,
-		}
-
+	RegisterCommand("smudge", smudgeCommand, func(cmd *cobra.Command) bool {
 		cmd.Flags().BoolVarP(&smudgeInfo, "info", "i", false, "")
 		cmd.Flags().BoolVarP(&smudgeSkip, "skip", "s", false, "")
-		return cmd
+		return true
 	})
 }

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -97,14 +97,8 @@ func humanizeBytes(bytes int64) string {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "status",
-			PreRun: resolveLocalStorage,
-			Run:    statusCommand,
-		}
-
+	RegisterCommand("status", statusCommand, func(cmd *cobra.Command) bool {
 		cmd.Flags().BoolVarP(&porcelain, "porcelain", "p", false, "Give the output in an easy-to-parse format for scripts.")
-		return cmd
+		return true
 	})
 }

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -97,8 +97,7 @@ func humanizeBytes(bytes int64) string {
 }
 
 func init() {
-	RegisterCommand("status", statusCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("status", statusCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&porcelain, "porcelain", "p", false, "Give the output in an easy-to-parse format for scripts.")
-		return true
 	})
 }

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -231,9 +231,8 @@ func blocklistItem(name string) string {
 }
 
 func init() {
-	RegisterCommand("track", trackCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("track", trackCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&trackVerboseLoggingFlag, "verbose", "v", false, "log which files are being tracked and modified")
 		cmd.Flags().BoolVarP(&trackDryRunFlag, "dry-run", "d", false, "preview results of running `git lfs track`")
-		return true
 	})
 }

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -231,15 +231,9 @@ func blocklistItem(name string) string {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "track",
-			PreRun: resolveLocalStorage,
-			Run:    trackCommand,
-		}
-
+	RegisterCommand("track", trackCommand, func(cmd *cobra.Command) bool {
 		cmd.Flags().BoolVarP(&trackVerboseLoggingFlag, "verbose", "v", false, "log which files are being tracked and modified")
 		cmd.Flags().BoolVarP(&trackDryRunFlag, "dry-run", "d", false, "preview results of running `git lfs track`")
-		return cmd
+		return true
 	})
 }

--- a/commands/command_uninit.go
+++ b/commands/command_uninit.go
@@ -22,18 +22,8 @@ func uninitHooksCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "uninit",
-			PreRun: resolveLocalStorage,
-			Run:    uninitCommand,
-		}
-
-		cmd.AddCommand(&cobra.Command{
-			Use:    "hooks",
-			PreRun: resolveLocalStorage,
-			Run:    uninitHooksCommand,
-		})
-		return cmd
+	RegisterCommand("uninit", uninitCommand, func(cmd *cobra.Command) bool {
+		cmd.AddCommand(NewCommand("hooks", uninitHooksCommand))
+		return true
 	})
 }

--- a/commands/command_uninit.go
+++ b/commands/command_uninit.go
@@ -22,8 +22,7 @@ func uninitHooksCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterCommand("uninit", uninitCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("uninit", uninitCommand, func(cmd *cobra.Command) {
 		cmd.AddCommand(NewCommand("hooks", uninitHooksCommand))
-		return true
 	})
 }

--- a/commands/command_uninstall.go
+++ b/commands/command_uninstall.go
@@ -28,8 +28,7 @@ func uninstallHooksCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterCommand("uninstall", uninstallCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("uninstall", uninstallCommand, func(cmd *cobra.Command) {
 		cmd.AddCommand(NewCommand("hooks", uninstallHooksCommand))
-		return true
 	})
 }

--- a/commands/command_uninstall.go
+++ b/commands/command_uninstall.go
@@ -28,18 +28,8 @@ func uninstallHooksCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "uninstall",
-			PreRun: resolveLocalStorage,
-			Run:    uninstallCommand,
-		}
-
-		cmd.AddCommand(&cobra.Command{
-			Use:    "hooks",
-			PreRun: resolveLocalStorage,
-			Run:    uninstallHooksCommand,
-		})
-		return cmd
+	RegisterCommand("uninstall", uninstallCommand, func(cmd *cobra.Command) bool {
+		cmd.AddCommand(NewCommand("hooks", uninstallHooksCommand))
+		return true
 	})
 }

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -93,14 +93,13 @@ func lockIdFromPath(path string) (string, error) {
 }
 
 func init() {
-	RegisterCommand("unlock", unlockCommand, func(cmd *cobra.Command) bool {
-		if !isCommandEnabled(cfg, "locks") {
-			return false
-		}
+	if !isCommandEnabled(cfg, "locks") {
+		return
+	}
 
+	RegisterCommand("unlock", unlockCommand, func(cmd *cobra.Command) {
 		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
 		cmd.Flags().StringVarP(&unlockCmdFlags.Id, "id", "i", "", "unlock a lock by its ID")
 		cmd.Flags().BoolVarP(&unlockCmdFlags.Force, "force", "f", false, "forcibly break another user's lock(s)")
-		return true
 	})
 }

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -93,20 +93,14 @@ func lockIdFromPath(path string) (string, error) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
+	RegisterCommand("unlock", unlockCommand, func(cmd *cobra.Command) bool {
 		if !isCommandEnabled(cfg, "locks") {
-			return nil
-		}
-
-		cmd := &cobra.Command{
-			Use:    "unlock",
-			PreRun: resolveLocalStorage,
-			Run:    unlockCommand,
+			return false
 		}
 
 		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
 		cmd.Flags().StringVarP(&unlockCmdFlags.Id, "id", "i", "", "unlock a lock by its ID")
 		cmd.Flags().BoolVarP(&unlockCmdFlags.Force, "force", "f", false, "forcibly break another user's lock(s)")
-		return cmd
+		return true
 	})
 }

--- a/commands/command_untrack.go
+++ b/commands/command_untrack.go
@@ -75,11 +75,5 @@ func removePath(path string, args []string) bool {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		return &cobra.Command{
-			Use:    "untrack",
-			PreRun: resolveLocalStorage,
-			Run:    untrackCommand,
-		}
-	})
+	RegisterCommand("untrack", untrackCommand, nil)
 }

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -55,9 +55,8 @@ func updateCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterCommand("update", updateCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("update", updateCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&updateForce, "force", "f", false, "Overwrite existing hooks.")
 		cmd.Flags().BoolVarP(&updateManual, "manual", "m", false, "Print instructions for manual install.")
-		return true
 	})
 }

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -55,14 +55,9 @@ func updateCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "update",
-			PreRun: resolveLocalStorage,
-			Run:    updateCommand,
-		}
+	RegisterCommand("update", updateCommand, func(cmd *cobra.Command) bool {
 		cmd.Flags().BoolVarP(&updateForce, "force", "f", false, "Overwrite existing hooks.")
 		cmd.Flags().BoolVarP(&updateManual, "manual", "m", false, "Print instructions for manual install.")
-		return cmd
+		return true
 	})
 }

--- a/commands/command_version.go
+++ b/commands/command_version.go
@@ -18,9 +18,8 @@ func versionCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterCommand("version", versionCommand, func(cmd *cobra.Command) bool {
+	RegisterCommand("version", versionCommand, func(cmd *cobra.Command) {
 		cmd.PreRun = nil
 		cmd.Flags().BoolVarP(&lovesComics, "comics", "c", false, "easter egg")
-		return true
 	})
 }

--- a/commands/command_version.go
+++ b/commands/command_version.go
@@ -18,14 +18,9 @@ func versionCommand(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RegisterSubcommand(func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:    "version",
-			PreRun: resolveLocalStorage,
-			Run:    versionCommand,
-		}
-
+	RegisterCommand("version", versionCommand, func(cmd *cobra.Command) bool {
+		cmd.PreRun = nil
 		cmd.Flags().BoolVarP(&lovesComics, "comics", "c", false, "easter egg")
-		return cmd
+		return true
 	})
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -46,10 +46,25 @@ var (
 	excludeArg string
 )
 
+// NewCommand creates a new 'git-lfs' sub command, given a command name and
+// command run function.
+//
+// Each command will initialize the local storage ('.git/lfs') directory when
+// run, unless the PreRun hook is set to nil.
 func NewCommand(name string, runFn func(*cobra.Command, []string)) *cobra.Command {
 	return &cobra.Command{Use: name, Run: runFn, PreRun: resolveLocalStorage}
 }
 
+// RegisterCommand creates a direct 'git-lfs' subcommand, given a command name,
+// a command run function, and an optional callback during the command
+// initialization process.
+//
+// The 'git-lfs' command initialization is deferred until the `commands.Run()`
+// function is called. The fn callback is passed the output from NewCommand,
+// and gives the caller the flexibility to customize the command (add flags,
+// tweak command hooks) and optionally disable the command by returning false.
+// A nil fn callback initializes the command with no flags, subcommands, or
+// custom command hooks.
 func RegisterCommand(name string, runFn func(cmd *cobra.Command, args []string), fn func(cmd *cobra.Command) bool) {
 	commandMu.Lock()
 	commandFuncs = append(commandFuncs, func() *cobra.Command {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -71,6 +71,24 @@ func Run() {
 	httputil.LogHttpStats(cfg)
 }
 
+func RegisterCommand(name string, runFn func(cmd *cobra.Command, args []string), fn func(cmd *cobra.Command) bool) {
+	subcommandMu.Lock()
+	subcommandFuncs = append(subcommandFuncs, func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use:    name,
+			PreRun: resolveLocalStorage,
+			Run:    runFn,
+		}
+
+		if fn != nil && !fn(cmd) {
+			return nil
+		}
+
+		return cmd
+	})
+	subcommandMu.Unlock()
+}
+
 func RegisterSubcommand(fn func() *cobra.Command) {
 	subcommandMu.Lock()
 	subcommandFuncs = append(subcommandFuncs, fn)

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -36,7 +36,7 @@ var (
 	ErrorWriter  = io.MultiWriter(os.Stderr, ErrorBuffer)
 	OutputWriter = io.MultiWriter(os.Stdout, ErrorBuffer)
 	ManPages     = make(map[string]string, 20)
-	cfg          *config.Configuration
+	cfg          = config.Config
 
 	// Run uses this to initialize the git-lfs command
 	commandFuncs []func() *cobra.Command
@@ -61,16 +61,14 @@ func NewCommand(name string, runFn func(*cobra.Command, []string)) *cobra.Comman
 //
 // The 'git-lfs' command initialization is deferred until the `commands.Run()`
 // function is called. The fn callback is passed the output from NewCommand,
-// and gives the caller the flexibility to customize the command (add flags,
-// tweak command hooks) and optionally disable the command by returning false.
-// A nil fn callback initializes the command with no flags, subcommands, or
-// custom command hooks.
-func RegisterCommand(name string, runFn func(cmd *cobra.Command, args []string), fn func(cmd *cobra.Command) bool) {
+// and gives the caller the flexibility to customize the command by adding
+// flags, tweaking command hooks, etc.
+func RegisterCommand(name string, runFn func(cmd *cobra.Command, args []string), fn func(cmd *cobra.Command)) {
 	commandMu.Lock()
 	commandFuncs = append(commandFuncs, func() *cobra.Command {
 		cmd := NewCommand(name, runFn)
-		if fn != nil && !fn(cmd) {
-			return nil
+		if fn != nil {
+			fn(cmd)
 		}
 		return cmd
 	})

--- a/commands/run.go
+++ b/commands/run.go
@@ -5,13 +5,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/github/git-lfs/config"
 	"github.com/github/git-lfs/httputil"
 	"github.com/spf13/cobra"
 )
 
 func Run() {
-	cfg = config.Config
 	root := NewCommand("git-lfs", gitlfsCommand)
 	root.PreRun = nil
 
@@ -41,7 +39,6 @@ func helpCommand(cmd *cobra.Command, args []string) {
 	} else {
 		printHelp(args[0])
 	}
-
 }
 
 func usageCommand(cmd *cobra.Command) error {

--- a/commands/run.go
+++ b/commands/run.go
@@ -4,11 +4,49 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/github/git-lfs/httputil"
+	"github.com/github/git-lfs/localstorage"
 	"github.com/spf13/cobra"
 )
 
+var (
+	commandFuncs []func() *cobra.Command
+	commandMu    sync.Mutex
+)
+
+// NewCommand creates a new 'git-lfs' sub command, given a command name and
+// command run function.
+//
+// Each command will initialize the local storage ('.git/lfs') directory when
+// run, unless the PreRun hook is set to nil.
+func NewCommand(name string, runFn func(*cobra.Command, []string)) *cobra.Command {
+	return &cobra.Command{Use: name, Run: runFn, PreRun: resolveLocalStorage}
+}
+
+// RegisterCommand creates a direct 'git-lfs' subcommand, given a command name,
+// a command run function, and an optional callback during the command
+// initialization process.
+//
+// The 'git-lfs' command initialization is deferred until the `commands.Run()`
+// function is called. The fn callback is passed the output from NewCommand,
+// and gives the caller the flexibility to customize the command by adding
+// flags, tweaking command hooks, etc.
+func RegisterCommand(name string, runFn func(cmd *cobra.Command, args []string), fn func(cmd *cobra.Command)) {
+	commandMu.Lock()
+	commandFuncs = append(commandFuncs, func() *cobra.Command {
+		cmd := NewCommand(name, runFn)
+		if fn != nil {
+			fn(cmd)
+		}
+		return cmd
+	})
+	commandMu.Unlock()
+}
+
+// Run initializes the 'git-lfs' command and runs it with the given stdin and
+// command line args.
 func Run() {
 	root := NewCommand("git-lfs", gitlfsCommand)
 	root.PreRun = nil
@@ -31,6 +69,13 @@ func Run() {
 func gitlfsCommand(cmd *cobra.Command, args []string) {
 	versionCommand(cmd, args)
 	cmd.Usage()
+}
+
+// resolveLocalStorage implements the `func(*cobra.Command, []string)` signature
+// necessary to wire it up via `cobra.Command.PreRun`. When run, this function
+// will resolve the localstorage directories.
+func resolveLocalStorage(cmd *cobra.Command, args []string) {
+	localstorage.ResolveDirs()
 }
 
 func helpCommand(cmd *cobra.Command, args []string) {

--- a/commands/run.go
+++ b/commands/run.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/github/git-lfs/config"
+	"github.com/github/git-lfs/httputil"
+	"github.com/spf13/cobra"
+)
+
+func Run() {
+	cfg = config.Config
+	root := NewCommand("git-lfs", gitlfsCommand)
+	root.PreRun = nil
+
+	// Set up help/usage funcs based on manpage text
+	root.SetHelpTemplate("{{.UsageString}}")
+	root.SetHelpFunc(helpCommand)
+	root.SetUsageFunc(usageCommand)
+
+	for _, f := range commandFuncs {
+		if cmd := f(); cmd != nil {
+			root.AddCommand(cmd)
+		}
+	}
+
+	root.Execute()
+	httputil.LogHttpStats(cfg)
+}
+
+func gitlfsCommand(cmd *cobra.Command, args []string) {
+	versionCommand(cmd, args)
+	cmd.Usage()
+}
+
+func helpCommand(cmd *cobra.Command, args []string) {
+	if len(args) == 0 {
+		printHelp("git-lfs")
+	} else {
+		printHelp(args[0])
+	}
+
+}
+
+func usageCommand(cmd *cobra.Command) error {
+	printHelp(cmd.Name())
+	return nil
+}
+
+func printHelp(commandName string) {
+	if txt, ok := ManPages[commandName]; ok {
+		fmt.Fprintf(os.Stderr, "%s\n", strings.TrimSpace(txt))
+	} else {
+		fmt.Fprintf(os.Stderr, "Sorry, no usage text found for %q\n", commandName)
+	}
+}


### PR DESCRIPTION
This is an incomplete PR that I wanted to try after reading [this conversation](https://github.com/github/git-lfs/pull/1478#discussion-diff-75845058).

Unlike the existing `RegisterSubcommand()`, `RegisterCommand()` wraps the initialization of the `*cobra.Command` with the following properties:

* `Use` - The lfs sub command name, needed by every command.
* `Run` - The function for the command.
* `PreRun` - This is the controversial part. _Most_ commands want this set.

I agree that it's better that the few commands that don't need `.git/lfs` initialized can disable the `PreRun` hook. By default though, all `RegisterCommand` callers should work.

The `bool` return value also lets commands choose if they're activated. Currently only used for experimental commands like `locks`.

If this approach is favorable, I'll update all `RegisterSubcommand()` callers, kill it, and change how `subcommandFuncs` works.