### PR TITLE
Storage retries

### DIFF
--- a/test/test-batch-retries.sh
+++ b/test/test-batch-retries.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "batch storage upload causes retries"
+(
+  set -e
+
+  reponame="batch-storage-upload-retry"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" batch-storage-repo-upload
+
+  contents="storage-upload-retry"
+  oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
+
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git config --local lfs.transfer.maxretries 3
+  git push origin master
+
+  assert_server_object "$reponame" "$oid"
+)
+end_test

--- a/test/test-batch-retries.sh
+++ b/test/test-batch-retries.sh
@@ -24,3 +24,40 @@ begin_test "batch storage upload causes retries"
   assert_server_object "$reponame" "$oid"
 )
 end_test
+
+begin_test "batch storage download causes retries"
+(
+  set -e
+
+  reponame="batch-storage-download-retry"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" batch-storage-repo-download
+
+  contents="storage-download-retry"
+  oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
+
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git push origin master
+  assert_server_object "$reponame" "$oid"
+
+  pushd ..
+    git \
+      -c "filter.lfs.smudge=cat" \
+      -c "filter.lfs.required=false" \
+      clone "$GITSERVER/$reponame" "$reponame-assert"
+
+    cd "$reponame-assert"
+
+    git config credential.helper lfstest
+    git config --local lfs.transfer.maxretries 3
+
+    git lfs pull origin
+
+    assert_local_object "$oid" "${#contents}"
+  popd
+)
+end_test

--- a/test/test-legacy-retries.sh
+++ b/test/test-legacy-retries.sh
@@ -61,3 +61,28 @@ begin_test "legacy download check causes retries"
   popd
 )
 end_test
+
+begin_test "legacy storage upload causes retries"
+(
+  set -e
+
+  reponame="legacy-storage-upload-retry"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" legacy-storage-repo-upload
+
+  git config --local lfs.batch false
+
+  contents="storage-upload-retry"
+  oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
+
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git config --local lfs.transfer.maxretries 3
+  git push origin master
+
+  assert_server_object "$reponame" "$oid"
+)
+end_test

--- a/test/test-legacy-retries.sh
+++ b/test/test-legacy-retries.sh
@@ -86,3 +86,41 @@ begin_test "legacy storage upload causes retries"
   assert_server_object "$reponame" "$oid"
 )
 end_test
+
+begin_test "legacy storage download causes retries"
+(
+  set -e
+
+  reponame="legacy-storage-download-retry"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" legacy-storage-repo-download
+
+  contents="storage-download-retry"
+  oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
+
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git push origin master
+  assert_server_object "$reponame" "$oid"
+
+  pushd ..
+    git \
+      -c "filter.lfs.smudge=cat" \
+      -c "filter.lfs.required=false" \
+      clone "$GITSERVER/$reponame" "$reponame-assert"
+
+    cd "$reponame-assert"
+
+    git config credential.helper lfstest
+    git config --local lfs.batch false
+    git config --local lfs.transfer.maxretries 3
+
+    git lfs pull origin
+
+    assert_local_object "$oid" "${#contents}"
+  popd
+)
+end_test


### PR DESCRIPTION
This pull-request adds tests asserting retry behavior when both upload and download requests are made to the storage endpoint.

I will follow this PR up with another special-case handler guarding interactions with the batch API endpoint, which, once merged, will fully cover the new retry behavior at the integration level.

--

/cc @technoweenie @sschuberth 