### PR TITLE
lfs/batcher: support immediate Flush()-ing

### DIFF
--- a/lfs/batcher.go
+++ b/lfs/batcher.go
@@ -66,10 +66,10 @@ func (b *Batcher) Exit() {
 }
 
 // acceptInput runs in its own goroutine and accepts input from external
-// clients. Without truncation, it fills and dispenses batches in a sequential
-// order: for a batch size N, N items will be processed before a new batch is
-// ready. If a batch is truncated while still filling itself, it will be
-// returned immediately, opening up a new batch for all subsequent items.
+// clients. Without flushing, the batch is filled completely in a sequential
+// order, and then dispensed. If, while filling a batch, it is flushed part-way
+// through, the batch will be dispensed with its current contents, and all
+// subsequent Add()s will be placed in the next batch.
 func (b *Batcher) acceptInput() {
 	var exit bool
 

--- a/lfs/batcher.go
+++ b/lfs/batcher.go
@@ -31,8 +31,8 @@ func NewBatcher(batchSize int) *Batcher {
 	return b
 }
 
-// Add adds an item (or many items) to the batcher. Add is safe to call from
-// multiple goroutines.
+// Add adds one or more items to the batcher. Add is safe to call from multiple
+// goroutines.
 func (b *Batcher) Add(ts ...interface{}) {
 	if atomic.CompareAndSwapUint32(&b.exited, 1, 0) {
 		b.input = make(chan interface{})

--- a/lfs/batcher.go
+++ b/lfs/batcher.go
@@ -31,16 +31,18 @@ func NewBatcher(batchSize int) *Batcher {
 	return b
 }
 
-// Add adds an item to the batcher. Add is safe to call from multiple
-// goroutines.
-func (b *Batcher) Add(t interface{}) {
+// Add adds an item (or many items) to the batcher. Add is safe to call from
+// multiple goroutines.
+func (b *Batcher) Add(ts ...interface{}) {
 	if atomic.CompareAndSwapUint32(&b.exited, 1, 0) {
 		b.input = make(chan interface{})
 		b.truncate = make(chan interface{})
 		go b.acceptInput()
 	}
 
-	b.input <- t
+	for _, t := range ts {
+		b.input <- t
+	}
 }
 
 // Next will wait for the one of the above batch triggers to occur and return

--- a/lfs/batcher.go
+++ b/lfs/batcher.go
@@ -19,7 +19,7 @@ type Batcher struct {
 func NewBatcher(batchSize int) *Batcher {
 	b := &Batcher{
 		batchSize:  batchSize,
-		input:      make(chan interface{}, batchSize),
+		input:      make(chan interface{}),
 		batchReady: make(chan []interface{}),
 	}
 
@@ -31,7 +31,7 @@ func NewBatcher(batchSize int) *Batcher {
 // goroutines.
 func (b *Batcher) Add(t interface{}) {
 	if atomic.CompareAndSwapUint32(&b.exited, 1, 0) {
-		b.input = make(chan interface{}, b.batchSize)
+		b.input = make(chan interface{})
 		go b.acceptInput()
 	}
 

--- a/lfs/batcher.go
+++ b/lfs/batcher.go
@@ -6,8 +6,10 @@ import "sync/atomic"
 // be added to the batcher from multiple goroutines and pulled off in groups
 // when one of the following conditions occurs:
 //   * The batch size is reached
+//   * Truncate() is called, forcing the batch to be returned immediately, as-is
 //   * Exit() is called
-// When an Exit() occurs, the group may be smaller than the batch size.
+// When an Exit() or Truncate() occurs, the group may be smaller than the batch
+// size.
 type Batcher struct {
 	exited     uint32
 	batchSize  int

--- a/lfs/batcher.go
+++ b/lfs/batcher.go
@@ -67,7 +67,7 @@ func (b *Batcher) Exit() {
 // ready. If a batch is truncated while still filling itself, it will be
 // returned immediately, opening up a new batch for all subsequent items.
 func (b *Batcher) acceptInput() {
-	exit := false
+	var exit bool
 
 	for {
 		batch := make([]interface{}, 0, b.batchSize)

--- a/lfs/batcher.go
+++ b/lfs/batcher.go
@@ -71,17 +71,17 @@ func (b *Batcher) acceptInput() {
 
 	for {
 		batch := make([]interface{}, 0, b.batchSize)
-	Loop:
+	Acc:
 		for len(batch) < b.batchSize {
 			select {
 			case t, ok := <-b.input:
 				if !ok {
 					exit = true // input channel was closed by Exit()
-					break Loop
+					break Acc
 				}
 				batch = append(batch, t)
 			case <-b.truncate:
-				break Loop
+				break Acc
 			}
 		}
 

--- a/lfs/batcher_test.go
+++ b/lfs/batcher_test.go
@@ -1,13 +1,14 @@
 package lfs
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestBatcherSizeMet(t *testing.T) {
+func TestBatcherOnlyReturnsCompleteBatchesWithoutExiting(t *testing.T) {
 	runBatcherTests([]batcherTestCase{
 		{2, 4, false},
 		{3, 5, false},
@@ -15,7 +16,7 @@ func TestBatcherSizeMet(t *testing.T) {
 	}, t)
 }
 
-func TestBatcherExit(t *testing.T) {
+func TestBatcherReturnsIncompleteBatchesWhenExiting(t *testing.T) {
 	runBatcherTests([]batcherTestCase{
 		{2, 4, true},
 		{3, 5, true},
@@ -27,7 +28,8 @@ func TestBatcherTruncatesPartialBatches(t *testing.T) {
 	first, second := "first", "second"
 
 	b := NewBatcher(3)
-	b.Add(first, second)
+	b.Add(first)
+	b.Add(second)
 	b.Truncate()
 
 	batch := b.Next()
@@ -45,43 +47,54 @@ type batcherTestCase struct {
 	ShouldExit bool
 }
 
-// Batcher makes and returns a lfs.Batcher according to the specification given
-// in this instance of batcherTestCase. When returned, it is filled with the
-// given amount of items, and has exited if it was told to.
-func (b batcherTestCase) Batcher() *Batcher {
+// Assert asserts that appropriate sized batches were emitted given a batch size
+// and item count, (and potentially an instruction to exit).
+//
+// In the case that the item count is an even divisor of the batch size, we
+// expect several full batches where the total amount of items returned in the
+// batches is equal to the given item count.
+//
+// In the case where the item count is _not_ an even divisor of the batch size,
+// we expect either: one partially full batch, or at least one completely full
+// batch and one partially full batch. If the batcher is instructed to exit, we
+// expect to see an item count returned equal to the given item count. If the
+// batcher is not instructed to exit, we should see an item count equal to the
+// number of full batches received * the batch size.
+func (b batcherTestCase) Assert(t *testing.T) {
 	batcher := NewBatcher(b.BatchSize)
-	for i := 0; i < b.ItemCount; i++ {
-		batcher.Add(&Downloadable{})
+
+	var remaining = b.ItemCount
+	for remaining > 0 {
+		size := int(math.Min(float64(b.BatchSize), float64(remaining)))
+		for i := 0; i < size; i++ {
+			batcher.Add(struct{}{})
+		}
+
+		if remaining < b.BatchSize {
+			if b.ShouldExit {
+				// If there is an uneven amount of items and we
+				// choose to exit, we should receive a partial
+				// batch upon calling `batcher.Next()` because
+				// of the following call to `batcher.Exit()`.
+				batcher.Exit()
+			} else {
+				// If there was an uneven amount of items and we
+				// choose _not_ to exit, then those remaining
+				// items are abandoned.
+				return
+			}
+		}
+
+		assert.Len(t, batcher.Next(), size)
+
+		remaining -= size
 	}
-
-	if b.ShouldExit {
-		batcher.Exit()
-	}
-
-	return batcher
-}
-
-// Batches returns the number of individual batches expected to be processed by
-// the batcher under test.
-func (b batcherTestCase) Batches() int {
-	if b.BatchSize == 0 {
-		return b.ItemCount
-	}
-
-	return b.ItemCount / b.BatchSize
 }
 
 // runBatcherTests processes all test cases, throwing assertion errors if they
 // fail.
 func runBatcherTests(cases []batcherTestCase, t *testing.T) {
 	for _, c := range cases {
-		b := c.Batcher()
-
-		items := c.ItemCount
-		for i := 0; i < c.Batches(); i++ {
-			group := b.Next()
-			assert.Len(t, group, c.BatchSize)
-			items -= c.BatchSize
-		}
+		c.Assert(t)
 	}
 }

--- a/lfs/batcher_test.go
+++ b/lfs/batcher_test.go
@@ -27,8 +27,7 @@ func TestBatcherTruncatesPartialBatches(t *testing.T) {
 	first, second := "first", "second"
 
 	b := NewBatcher(3)
-	b.Add(first)
-	b.Add(second)
+	b.Add(first, second)
 	b.Truncate()
 
 	batch := b.Next()

--- a/lfs/batcher_test.go
+++ b/lfs/batcher_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBatcherSizeMet(t *testing.T) {
@@ -20,6 +21,21 @@ func TestBatcherExit(t *testing.T) {
 		{3, 5, true},
 		{0, 0, true},
 	}, t)
+}
+
+func TestBatcherTruncatesPartialBatches(t *testing.T) {
+	first, second := "first", "second"
+
+	b := NewBatcher(3)
+	b.Add(first)
+	b.Add(second)
+	b.Truncate()
+
+	batch := b.Next()
+
+	require.Len(t, batch, 2)
+	assert.Equal(t, first, batch[0])
+	assert.Equal(t, second, batch[1])
 }
 
 // batcherTestCase specifies information about how to run a particular test

--- a/lfs/batcher_test.go
+++ b/lfs/batcher_test.go
@@ -24,13 +24,13 @@ func TestBatcherReturnsIncompleteBatchesWhenExiting(t *testing.T) {
 	}, t)
 }
 
-func TestBatcherTruncatesPartialBatches(t *testing.T) {
+func TestBatcherFlushesPartialBatches(t *testing.T) {
 	first, second := "first", "second"
 
 	b := NewBatcher(3)
 	b.Add(first)
 	b.Add(second)
-	b.Truncate()
+	b.Flush()
 
 	batch := b.Next()
 


### PR DESCRIPTION
This pull-request adds the ability to immediately flush the currently accumulating batch.

The motivation behind this pull-request is the ability to support multiple retries per object in the current transfer queue implementation. Currently, we [keep track of the items that failed to transfer](https://github.com/github/git-lfs/blob/b7b1f2b7985c8f7a18c563c70898f669ffb8c13c/lfs/transfer_queue.go#L420) and then [retry them once more](https://github.com/github/git-lfs/blob/b7b1f2b7985c8f7a18c563c70898f669ffb8c13c/lfs/transfer_queue.go#L233-L242) before we exit in [`Wait()`](https://github.com/github/git-lfs/blob/b7b1f2b7985c8f7a18c563c70898f669ffb8c13c/lfs/transfer_queue.go#L218-L221).

In the future, we'd like to support retrying objects multiple times, by re-submitting them into the Batcher, and then getting batches of retries out. In order to do this, we need to know how many retries there are left. In my initial pass, I simply re-added failed items to the batcher, and waited for a batch to come out. However, a batch isn't delivered until we either [fill the batch size](https://github.com/github/git-lfs/blob/b7b1f2b7985c8f7a18c563c70898f669ffb8c13c/lfs/batcher.go#L63) (unlikely for retries), or [Exit()](https://github.com/github/git-lfs/blob/b7b1f2b7985c8f7a18c563c70898f669ffb8c13c/lfs/batcher.go#L65-L68), [and close all of the channels](https://github.com/github/git-lfs/blob/b7b1f2b7985c8f7a18c563c70898f669ffb8c13c/lfs/batcher.go#L51).

To allow us to force a batch to be delivered immediately, we guarentee that an item has been delivered on the channel (more information in https://github.com/github/git-lfs/commit/98873d87c4b06beecbba57221e70dd975ce7d7d4), and then immediately Flush() the batch, giving us a batch of 1 item to be retried.

In future PRs, I plan to make this retry behavior smarter, by overflowing retry buckets, or batching the retries together. As a first pass, I just want it to work 😄 

As a side 📝 , the test cases that I introduced in https://github.com/github/git-lfs/pull/613 (coincidentally, my first LFS patch) did not fully cover the behavior of the batcher, namely what happens when an uneven amount of items is added. This is what was causing the deadlock in https://github.com/github/git-lfs/pull/1528/commits/98873d87c4b06beecbba57221e70dd975ce7d7d4. With some debugging, the old tests produced:

```
Creating batcher with 5 items and size 3
Added item
Added item
Added item
Added item # <- gone
Added item # <- gone
Grabbing batch #1
Got batch size of 3
<end>
```

The remaining two items are gone! No one ever checks for them. I fixed this behavior in https://github.com/github/git-lfs/pull/1528/commits/a0d0635c82cb8fec724ff24ea7664b28d3dc9d03.


--

/cc @rubyist since you were the original author
/cc @technoweenie @sinbad for 👀  and 💭 s