### PR TITLE
Expose the result message in case of an SSH authentication error

### DIFF
--- a/api/v1.go
+++ b/api/v1.go
@@ -91,10 +91,10 @@ func NewRequest(cfg *config.Configuration, method, oid string) (*http.Request, e
 
 	res, endpoint, err := auth.SshAuthenticate(cfg, operation, oid)
 	if err != nil {
-		tracerx.Printf("ssh: attempted with %s.  Error: %s",
-			endpoint.SshUserAndHost, err.Error(),
+		tracerx.Printf("ssh: %s with %s failed, error: %s, message: %s",
+			operation, endpoint.SshUserAndHost, err.Error(), res.Message,
 		)
-		return nil, err
+		return nil, errors.Wrap(errors.New(res.Message), err.Error())
 	}
 
 	if len(res.Href) > 0 {
@@ -118,10 +118,10 @@ func NewRequest(cfg *config.Configuration, method, oid string) (*http.Request, e
 func NewBatchRequest(cfg *config.Configuration, operation string) (*http.Request, error) {
 	res, endpoint, err := auth.SshAuthenticate(cfg, operation, "")
 	if err != nil {
-		tracerx.Printf("ssh: %s attempted with %s.  Error: %s",
-			operation, endpoint.SshUserAndHost, err.Error(),
+		tracerx.Printf("ssh: %s with %s failed, error: %s, message: %s",
+			operation, endpoint.SshUserAndHost, err.Error(), res.Message,
 		)
-		return nil, err
+		return nil, errors.Wrap(errors.New(res.Message), err.Error())
 	}
 
 	if len(res.Href) > 0 {

--- a/auth/ssh.go
+++ b/auth/ssh.go
@@ -51,7 +51,7 @@ func SshAuthenticate(cfg *config.Configuration, operation, oid string) (SshAuthR
 
 	// Processing result
 	if err != nil {
-		res.Message = errbuf.String()
+		res.Message = strings.TrimSpace(errbuf.String())
 	} else {
 		err = json.Unmarshal(outbuf.Bytes(), &res)
 	}


### PR DESCRIPTION
Not only expose the error message, but also the result message from
calling SSH which contains details about the cause. At the example of
using the wrong SSH key for authentication, with this the console shows

    download check: exit status 255: Permission denied (publickey).

instead of just

    download check: exit status 255

and the log shows

    trace git-lfs: ssh: download with url failed,
    error: exit status 255, message: Permission denied (publickey).

instead of just

    trace git-lfs: ssh: download attempted with url.
    Error: exit status 255