### PR TITLE
commands,lfs/tq: Only send unique OIDs to the Transfer Queue

### DIFF
--- a/test/test-duplicate-oids.sh
+++ b/test/test-duplicate-oids.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "multiple revs with same OID get pushed once"
+(
+  set -e
+
+  reponame="mutliple-revs-one-oid"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  contents="contents"
+  contents_oid="$(calc_oid "$contents")"
+
+  # Stash the contents of the file that we want to commit in .git/lfs/objects.
+  object_dir="$(echo $contents_oid \
+    | awk '{ print substr($0, 0, 2) "/" substr($0, 3, 2) }')"
+  mkdir -p ".git/lfs/objects/$object_dir"
+  printf "$contents" > ".git/lfs/objects/$object_dir/$contents_oid"
+
+  # Create a pointer with the old "http://git-media.io" spec
+  legacy_pointer="$(pointer $contents_oid 8 http://git-media.io/v/2)"
+  # Create a pointer with the latest spec to create a modification, but leave
+  # the OID untouched.
+  latest_pointer="$(pointer $contents_oid 8)"
+
+  # Commit the legacy pointer
+  printf "$legacy_pointer" > a.dat
+  git add a.dat
+  git commit -m "commit legacy"
+
+  # Commit the new pointer, causing a diff on a.dat, but leaving the OID
+  # unchanged.
+  printf "$latest_pointer" > a.dat
+  git add a.dat
+  git commit -m "commit latest"
+
+  # Delay the push until here, so the server doesn't have a copy of the OID that
+  # we're trying to push.
+  git push origin master 2>&1 | tee push.log
+  grep "Git LFS: (1 of 1 files)" push.log
+
+  assert_server_object "$reponame" "$contents_oid"
+)
+end_test

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -145,15 +145,16 @@ refute_server_lock() {
 
 # pointer returns a string Git LFS pointer file.
 #
-#   $ pointer abc-some-oid 123
+#   $ pointer abc-some-oid 123 <version>
 #   > version ...
 pointer() {
   local oid=$1
   local size=$2
-  printf "version https://git-lfs.github.com/spec/v1
+  local version=${3:-https://git-lfs.github.com/spec/v1}
+  printf "version %s
 oid sha256:%s
 size %s
-" "$oid" "$size"
+" "$version" "$oid" "$size"
 }
 
 # wait_for_file simply sleeps until a file exists.


### PR DESCRIPTION
This pull-request fixes a regression where sending a non-unique OID to a transfer queue more than once would result in a `panic()` after having decremented the `sync.WaitGroup` past zero.

The fix comes in two parts:

0. https://github.com/github/git-lfs/commit/047fe19830fd497dd9882ed38a3030ec81938491: Only allow calling `lfs.TransferQueue.Add()` once per OID.
0. https://github.com/github/git-lfs/commit/d770dfa09eb289ff4d4167d91ce4a9030f9886ed: De-dup incoming pointers such that the progress meter displays the right number of bytes and files.

Regarding https://github.com/github/git-lfs/commit/d770dfa09eb289ff4d4167d91ce4a9030f9886ed, I am not hugely excited about adding another conditional against a potentially large set of data, but given the expected lifetime of this code, and the relative speed of the implementation (`tools.StringSet`), I am OK with releasing this.

As an additional note, this is a similar piece of functionality as compared what we do when calling `git lfs fetch` in `lfs.readyAndMissingPointers`. This function accepts:

- a list of all pointers
- an include filter
- an exclude filter

and returns (in order):

- the pointers we already have
- the pointers we need
- the total number of bytes we're expecting to transfer.

To make this calculation, it uses a similar mechanism [here](https://github.com/github/git-lfs/blob/b7b1f2b7985c8f7a18c563c70898f669ffb8c13c/commands/command_fetch.go#L317-L322) to de-dup pointers that we have seen already.

--

/cc @technoweenie @rubyist @sinbad @sschuberth 