### PR TITLE
Handle local storage init errors with a short, contextual error msg

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -56,7 +56,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 	defer os.Chdir(cwd)
 
 	// Also need to derive dirs now
-	resolveLocalStorage(nil, nil)
+	commandPreRun(nil, nil)
 	requireInRepo()
 
 	// Now just call pull with default args

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/github/git-lfs/localstorage"
 	"github.com/github/git-lfs/subprocess"
 
 	"github.com/github/git-lfs/git"
@@ -57,7 +56,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 	defer os.Chdir(cwd)
 
 	// Also need to derive dirs now
-	localstorage.ResolveDirs()
+	resolveLocalStorage(nil, nil)
 	requireInRepo()
 
 	// Now just call pull with default args

--- a/commands/run.go
+++ b/commands/run.go
@@ -22,7 +22,7 @@ var (
 // Each command will initialize the local storage ('.git/lfs') directory when
 // run, unless the PreRun hook is set to nil.
 func NewCommand(name string, runFn func(*cobra.Command, []string)) *cobra.Command {
-	return &cobra.Command{Use: name, Run: runFn, PreRun: resolveLocalStorage}
+	return &cobra.Command{Use: name, Run: runFn, PreRun: commandPreRun}
 }
 
 // RegisterCommand creates a direct 'git-lfs' subcommand, given a command name,
@@ -74,7 +74,7 @@ func gitlfsCommand(cmd *cobra.Command, args []string) {
 // resolveLocalStorage implements the `func(*cobra.Command, []string)` signature
 // necessary to wire it up via `cobra.Command.PreRun`. When run, this function
 // will resolve the localstorage directories.
-func resolveLocalStorage(cmd *cobra.Command, args []string) {
+func commandPreRun(cmd *cobra.Command, args []string) {
 	if err := localstorage.ResolveDirs(); err != nil {
 		Exit("Init error: %v", err)
 	}

--- a/commands/run.go
+++ b/commands/run.go
@@ -4,11 +4,49 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/github/git-lfs/httputil"
+	"github.com/github/git-lfs/localstorage"
 	"github.com/spf13/cobra"
 )
 
+var (
+	commandFuncs []func() *cobra.Command
+	commandMu    sync.Mutex
+)
+
+// NewCommand creates a new 'git-lfs' sub command, given a command name and
+// command run function.
+//
+// Each command will initialize the local storage ('.git/lfs') directory when
+// run, unless the PreRun hook is set to nil.
+func NewCommand(name string, runFn func(*cobra.Command, []string)) *cobra.Command {
+	return &cobra.Command{Use: name, Run: runFn, PreRun: resolveLocalStorage}
+}
+
+// RegisterCommand creates a direct 'git-lfs' subcommand, given a command name,
+// a command run function, and an optional callback during the command
+// initialization process.
+//
+// The 'git-lfs' command initialization is deferred until the `commands.Run()`
+// function is called. The fn callback is passed the output from NewCommand,
+// and gives the caller the flexibility to customize the command by adding
+// flags, tweaking command hooks, etc.
+func RegisterCommand(name string, runFn func(cmd *cobra.Command, args []string), fn func(cmd *cobra.Command)) {
+	commandMu.Lock()
+	commandFuncs = append(commandFuncs, func() *cobra.Command {
+		cmd := NewCommand(name, runFn)
+		if fn != nil {
+			fn(cmd)
+		}
+		return cmd
+	})
+	commandMu.Unlock()
+}
+
+// Run initializes the 'git-lfs' command and runs it with the given stdin and
+// command line args.
 func Run() {
 	root := NewCommand("git-lfs", gitlfsCommand)
 	root.PreRun = nil
@@ -31,6 +69,13 @@ func Run() {
 func gitlfsCommand(cmd *cobra.Command, args []string) {
 	versionCommand(cmd, args)
 	cmd.Usage()
+}
+
+// resolveLocalStorage implements the `func(*cobra.Command, []string)` signature
+// necessary to wire it up via `cobra.Command.PreRun`. When run, this function
+// will resolve the localstorage directories.
+func resolveLocalStorage(cmd *cobra.Command, args []string) {
+	localstorage.ResolveDirs()
 }
 
 func helpCommand(cmd *cobra.Command, args []string) {

--- a/commands/run.go
+++ b/commands/run.go
@@ -75,7 +75,9 @@ func gitlfsCommand(cmd *cobra.Command, args []string) {
 // necessary to wire it up via `cobra.Command.PreRun`. When run, this function
 // will resolve the localstorage directories.
 func resolveLocalStorage(cmd *cobra.Command, args []string) {
-	localstorage.ResolveDirs()
+	if err := localstorage.ResolveDirs(); err != nil {
+		Exit("Init error: %v", err)
+	}
 }
 
 func helpCommand(cmd *cobra.Command, args []string) {

--- a/localstorage/currentstore.go
+++ b/localstorage/currentstore.go
@@ -1,12 +1,12 @@
 package localstorage
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/github/git-lfs/config"
+	"github.com/github/git-lfs/errors"
 )
 
 const (
@@ -25,8 +25,7 @@ func Objects() *LocalStorage {
 	return objects
 }
 
-func ResolveDirs() {
-
+func ResolveDirs() error {
 	config.ResolveGitBasicDirs()
 	TempDir = filepath.Join(config.LocalGitDir, "lfs", "tmp") // temp files per worktree
 
@@ -36,14 +35,15 @@ func ResolveDirs() {
 	)
 
 	if err != nil {
-		panic(fmt.Sprintf("Error trying to init LocalStorage: %s", err))
+		return errors.Wrap(err, "localstorage")
 	}
 
 	objects = objs
 	config.LocalLogDir = filepath.Join(objs.RootDir, "logs")
 	if err := os.MkdirAll(config.LocalLogDir, localLogDirPerms); err != nil {
-		panic(fmt.Errorf("Error trying to create log directory in '%s': %s", config.LocalLogDir, err))
+		return errors.Wrap(err, "localstorage")
 	}
+	return nil
 }
 
 func TempFile(prefix string) (*os.File, error) {

--- a/test/testutils.go
+++ b/test/testutils.go
@@ -303,7 +303,7 @@ func (repo *Repo) AddCommits(inputs []*CommitInput) []*CommitOutput {
 			}
 			// this only created the temp file, move to final location
 			tmpfile := cleaned.Filename
-			storageOnce.Do(localstorage.ResolveDirs)
+			storageOnce.Do(func() { localstorage.ResolveDirs() })
 			mediafile, err := lfs.LocalMediaPath(cleaned.Oid)
 			if err != nil {
 				repo.callback.Errorf("Unable to get local media path: %v", err)

--- a/test/testutils.go
+++ b/test/testutils.go
@@ -76,7 +76,9 @@ func (r *Repo) Pushd() {
 		r.callback.Fatalf("Can't chdir %v", err)
 	}
 	r.popDir = oldwd
-	localstorage.ResolveDirs()
+	if err := localstorage.ResolveDirs(); err != nil {
+		r.callback.Fatalf("init error: %v", err)
+	}
 }
 
 func (r *Repo) Popd() {


### PR DESCRIPTION
Old error:

```bash
panic: Error trying to init LocalStorage: mkdir lfs: permission denied

goroutine 1 [running]:
panic(0x377740, 0xc420102920)
        /usr/local/Cellar/go/1.7/libexec/src/runtime/panic.go:500 +0x1a1
github.com/github/git-lfs/localstorage.ResolveDirs()
        /private/tmp/git-lfs-20160826-6787-1o15v20/git-lfs-1.4.1/src/github.com/github/git-lfs/localstorage/currentstore.go:39 +0x4c3
github.com/github/git-lfs/commands.resolveLocalStorage(0xc420123d40, 0x5f2ae0, 0x0, 0x0)
        /private/tmp/git-lfs-20160826-6787-1o15v20/git-lfs-1.4.1/src/github.com/github/git-lfs/commands/commands.go:342 +0x14
github.com/github/git-lfs/vendor/github.com/spf13/cobra.(*Command).execute(0xc420123d40, 0x5f2ae0, 0x0, 0x0, 0xc420123d40, 0x5f2ae0)
        /private/tmp/git-lfs-20160826-6787-1o15v20/git-lfs-1.4.1/src/github.com/github/git-lfs/vendor/github.com/spf13/cobra/command.go:474 +0x255
github.com/github/git-lfs/vendor/github.com/spf13/cobra.(*Command).Execute(0xc4200f64e0, 0xc42004fed0, 0x1)
        /private/tmp/git-lfs-20160826-6787-1o15v20/git-lfs-1.4.1/src/github.com/github/git-lfs/vendor/github.com/spf13/cobra/command.go:551 +0x380
github.com/github/git-lfs/commands.Run()
        /private/tmp/git-lfs-20160826-6787-1o15v20/git-lfs-1.4.1/src/github.com/github/git-lfs/commands/commands.go:70 +0x180
main.main()
        /private/tmp/git-lfs-20160826-6787-1o15v20/git-lfs-1.4.1/git-lfs.go:33 +0x111
```

This looks scary for such a small error. How about:

```bash
Init error: localstorage: mkdir lfs: not a directory
```

`localstorage.ResolveDirs()` now uses `errors.Wrap()` to add the "localstorage" context. The command `PreRun` adds the "Init error" context.