### PR TITLE
Make path comparison robust against Windows short / long path issues

### DIFF
--- a/git/git_test.go
+++ b/git/git_test.go
@@ -291,7 +291,17 @@ func TestGitAndRootDirs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, git, filepath.Join(root, ".git"))
+	expected, err := os.Stat(git)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual, err := os.Stat(filepath.Join(root, ".git"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.True(t, os.SameFile(expected, actual))
 }
 
 func TestGetTrackedFiles(t *testing.T) {


### PR DESCRIPTION
On Windows 10, this test was failing because the current user's home
directory was in DOS-style 8.3 short path notation in the expected Git
path, whereas the actual path was using the long path notation. Fix that
by comparing files based on Stat() instead of comparing strings.