### PR TITLE
Fixes and improvements to setting the credential helper for tests

### DIFF
--- a/test/test-credentials-no-prompt.sh
+++ b/test/test-credentials-no-prompt.sh
@@ -5,14 +5,6 @@
 # these tests rely on GIT_TERMINAL_PROMPT to test properly
 ensure_git_version_isnt $VERSION_LOWER "2.3.0"
 
-# if there is a system cred helper we can't run this test
-# can't disable without changing state outside test & probably don't have permission
-# this is common on OS X with certain versions of Git installed, default cred helper
-if [[ -n "$(git config --system credential.helper)" ]]; then
-  echo "skip: $0 (system cred helper we can't disable)"
-  exit
-fi
-
 begin_test "attempt private access without credential helper"
 (
   set -e

--- a/test/test-object-authenticated.sh
+++ b/test/test-object-authenticated.sh
@@ -5,14 +5,6 @@
 # these tests rely on GIT_TERMINAL_PROMPT to test properly
 ensure_git_version_isnt $VERSION_LOWER "2.3.0"
 
-# if there is a system cred helper we can't run this test
-# can't disable without changing state outside test & probably don't have permission
-# this is common on OS X with certain versions of Git installed, default cred helper
-if [[ -n "$(git config --system credential.helper)" ]]; then
-  echo "skip: $0 (system cred helper we can't disable)"
-  exit
-fi
-
 begin_test "download authenticated object"
 (
   set -e

--- a/test/testenv.sh
+++ b/test/testenv.sh
@@ -106,11 +106,6 @@ GIT_TERMINAL_PROMPT=0
 
 export CREDSDIR
 
-if [[ `git config --system credential.helper | grep osxkeychain` == "osxkeychain" ]]
-then
-  OSXKEYFILE="$TMPDIR/temp.keychain"
-fi
-
 mkdir -p "$TMPDIR"
 mkdir -p "$TRASHDIR"
 

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -304,6 +304,9 @@ setup() {
   HOME="$TESTHOME"
   mkdir "$HOME"
   git lfs install
+
+  # Ensure e.g. no credential helpers are taken into account from the system config.
+  export GIT_CONFIG_NOSYSTEM=1
   git config --global credential.usehttppath true
   git config --global credential.helper lfstest
   git config --global user.name "Git LFS Tests"

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -335,21 +335,6 @@ setup() {
   echo "GIT:"
   git config --get-regexp "lfs|credential|user"
 
-  if [ "$OSXKEYFILE" ]; then
-    # Only OS X will encounter this
-    # We can't disable osxkeychain and it gets called on store as well as ours,
-    # reporting "A keychain cannot be found to store.." errors because the test
-    # user env has no keychain; so create one
-    mkdir -p $HOME/Library/Preferences # required to store keychain lists
-    security create-keychain -p pass "$OSXKEYFILE"
-    security list-keychains -s "$OSXKEYFILE"
-    security unlock-keychain -p pass "$OSXKEYFILE"
-    security set-keychain-settings -lut 7200 "$OSXKEYFILE"
-    security default-keychain -s "$OSXKEYFILE"
-
-    echo "OSX Keychain: $OSXKEYFILE"
-  fi
-
   wait_for_file "$LFS_URL_FILE"
   wait_for_file "$LFS_SSL_URL_FILE"
   wait_for_file "$LFS_CERT_FILE"
@@ -367,12 +352,6 @@ shutdown() {
     # test/test-*.sh file is run manually.
     if [ -s "$LFS_URL_FILE" ]; then
       curl "$(cat "$LFS_URL_FILE")/shutdown"
-    fi
-
-    if [ "$OSXKEYFILE" ]; then
-      # explicitly clean up keychain to make sure search list doesn't look for it
-      # shouldn't matter because $HOME is separate & keychain prefs are there but still
-      security delete-keychain "$OSXKEYFILE"
     fi
 
     [ -z "$KEEPTRASH" ] && rm -rf "$REMOTEDIR"

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -330,7 +330,7 @@ setup() {
   echo "  LFSTEST_CERT=$LFS_CERT_FILE"
   echo "  LFSTEST_DIR=$REMOTEDIR"
   echo "GIT:"
-  git config --global --get-regexp "lfs|credential|user"
+  git config --get-regexp "lfs|credential|user"
 
   if [ "$OSXKEYFILE" ]; then
     # Only OS X will encounter this

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -91,10 +91,6 @@ begin_test () {
     mkdir "$HOME"
     cp "$TESTHOME/.gitconfig" "$HOME/.gitconfig"
 
-    if [ "$OSXKEYFILE" ]; then
-      ln -s "$TESTHOME/Library" "$HOME"
-    fi
-
     # allow the subshell to exit non-zero without exiting this process
     set -x +e
 }


### PR DESCRIPTION
This should also fix integration tests hanging in AppVeyor CI as the system-wide credential helper Git for Windows sets is not used anymore, and not popping up a GUI for entering credentials anymore.