### PR TITLE
Allow fetch to run without a remote configured

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -42,12 +42,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		}
 		cfg.CurrentRemote = args[0]
 	} else {
-		// Actively find the default remote, don't just assume origin
-		defaultRemote, err := git.DefaultRemote()
-		if err != nil {
-			Exit("No default remote")
-		}
-		cfg.CurrentRemote = defaultRemote
+		cfg.CurrentRemote = ""
 	}
 
 	if len(args) > 1 {
@@ -246,6 +241,16 @@ func fetchPointers(pointers []*lfs.WrappedPointer, include, exclude []string) bo
 // Fetch and report completion of each OID to a channel (optional, pass nil to skip)
 // Returns true if all completed with no errors, false if errors were written to stderr/log
 func fetchAndReportToChan(allpointers []*lfs.WrappedPointer, include, exclude []string, out chan<- *lfs.WrappedPointer) bool {
+	// Lazily initialize the current remote.
+	if len(cfg.CurrentRemote) == 0 {
+		// Actively find the default remote, don't just assume origin
+		defaultRemote, err := git.DefaultRemote()
+		if err != nil {
+			Exit("No default remote")
+		}
+		cfg.CurrentRemote = defaultRemote
+	}
+
 	ready, pointers, totalSize := readyAndMissingPointers(allpointers, include, exclude)
 	q := lfs.NewDownloadQueue(len(pointers), totalSize, false)
 


### PR DESCRIPTION
For newly initialized local repositories that are configured to track
existing LFS objects by manually creating pointer files via
git-lfs-pointer, there might be no remote configured yet. Still it should
be possible to fetch the LFS objects. Allow this by postponing the check
for a remote until it is really required.