### PR TITLE
Travis: Only install git if not installed yet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
       before_script:
         - >
           brew update;
-          brew install git;
+          brew ls --versions git && brew upgrade git || brew install git;
     - env: git-latest-go-1.5
       os: linux
       go: 1.5
@@ -58,7 +58,7 @@ matrix:
       before_script:
         - >
           brew update;
-          brew install git;
+          brew ls --versions git && brew upgrade git || brew install git;
 
 before_install:
   - >


### PR DESCRIPTION
It seems some osx10.11 Travis workers already have git installed via
homebrew, resulting in

    Error: git-2.10.0 already installed

    To install this version, first `brew unlink git`

So only install git if not installed yet, and upgrade it otherwise.