### PR TITLE
testhelpers: do not set credential.helper multiple times

### DIFF
--- a/test/test-credentials-no-prompt.sh
+++ b/test/test-credentials-no-prompt.sh
@@ -27,7 +27,6 @@ begin_test "attempt private access without credential helper"
   git add .gitattributes
   git commit -m "initial commit"
 
-  git config --global credential.helper lfsnoop
   git config credential.helper lfsnoop
   git config -l
 

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -221,7 +221,6 @@ clone_repo() {
   out=$(git clone "$GITSERVER/$reponame" "$dir" 2>&1)
   cd "$dir"
 
-  git config credential.helper lfstest
   echo "$out" > clone.log
   echo "$out"
 }
@@ -238,8 +237,6 @@ clone_repo_ssl() {
   echo "clone local git repository $reponame to $dir"
   out=$(git clone "$SSLGITSERVER/$reponame" "$dir" 2>&1)
   cd "$dir"
-
-  git config credential.helper lfstest
 
   echo "$out" > clone_ssl.log
   echo "$out"


### PR DESCRIPTION
We already set this globally in setup().