### PR TITLE
Teach status to recognize multiple files with identical contents

### DIFF
--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -221,8 +221,10 @@ func ScanIndex(ref string) ([]*WrappedPointer, error) {
 		seenRevs := make(map[string]bool, 0)
 
 		for rev := range revs.Results {
-			seenRevs[rev] = true
-			allRevsChan <- rev
+			if !seenRevs[rev] {
+				allRevsChan <- rev
+				seenRevs[rev] = true
+			}
 		}
 		err := revs.Wait()
 		if err != nil {
@@ -230,8 +232,9 @@ func ScanIndex(ref string) ([]*WrappedPointer, error) {
 		}
 
 		for rev := range cachedRevs.Results {
-			if _, ok := seenRevs[rev]; !ok {
+			if !seenRevs[rev] {
 				allRevsChan <- rev
+				seenRevs[rev] = true
 			}
 		}
 		err = cachedRevs.Wait()

--- a/test/test-status.sh
+++ b/test/test-status.sh
@@ -109,3 +109,26 @@ Git LFS objects not staged for commit:"
 )
 end_test
 
+begin_test "status shows multiple files with identical contents"
+(
+  set -e
+
+  reponame="uniq-status"
+  mkdir "$reponame"
+  cd "$reponame"
+
+  git init
+  git lfs track "*.dat"
+
+  contents="contents"
+  printf "$contents" > a.dat
+  printf "$contents" > b.dat
+
+  git add --all .
+
+  git lfs status | tee status.log
+
+  [ "1" -eq "$(grep -c "a.dat" status.log)" ]
+  [ "1" -eq "$(grep -c "b.dat" status.log)" ]
+)
+end_test


### PR DESCRIPTION
This pull-request teaches the `git lfs status` command how to recognize multiple files that share the same contents. By modifying the behavior of `lfs.ScanIndex`, we now maintain a _slice_ of file metadata associated with a given OID, instead of a one-to-one association [(as before)](https://github.com/github/git-lfs/blob/d8cab9ec1ce008f0230ca6a97581eda0b362d4a1/lfs/scanner.go#L188).

`ScanIndex` now only [accepts unique pointer OIDs][1] (even if there are multiple pointers for a given OID, in the case of many files sharing the same contents), and then [resolves them all at once][2] to multiple files, per the data stored in the indexFileMap. 

[1]: https://github.com/github/git-lfs/commit/752b88e781dcb431e4fe38ea08fccb64cfddf212
[2]: https://github.com/github/git-lfs/blob/7c1b2f063979adcde638cf54eb79f0177e4cb947/lfs/scanner.go#L276-L289

While working on this, @technoweenie and I found what may be a Git core bug having to do with checking a file that is both in the index and working tree (i.e., it appears in both `git diff-index` and `git diff-index --cached`). I stashed a failing test that I wrote to demonstrate this behavior in [this][3] Gist.

[3]: https://gist.github.com/ttaylorr/bc6df845466cfb720327d31610bc97f7

As an aside, this PR is a temporary measure. Maintaining these extra caches is not a long-term solution that I'd like to keep, this is more of a hack to solve this bug quickly.

--

/cc @technoweenie @sinbad @rubyist