### PR TITLE
lfs/tq: extract `RetryCounter`

### DIFF
--- a/lfs/transfer_queue_test.go
+++ b/lfs/transfer_queue_test.go
@@ -1,0 +1,62 @@
+package lfs
+
+import (
+	"testing"
+
+	"github.com/github/git-lfs/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryCounterDefaultsToFixedRetries(t *testing.T) {
+	rc := newRetryCounter(config.NewFrom(config.Values{}))
+
+	assert.Equal(t, 1, rc.MaxRetries)
+}
+
+func TestRetryCounterIsConfigurable(t *testing.T) {
+	rc := newRetryCounter(config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.transfer.maxretries": "3",
+		},
+	}))
+
+	assert.Equal(t, 3, rc.MaxRetries)
+}
+
+func TestRetryCounterClampsValidValues(t *testing.T) {
+	rc := newRetryCounter(config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.transfer.maxretries": "-1",
+		},
+	}))
+
+	assert.Equal(t, 1, rc.MaxRetries)
+}
+
+func TestRetryCounterIgnoresNonInts(t *testing.T) {
+	rc := newRetryCounter(config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.transfer.maxretries": "not_an_int",
+		},
+	}))
+
+	assert.Equal(t, 1, rc.MaxRetries)
+}
+
+func TestRetryCounterIncrementsObjects(t *testing.T) {
+	rc := newRetryCounter(config.NewFrom(config.Values{}))
+
+	rc.Increment("oid")
+
+	assert.Equal(t, 1, rc.CountFor("oid"))
+}
+
+func TestRetryCounterCanNotRetryAfterExceedingRetryCount(t *testing.T) {
+	rc := newRetryCounter(config.NewFrom(config.Values{}))
+
+	rc.Increment("oid")
+	count, canRetry := rc.CanRetry("oid")
+
+	assert.Equal(t, 1, count)
+	assert.False(t, canRetry)
+}


### PR DESCRIPTION
This pull-request introduces the extracted `RetryCounter` type, which serves two purposes:
- Allows configuration via the `lfs.transfer.maxretries` `.gitconfig` option
- Serves as a base on which to implement retry budgets

📝  I left a few notes throughout the code to point out some choices I made, but this should be a pretty minor change regardless.

I want to investigate a higher-level integration test for this behavior, but I'm not sure what it will look like after retry budgets are implemented. As a first pass, I'm thinking that we could encode "number of retries before success" on the server side and assert that we retried as many times as we could on the client side.

:wave: thanks in advance for the review.

---

/cc @technoweenie @rubyist @sinbad for 👀 