### PR TITLE
git,lfs: improve behavior of `git-lfs uninstall`

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -352,9 +352,21 @@ func (c *gitConfig) UnsetGlobal(key string) (string, error) {
 	return subprocess.SimpleExec("git", "config", "--global", "--unset", key)
 }
 
+// UnsetSystemMatchingValues removes the git config value for the key from the
+// global config whose values match the given regular expression.
+func (c *gitConfig) UnsetGlobalMatchingValue(key string, re *regexp.Regexp) (string, error) {
+	return subprocess.SimpleExec("git", "config", "--global", "--unset", key, re.String())
+}
+
 // UnsetSystem removes the git config value for the key from the system config
 func (c *gitConfig) UnsetSystem(key string) (string, error) {
 	return subprocess.SimpleExec("git", "config", "--system", "--unset", key)
+}
+
+// UnsetSystemMatchingValues removes the git config value for the key from the
+// system config whose values match the given regular expression.
+func (c *gitConfig) UnsetSystemMatchingValue(key string, re *regexp.Regexp) (string, error) {
+	return subprocess.SimpleExec("git", "config", "--system", "--unset", key, re.String())
 }
 
 // UnsetGlobalSection removes the entire named section from the global config

--- a/lfs/attribute.go
+++ b/lfs/attribute.go
@@ -100,8 +100,9 @@ func (a *Attribute) set(key, value string, upgradeables []string, opt InstallOpt
 	return nil
 }
 
-// Uninstall removes all properties in the path of this property, and leaves
-// other properties in the same section name-space alone.
+// Uninstall removes all properties in the path of this property whose value
+// matches any of the "upgradable" values for that path, and leaves other
+// properties in the same section name-space alone.
 func (a *Attribute) Uninstall() {
 	paths := make(map[string]*regexp.Regexp)
 	for path, value := range a.Properties {

--- a/lfs/attribute.go
+++ b/lfs/attribute.go
@@ -2,6 +2,7 @@ package lfs
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/github/git-lfs/git"
@@ -99,11 +100,29 @@ func (a *Attribute) set(key, value string, upgradeables []string, opt InstallOpt
 	return nil
 }
 
-// Uninstall removes all properties in the path of this property.
+// Uninstall removes all properties in the path of this property, and leaves
+// other properties in the same section name-space alone.
 func (a *Attribute) Uninstall() {
-	// uninstall from both system and global
-	git.Config.UnsetSystemSection(a.Section)
-	git.Config.UnsetGlobalSection(a.Section)
+	paths := make(map[string]*regexp.Regexp)
+	for path, value := range a.Properties {
+		acceptedValues := append([]string{value}, a.Upgradeables[path]...)
+		for i, v := range acceptedValues {
+			acceptedValues[i] = fmt.Sprintf("(%s)", regexp.QuoteMeta(v))
+		}
+
+		re, err := regexp.CompilePOSIX(strings.Join(acceptedValues, "|"))
+		if err != nil {
+			continue
+		}
+
+		paths[fmt.Sprintf("%s.%s", a.Section, path)] = re
+	}
+
+	// uninstall (by path) from both system and global
+	for path, re := range paths {
+		git.Config.UnsetSystemMatchingValue(path, re)
+		git.Config.UnsetGlobalMatchingValue(path, re)
+	}
 }
 
 // shouldReset determines whether or not a value is resettable given its current


### PR DESCRIPTION
@petermarko points out in https://github.com/github/git-lfs/issues/1519 that `git-lfs uninstall` will remove all `.gitconfig` values in the `filters.lfs` section forcefully.

In a scenario where a user runs `git lfs install`, their .gitconfig looks something like:

```bash
$ git config -l | grep "filter\.lfs"
filter.lfs.smudge=git-lfs smudge -- %f
filter.lfs.required=true
filter.lfs.clean=git-lfs clean -- %f
```

If they either added a new value to the `filter.lfs` section, or _changed_ one of the existing values (i.e., `git config filter.lfs.smudge "my_custom_thing"`), then upon running `git-lfs uninstall`, both of those changes would be overwritten. This PR addresses that.

The new behavior of the `(a *Attribute) Uninstall()` method now only removes:

- Paths that are explicitly set by `git lfs install`, and
  - matches the value that `git lfs install` set it to, or
  - matches one of the values that is "upgradable" for that path

To do this, LFS takes advantage of the `value_regexp` parameter in `git-config`:

> If you want to update or unset an option which can occur on multiple lines, a POSIX regexp value_regex needs to be given. Only the existing values that match the regexp are updated or unset.

This PR is a first step to some upgrade improvements that I'd like to ship to our package installations. For more information on this, see: https://github.com/github/git-lfs/issues/1519#issuecomment-246502641

--

/cc @technoweenie @petermarko #1519
