### PR TITLE
use filepath.Clean() when comparing filenames to include/exclude patterns

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -76,6 +76,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 
 	} else { // !all
 		includePaths, excludePaths := determineIncludeExcludePaths(cfg, include, exclude)
+		fmt.Println("FETCH INCLUDE", includePaths)
 
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored
 		for _, ref := range refs {

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -76,7 +76,6 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 
 	} else { // !all
 		includePaths, excludePaths := determineIncludeExcludePaths(cfg, include, exclude)
-		fmt.Println("FETCH INCLUDE", includePaths)
 
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored
 		for _, ref := range refs {

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -81,27 +81,26 @@ func FilenamePassesIncludeExcludeFilter(filename string, includePaths, excludePa
 		return true
 	}
 
-	// For Win32, because git reports files with / separators
-	cleanfilename := filepath.Clean(filename)
+	filename = filepath.Clean(filename)
 	if len(includePaths) > 0 {
 		matched := false
 		for _, inc := range includePaths {
+			inc = filepath.Clean(inc)
+
 			// Special case local dir, matches all (inc subpaths)
 			if _, local := localDirSet[inc]; local {
 				matched = true
 				break
 			}
+
 			matched, _ = filepath.Match(inc, filename)
-			if !matched && IsWindows() {
-				// Also Win32 match
-				matched, _ = filepath.Match(inc, cleanfilename)
-			}
 			if !matched {
 				// Also support matching a parent directory without a wildcard
-				if strings.HasPrefix(cleanfilename, inc+string(filepath.Separator)) {
+				if strings.HasPrefix(filename, inc+string(filepath.Separator)) {
 					matched = true
 				}
 			}
+
 			if matched {
 				break
 			}
@@ -114,23 +113,21 @@ func FilenamePassesIncludeExcludeFilter(filename string, includePaths, excludePa
 
 	if len(excludePaths) > 0 {
 		for _, ex := range excludePaths {
+			ex = filepath.Clean(ex)
+
 			// Special case local dir, matches all (inc subpaths)
 			if _, local := localDirSet[ex]; local {
 				return false
 			}
-			matched, _ := filepath.Match(ex, filename)
-			if !matched && IsWindows() {
-				// Also Win32 match
-				matched, _ = filepath.Match(ex, cleanfilename)
-			}
-			if matched {
-				return false
-			}
-			// Also support matching a parent directory without a wildcard
-			if strings.HasPrefix(cleanfilename, ex+string(filepath.Separator)) {
+
+			if matched, _ := filepath.Match(ex, filename); matched {
 				return false
 			}
 
+			// Also support matching a parent directory without a wildcard
+			if strings.HasPrefix(filename, ex+string(filepath.Separator)) {
+				return false
+			}
 		}
 	}
 


### PR DESCRIPTION
This removes the windows-specific hacks, and uses `filepath.Clean()` to sanitize the paths. This broke previously because it was `filepath.Match()` expects back slashes on windows.