### PR TITLE
Simplify getting the absolute Git root directory

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -596,11 +596,7 @@ func GitAndRootDirs() (string, string, error) {
 		return absGitDir, "", nil
 	}
 
-	absRootDir, err := filepath.Abs(paths[1])
-	if err != nil {
-		return "", "", fmt.Errorf("Error converting %q to absolute: %s", paths[1], err)
-	}
-
+	absRootDir := paths[1]
 	return absGitDir, absRootDir, nil
 }
 


### PR DESCRIPTION
"git rev-parse --show-toplevel" is defined to already return an absolute
path, so there is no need to convert it.