### PR TITLE
AppVeyor: Do not build branches with open pull requests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+skip_branch_with_pr: true
+
 environment:
   GOPATH: $(HOMEDRIVE)$(HOMEPATH)\go
   MSYSTEM: MINGW64


### PR DESCRIPTION
As suggested [here](https://github.com/appveyor/ci/issues/1115#issuecomment-254367662). However, I'm wondering why I still see build for bot the branch and PR here, and now I also start seeing both for Travis CI builds.