### PR TITLE
Enable running tests on AppVeyor CI

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,7 +67,7 @@ These are items that don't affect Git LFS end users.
 
 | | Name | Ref |
 | ------ | ---- | --- |
-| | CI builds for Windows. | |
+| :ship: | CI builds for Windows. | [#1567](https://github.com/github/git-lfs/pull/1567) |
 | | Automated build servers that build Git LFS on native platforms. | |
 | | Automated QA test suite for running release candidates through a gauntlet of open source and proprietary Git LFS environments. | |
 | | Automatic updates of the Git LFS client. | [#531](https://github.com/github/git-lfs/issues/531) |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,24 @@
+environment:
+  GOPATH: $(HOMEDRIVE)$(HOMEPATH)\go
+  MSYSTEM: MINGW64
+
+clone_folder: $(GOPATH)\src\github.com\github\git-lfs
+
 install:
   - cinst InnoSetup -y
   - set PATH="C:\Program Files (x86)\Inno Setup 5";%PATH%
 
 build_script:
-  - bash -c 'GOARCH=386 script/bootstrap'
+  - bash --login -c 'GOARCH=386 script/bootstrap'
   - mv bin\git-lfs.exe git-lfs-x86.exe
-  - bash -c 'GOARCH=amd64 script/bootstrap'
+  - bash --login -c 'GOARCH=amd64 script/bootstrap'
   - mv bin\git-lfs.exe git-lfs-x64.exe
 
 after_build:
   - iscc script\windows-installer\inno-setup-git-lfs-installer.iss
+
+test_script:
+  - bash --login script/cibuild
 
 artifacts:
   - path: git-lfs-x86.exe


### PR DESCRIPTION
This depends on (and contains the changes from) PR #1566. Once that other PR is merged, this PR contains only a single commit to turn on tests on AppVeyor CI, which should now all pass.