### PR TITLE
Make AppVeyor CI for Windows work again

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,56 +1,17 @@
-version: 1.0.{build}
-init:
-- cmd: >-
-    set REPO_DIR=%cd%
-
-
-    mkdir %BASHROOT%
-
-    cd %BASHROOT%
-
-
-    curl -LOk https://github.com/git-for-windows/git/releases/download/v2.6.2.windows.1/PortableGit-2.6.2-64-bit.7z.exe
-
-
-    7z x PortableGit-2.6.2-64-bit.7z.exe > nul
-
-
-    mkdir c:\go15
-
-    cd \go15
-
-
-    curl -LO https://storage.googleapis.com/golang/go1.5.1.windows-amd64.zip
-
-    unzip -o go1.5.1.windows-amd64.zip > nul
-
-
-    set PATH=%BASHROOT%\bin;%GOROOT%\bin;%PATH%
-
-
-    cd %REPO_DIR%
-environment:
-  GOROOT: c:\go15\go
-  BASHROOT: c:\bash2
 install:
-- cmd: 
+  - cinst InnoSetup -y
+  - set PATH="C:\Program Files (x86)\Inno Setup 5";%PATH%
+
 build_script:
-- cmd: >-
-    mkdir src\github.com\github
+  - bash -c 'GOARCH=386 script/bootstrap'
+  - mv bin\git-lfs git-lfs-x86.exe
+  - bash -c 'GOARCH=amd64 script/bootstrap'
+  - mv bin\git-lfs git-lfs-x64.exe
 
+after_build:
+  - iscc script\windows-installer\inno-setup-git-lfs-installer.iss
 
-    mklink /J src\github.com\github\git-lfs .
-
-
-    set GOPATH=%CD%
-
-
-    go version
-
-
-    bash script\bootstrap
-
-
-    mv bin\git-lfs bin\git-lfs.exe
 artifacts:
-- path: bin\git-lfs.exe
+  - path: git-lfs-x86.exe
+  - path: git-lfs-x64.exe
+  - path: git-lfs-windows-*.exe

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
-# Only set GOPATH on non-Windows platforms as Windows can't do the symlinking
-# that we need.
-if [ -z "$GOPATH" ] && uname -s | grep -vq "_NT-"; then
+if uname -s | grep -q "_NT-"; then
+  # Tell Cygwin / MSYS to really create symbolic links.
+  export CYGWIN="$CYGWIN winsymlinks:nativestrict"
+  export MSYS="$MSYS winsymlinks:nativestrict"
+fi
+
+if [ -z "$GOPATH" ]; then
   export GOPATH="$(pwd)"
   mkdir -p src/github.com/github
   [ -h src/github.com/github/git-lfs ] ||

--- a/script/fmt
+++ b/script/fmt
@@ -6,7 +6,7 @@ hash goimports 2>/dev/null && {
 }
 
 # don't run gofmt in these directories
-ignored=(/bin/ /docs/ /log/ /man/ /tmp/ /vendor/ /rpm/ /docker/ /debian/)
+ignored=(/bin/ /docs/ /log/ /man/ /tmp/ /vendor/ /rpm/ /docker/ /debian/ /src/)
 for i in */ ; do
   if [[ ! ${ignored[*]} =~ "/$i" ]]; then
     $formatter -w -l "$@" "${i%?}"


### PR DESCRIPTION
This build the binaries and installer for now. Not running tests yet.