### PR TITLE
docs/man: reference git-lfs-pointer(1) in clean documentation

### DIFF
--- a/docs/man/git-lfs-clean.1.ronn
+++ b/docs/man/git-lfs-clean.1.ronn
@@ -13,8 +13,12 @@ LFS pointer file for that file to standard output.
 Clean is typically run by Git's clean filter, configured by the repository's
 Git attributes.
 
+Clean is not part of the user-facing Git plumbing commands. To preview the
+pointer of a large file as it would be generated, see the git-lfs-pointer(1)
+command.
+
 ## SEE ALSO
 
-git-lfs-install(1), git-lfs-push(1), gitattributes(5).
+git-lfs-install(1), git-lfs-push(1), git-lfs-pointer(1), gitattributes(5).
 
 Part of the git-lfs(1) suite.


### PR DESCRIPTION
This pull-request adds some new documentation to `git-lfs-clean`'s man page to reflect that it is not a part of the user-facing plumbing commands. Instead, it points to the `git-lfs-pointer(1)` documentation in order to preview what the generated pointer data would look like for a particular object.

--

/cc @sinbad @kingces95 @technoweenie #1501 