### PR TITLE
lfs/tq: send error before terminating object

### DIFF
--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -434,8 +434,8 @@ func (q *TransferQueue) batchApiRoutine() {
 				if q.canRetryObject(t.Oid(), err) {
 					q.retry(t)
 				} else {
-					q.wait.Done()
 					errOnce.Do(func() { q.errorc <- err })
+					q.wait.Done()
 				}
 			}
 


### PR DESCRIPTION
Previously, decrementing the surrounding `sync.WaitGroup` allowed the
`q.errorc` channel to be closed before this send could occur. This racy
behavior introduced a send-on-closed-channel panic, which is fixed in this
commit.

--

/cc @technoweenie @sinbad @rubyist 