### PR TITLE
Test legacy check retries behavior

### DIFF
--- a/lfs/transfer_queue.go
+++ b/lfs/transfer_queue.go
@@ -338,7 +338,7 @@ func (q *TransferQueue) individualApiRoutine(apiWaiter chan interface{}) {
 	for t := range q.apic {
 		obj, err := t.LegacyCheck()
 		if err != nil {
-			if q.canRetryObject(obj.Oid, err) {
+			if q.canRetryObject(t.Oid(), err) {
 				q.retry(t)
 			} else {
 				q.errorc <- err

--- a/test/test-legacy-retries.sh
+++ b/test/test-legacy-retries.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "legacy upload check causes retries"
+(
+  set -e
+
+  reponame="legacy-upload-check-retry"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" repo-upload
+  git config --local lfs.batch false
+
+  contents="legacy-upload-check-retry"
+  oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
+
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git config --local lfs.transfer.maxretries 3
+  git push origin master
+
+  assert_server_object "$reponame" "$oid"
+)
+end_test
+
+begin_test "legacy download check causes retries"
+(
+  set -e
+
+  reponame="legacy-download-check-retry"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" repo-download
+
+  contents="legacy-download-check-retry"
+  oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
+
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git push origin master
+  assert_server_object "$reponame" "$oid"
+
+  pushd ..
+    git \
+      -c "filter.lfs.smudge=" \
+      -c "filter.lfs.required=false" \
+      clone "$GITSERVER/$reponame" "$reponame-assert"
+
+    cd "$reponame-assert"
+
+    git config credential.helper lfstest
+    git config --local lfs.batch false
+    git config --local lfs.transfer.maxretries 2
+
+    git lfs pull origin
+  popd
+)
+end_test

--- a/test/test-legacy-retries.sh
+++ b/test/test-legacy-retries.sh
@@ -47,7 +47,7 @@ begin_test "legacy download check causes retries"
 
   pushd ..
     git \
-      -c "filter.lfs.smudge=" \
+      -c "filter.lfs.smudge=cat" \
       -c "filter.lfs.required=false" \
       clone "$GITSERVER/$reponame" "$reponame-assert"
 

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -70,7 +70,8 @@ refute_server_object() {
   curl -v "$GITSERVER/$reponame.git/info/lfs/objects/$oid" \
     -u "user:pass" \
     -o http.json \
-    -H "Accept: application/vnd.git-lfs+json" 2>&1 |
+    -H "Accept: application/vnd.git-lfs+json" \
+    -H "X-Ignore-Retries: true" 2>&1 |
     tee http.log
 
   grep "404 Not Found" http.log
@@ -100,7 +101,8 @@ assert_server_object() {
   curl -v "$GITSERVER/$reponame.git/info/lfs/objects/$oid" \
     -u "user:pass" \
     -o http.json \
-    -H "Accept: application/vnd.git-lfs+json" 2>&1 |
+    -H "Accept: application/vnd.git-lfs+json" \
+    -H "X-Ignore-Retries: true" 2>&1 |
     tee http.log
   grep "200 OK" http.log
 


### PR DESCRIPTION
This pull-request fixes an issue described in https://github.com/github/git-lfs/issues/1580, where, when using the transferqueue with `lfs.batch=false`, a failed legacy check would result in a nil-pointer dereference `panic`.

To ensure further safety, I added two new `oidHandler`s to force a finite number of retries into both the upload/download check for legacy transfers. I will follow this up in my next pull-request with a similar solution for the storage endpoint so we can also test this behavior when using the batch API.

--

/cc @technoweenie @rubyist @sschuberth #1580