### PR TITLE
api: correctly print legacy API warning to Stderr

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -217,7 +217,7 @@ var warningOnce sync.Once
 
 func legacyWarning() {
 	warningOnce.Do(func() {
-		fmt.Println(os.Stderr, "WARNING: Git LFS is using a deprecated API, which will be removed in v1.5.0.")
-		fmt.Println(os.Stderr, "         Consider enabling the latest API by running: `git config lfs.batch true`.")
+		fmt.Fprintln(os.Stderr, "WARNING: Git LFS is using a deprecated API, which will be removed in v1.5.0.")
+		fmt.Fprintln(os.Stderr, "         Consider enabling the latest API by running: `git config lfs.batch true`.")
 	})
 }


### PR DESCRIPTION
This pull-request fixes some accidental usage of `fmt.Println` where `fmt.Fprintln` should have been used instead. Since `fmt.Println` accepts variadic arguments of the form `(vs ...interface{})`, the old behavior was to print out the address of `os.Stderr` (given as the first argument), and then the message as expected.

--

/cc @technoweenie 