### PR TITLE
lfs: warn on usage of the legacy API

### DIFF
--- a/test/test-push-bad-dns.sh
+++ b/test/test-push-bad-dns.sh
@@ -51,10 +51,11 @@ begin_test "push (legacy): upload to bad dns"
   git config lfs.url "http://git-lfs-bad-dns:$port"
 
   set +e
-  GIT_TERMINAL_PROMPT=0 git push origin master
-  res="$?"
+  GIT_TERMINAL_PROMPT=0 git push origin master 2>&1 | tee push.log
+  res="${PIPESTATUS[0]}"
   set -e
 
+  grep "WARNING: Git LFS is using a deprecated API" push.log
   refute_server_object "$reponame" "$(calc_oid "hi")"
   if [ "$res" = "0" ]; then
     echo "push successful?"

--- a/test/test-push-legacy-failures.sh
+++ b/test/test-push-legacy-failures.sh
@@ -19,10 +19,11 @@ push_legacy_fail_test() {
   git commit -m "welp"
 
   set +e
-  git push origin master
-  res="$?"
+  git push origin master 2>&1 | tee push.log
+  res="${PIPESTATUS[0]}"
   set -e
 
+  grep "WARNING: Git LFS is using a deprecated API" push.log
   refute_server_object "$reponame" "$(calc_oid "$contents")"
   if [ "$res" = "0" ]; then
     echo "push successful?"


### PR DESCRIPTION
This pull request triggers a warning whenever usage of the legacy API is detected. This is a part of a larger effort to remove usage of the legacy API entirely from Git LFS by the time we release v1.5.0.

I decided to print the message out from the API, since it's the quickest way we can land this without some extra plumbing. Because the `commands` package already has a dependency leading into the `api` package, we can't use `commands.Error` or similar, thus the need for a `fmt.Fprintf` directly.

One other option is to check the config value for `lfs.batch` directly (via `coonfig.Config.BatchEnabled()`) and print it out from the commands package. This would be cleaner, of course, but doesn't accurately cover the case where we fallback to the legacy API mid-transfer.

Either way, this code isn't going to live here long, so I don't think it matters terribly much.

--

/cc @technoweenie @rubyist 