### PR TITLE
lfs/tq: use extra arguments given to tracerx.Printf

### DIFF
--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -498,7 +498,7 @@ func (q *TransferQueue) retryCollector() {
 
 		q.Add(t)
 		if q.batcher != nil {
-			tracerx.Printf("tq: flushing batch in response to retry #%d for %q", count, t.Oid(), t.Size())
+			tracerx.Printf("tq: flushing batch in response to retry #%d for %q (size: %d)", count, t.Oid(), t.Size())
 			q.batcher.Flush()
 		}
 	}


### PR DESCRIPTION
This pull-request fixes all places within the transferqueue where an incorrect number of arguments are given to the trace log.

-

/cc @technoweenie 