### PR TITLE
Windows test framework fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,9 @@ install:
 
 build_script:
   - bash -c 'GOARCH=386 script/bootstrap'
-  - mv bin\git-lfs git-lfs-x86.exe
+  - mv bin\git-lfs.exe git-lfs-x86.exe
   - bash -c 'GOARCH=amd64 script/bootstrap'
-  - mv bin\git-lfs git-lfs-x64.exe
+  - mv bin\git-lfs.exe git-lfs-x64.exe
 
 after_build:
   - iscc script\windows-installer\inno-setup-git-lfs-installer.iss

--- a/script/build.go
+++ b/script/build.go
@@ -54,7 +54,7 @@ func mainBuild() {
 	errored := false
 
 	if *BuildAll {
-		for _, buildos := range []string{"linux", "darwin", "freebsd"} {
+		for _, buildos := range []string{"linux", "darwin", "freebsd", "windows"} {
 			for _, buildarch := range []string{"amd64", "386"} {
 				if err := build(buildos, buildarch, buildMatrix); err != nil {
 					errored = true

--- a/script/build.go
+++ b/script/build.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	BuildOS    = flag.String("os", "", "OS to target: darwin, freebsd, linux, windows")
+	BuildOS    = flag.String("os", runtime.GOOS, "OS to target: darwin, freebsd, linux, windows")
 	BuildArch  = flag.String("arch", "", "Arch to target: 386, amd64")
 	BuildAll   = flag.Bool("all", false, "Builds all architectures")
 	ShowHelp   = flag.Bool("help", false, "Shows help")

--- a/script/integration.go
+++ b/script/integration.go
@@ -190,13 +190,18 @@ func setBash() {
 		// can't understand paths like '/usr/bin/bash', needs Windows version
 		findcmd = "where"
 	}
+
 	out, err := exec.Command(findcmd, "bash").Output()
 	if err != nil {
 		fmt.Println("Unable to find bash:", err)
 		os.Exit(1)
 	}
+	if len(out) == 0 {
+		fmt.Printf("No output from '%s bash'\n", findcmd)
+		os.Exit(1)
+	}
 
-	bashPath = strings.TrimSpace(string(out))
+	bashPath = strings.TrimSpace(strings.Split(string(out), "\n")[0])
 	if debugging {
 		fmt.Println("Using", bashPath)
 	}

--- a/test/cmd/git-credential-lfsnoop.go
+++ b/test/cmd/git-credential-lfsnoop.go
@@ -1,3 +1,5 @@
+// +build testtools
+
 package main
 
 func main() {

--- a/test/test-credentials-no-prompt.sh
+++ b/test/test-credentials-no-prompt.sh
@@ -5,14 +5,6 @@
 # these tests rely on GIT_TERMINAL_PROMPT to test properly
 ensure_git_version_isnt $VERSION_LOWER "2.3.0"
 
-# if there is a system cred helper we can't run this test
-# can't disable without changing state outside test & probably don't have permission
-# this is common on OS X with certain versions of Git installed, default cred helper
-if [[ -n "$(git config --system credential.helper)" ]]; then
-  echo "skip: $0 (system cred helper we can't disable)"
-  exit
-fi
-
 begin_test "attempt private access without credential helper"
 (
   set -e

--- a/test/test-object-authenticated.sh
+++ b/test/test-object-authenticated.sh
@@ -5,14 +5,6 @@
 # these tests rely on GIT_TERMINAL_PROMPT to test properly
 ensure_git_version_isnt $VERSION_LOWER "2.3.0"
 
-# if there is a system cred helper we can't run this test
-# can't disable without changing state outside test & probably don't have permission
-# this is common on OS X with certain versions of Git installed, default cred helper
-if [[ -n "$(git config --system credential.helper)" ]]; then
-  echo "skip: $0 (system cred helper we can't disable)"
-  exit
-fi
-
 begin_test "download authenticated object"
 (
   set -e

--- a/test/testenv.sh
+++ b/test/testenv.sh
@@ -105,6 +105,7 @@ GIT_CONFIG_NOSYSTEM=1
 GIT_TERMINAL_PROMPT=0
 
 export CREDSDIR
+export GIT_CONFIG_NOSYSTEM
 
 if [[ `git config --system credential.helper | grep osxkeychain` == "osxkeychain" ]]
 then

--- a/test/testenv.sh
+++ b/test/testenv.sh
@@ -107,11 +107,6 @@ GIT_TERMINAL_PROMPT=0
 export CREDSDIR
 export GIT_CONFIG_NOSYSTEM
 
-if [[ `git config --system credential.helper | grep osxkeychain` == "osxkeychain" ]]
-then
-  OSXKEYFILE="$TMPDIR/temp.keychain"
-fi
-
 mkdir -p "$TMPDIR"
 mkdir -p "$TRASHDIR"
 

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -289,12 +289,13 @@ setup() {
   git version
 
   if [ -z "$SKIPCOMPILE" ]; then
+    [ $IS_WINDOWS == "1" ] && EXT=".exe"
     for go in test/cmd/*.go; do
-      GO15VENDOREXPERIMENT=1 go build -o "$BINPATH/$(basename $go .go)" "$go"
+      GO15VENDOREXPERIMENT=1 go build -o "$BINPATH/$(basename $go .go)$EXT" "$go"
     done
     if [ -z "$SKIPAPITESTCOMPILE" ]; then
       # Ensure API test util is built during tests to ensure it stays in sync
-      GO15VENDOREXPERIMENT=1 go build -o "$BINPATH/git-lfs-test-server-api" "test/git-lfs-test-server-api/main.go" "test/git-lfs-test-server-api/testdownload.go" "test/git-lfs-test-server-api/testupload.go"
+      GO15VENDOREXPERIMENT=1 go build -o "$BINPATH/git-lfs-test-server-api$EXT" "test/git-lfs-test-server-api/main.go" "test/git-lfs-test-server-api/testdownload.go" "test/git-lfs-test-server-api/testupload.go"
     fi
   fi
 

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -332,21 +332,6 @@ setup() {
   echo "GIT:"
   git config --global --get-regexp "lfs|credential|user"
 
-  if [ "$OSXKEYFILE" ]; then
-    # Only OS X will encounter this
-    # We can't disable osxkeychain and it gets called on store as well as ours,
-    # reporting "A keychain cannot be found to store.." errors because the test
-    # user env has no keychain; so create one
-    mkdir -p $HOME/Library/Preferences # required to store keychain lists
-    security create-keychain -p pass "$OSXKEYFILE"
-    security list-keychains -s "$OSXKEYFILE"
-    security unlock-keychain -p pass "$OSXKEYFILE"
-    security set-keychain-settings -lut 7200 "$OSXKEYFILE"
-    security default-keychain -s "$OSXKEYFILE"
-
-    echo "OSX Keychain: $OSXKEYFILE"
-  fi
-
   wait_for_file "$LFS_URL_FILE"
   wait_for_file "$LFS_SSL_URL_FILE"
   wait_for_file "$LFS_CERT_FILE"
@@ -364,12 +349,6 @@ shutdown() {
     # test/test-*.sh file is run manually.
     if [ -s "$LFS_URL_FILE" ]; then
       curl "$(cat "$LFS_URL_FILE")/shutdown"
-    fi
-
-    if [ "$OSXKEYFILE" ]; then
-      # explicitly clean up keychain to make sure search list doesn't look for it
-      # shouldn't matter because $HOME is separate & keychain prefs are there but still
-      security delete-keychain "$OSXKEYFILE"
     fi
 
     [ -z "$KEEPTRASH" ] && rm -rf "$REMOTEDIR"

--- a/test/testlib.sh
+++ b/test/testlib.sh
@@ -91,10 +91,6 @@ begin_test () {
     mkdir "$HOME"
     cp "$TESTHOME/.gitconfig" "$HOME/.gitconfig"
 
-    if [ "$OSXKEYFILE" ]; then
-      ln -s "$TESTHOME/Library" "$HOME"
-    fi
-
     # allow the subshell to exit non-zero without exiting this process
     set -x +e
 }


### PR DESCRIPTION
First round of fixes to the test framework to make tests basically run on Windows. With this, the remaining failing tests are:

In *test/test-custom-transfers.sh*:

    test: custom-transfer-upload-download ...                          FAILED

In *test/test-fetch-include.sh*:

    test: fetch: include first matching file ...                       FAILED
    test: fetch: include second matching file ...                      FAILED

Running tests in AppVeyor will be enabled in a separate PR once these tests are fixed and https://github.com/appveyor/ci/issues/1022 is deployed.