### PR TITLE
transfer: more descriptive "expired at" errors

### DIFF
--- a/api/object.go
+++ b/api/object.go
@@ -59,19 +59,20 @@ func (o *ObjectResource) Rel(name string) (*LinkRelation, bool) {
 	return rel, ok
 }
 
-// IsExpired returns true if any of the actions in this object resource have an
-// ExpiresAt field that is after the given instant "now".
+// IsExpired returns true, and the time of the expired action, if any of the
+// actions in this object resource have an ExpiresAt field that is after the
+// given instant "now".
 //
 // If the object contains no actions, or none of the actions it does contain
 // have non-zero ExpiresAt fields, the object is not expired.
-func (o *ObjectResource) IsExpired(now time.Time) bool {
+func (o *ObjectResource) IsExpired(now time.Time) (time.Time, bool) {
 	for _, a := range o.Actions {
 		if !a.ExpiresAt.IsZero() && a.ExpiresAt.Before(now) {
-			return true
+			return a.ExpiresAt, true
 		}
 	}
 
-	return false
+	return time.Time{}, false
 }
 
 func (o *ObjectResource) NeedsAuth() bool {

--- a/api/object_test.go
+++ b/api/object_test.go
@@ -14,7 +14,8 @@ func TestObjectsWithNoActionsAreNotExpired(t *testing.T) {
 		Actions: map[string]*api.LinkRelation{},
 	}
 
-	assert.False(t, o.IsExpired(time.Now()))
+	_, expired := o.IsExpired(time.Now())
+	assert.False(t, expired)
 }
 
 func TestObjectsWithZeroValueTimesAreNotExpired(t *testing.T) {
@@ -28,7 +29,8 @@ func TestObjectsWithZeroValueTimesAreNotExpired(t *testing.T) {
 		},
 	}
 
-	assert.False(t, o.IsExpired(time.Now()))
+	_, expired := o.IsExpired(time.Now())
+	assert.False(t, expired)
 }
 
 func TestObjectsWithExpirationDatesAreExpired(t *testing.T) {
@@ -45,5 +47,7 @@ func TestObjectsWithExpirationDatesAreExpired(t *testing.T) {
 		},
 	}
 
-	assert.True(t, o.IsExpired(now))
+	expiredAt, expired := o.IsExpired(now)
+	assert.Equal(t, expires, expiredAt)
+	assert.True(t, expired)
 }

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -49,7 +49,7 @@ var (
 		"status-batch-403", "status-batch-404", "status-batch-410", "status-batch-422", "status-batch-500",
 		"status-storage-403", "status-storage-404", "status-storage-410", "status-storage-422", "status-storage-500", "status-storage-503",
 		"status-legacy-404", "status-legacy-410", "status-legacy-422", "status-legacy-403", "status-legacy-500",
-		"status-batch-resume-206", "batch-resume-fail-fallback", "return-expired-action", "return-invalid-size",
+		"status-batch-resume-206", "batch-resume-fail-fallback", "return-expired-action", "return-expired-action-forever", "return-invalid-size",
 		"object-authenticated", "legacy-download-check-retry", "legacy-upload-check-retry", "storage-download-retry", "storage-upload-retry",
 	}
 )
@@ -438,7 +438,7 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, id, repo string) {
 					Header: map[string]string{},
 				}
 
-				if handler == "return-expired-action" && canServeExpired(repo) {
+				if handler == "return-expired-action-forever" || (handler == "return-expired-action" && canServeExpired(repo)) {
 					a.ExpiresAt = time.Now().Add(-5 * time.Minute)
 					serveExpired(repo)
 				}

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -512,44 +512,6 @@ begin_test "push (retry with expired actions)"
 )
 end_test
 
-begin_test "push with continually expired actions"
-(
-  set -e
-
-  reponame="push_no_retry_expired_action"
-  setup_remote_repo "$reponame"
-  clone_repo "$reponame" "$reponame"
-
-  git lfs track "*.dat"
-
-  contents="return-expired-action-forever"
-  contents_oid="$(calc_oid $contents)"
-  printf "$contents" > a.dat
-  git add .gitattributes a.dat
-
-  git commit -m "add a.dat, .gitattributes" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
-  grep "2 files changed" commit.log
-  grep "create mode 100644 a.dat" commit.log
-  grep "create mode 100644 .gitattributes" commit.log
-
-  set +e
-  git push origin master 2>&1 | tee push.log
-  res=${PIPESTATUS[0]}
-  set -e
-
-  if [ "$res" = "0" ]; then
-    echo "push was successful, shouldn't have been"
-    exit 1
-  fi
-
-  grep    "object \"$contents_oid\" has expired" push.log
-  grep -e "4m.* ago" push.log
-
-  refute_server_object "$reponame" "$contents_oid"
-)
-end_test
-
 begin_test "push to raw remote url"
 (
   set -e

--- a/transfer/adapterbase.go
+++ b/transfer/adapterbase.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	// objectExpirationGracePeriod is the grace period applied to objects
-	// when checking whether or not they have expired.
-	objectExpirationGracePeriod = 5 * time.Second
+	// objectExpirationToTransfer is the duration we expect to have passed
+	// from the time that the object's expires_at property is checked to
+	// when the transfer is executed.
+	objectExpirationToTransfer = 5 * time.Second
 )
 
 // adapterBase implements the common functionality for core adapters which

--- a/transfer/adapterbase.go
+++ b/transfer/adapterbase.go
@@ -138,8 +138,8 @@ func (a *adapterBase) worker(workerNum int, ctx interface{}) {
 		if expAt, expired := t.Object.IsExpired(transferTime); expired {
 			tracerx.Printf("xfer: adapter %q worker %d found job for %q expired, retrying...", a.Name(), workerNum, t.Object.Oid)
 			err = errors.NewRetriableError(errors.Errorf(
-				"lfs/transfer: object %q has expired at %s, %s ago",
-				t.Object.Oid, expAt, tt.Sub(expAt),
+				"lfs/transfer: object %q expires at %s",
+				t.Object.Oid, expAt.In(time.Local).Format(time.RFC822),
 			))
 		} else if t.Object.Size < 0 {
 			tracerx.Printf("xfer: adapter %q worker %d found invalid size for %q (got: %d), retrying...", a.Name(), workerNum, t.Object.Oid, t.Object.Size)

--- a/transfer/adapterbase.go
+++ b/transfer/adapterbase.go
@@ -125,13 +125,17 @@ func (a *adapterBase) worker(workerNum int, ctx interface{}) {
 		}
 		tracerx.Printf("xfer: adapter %q worker %d processing job for %q", a.Name(), workerNum, t.Object.Oid)
 
-		// tt is the time that we are to compare the transfer's
+		// transferTime is the time that we are to compare the transfer's
 		// `expired_at` property against.
-		tt := time.Now().Add(-objectExpirationGracePeriod)
+		//
+		// We add the `objectExpirationToTransfer` since there will be
+		// some time lost from this comparison to the time we actually
+		// transfer the object
+		transferTime := time.Now().Add(objectExpirationToTransfer)
 
 		// Actual transfer happens here
 		var err error
-		if expAt, expired := t.Object.IsExpired(tt); expired {
+		if expAt, expired := t.Object.IsExpired(transferTime); expired {
 			tracerx.Printf("xfer: adapter %q worker %d found job for %q expired, retrying...", a.Name(), workerNum, t.Object.Oid)
 			err = errors.NewRetriableError(errors.Errorf(
 				"lfs/transfer: object %q has expired at %s, %s ago",


### PR DESCRIPTION
This pull request enhances of the descriptiveness of the error message returned when an object has expired.

To accomplish this, we needed to teach the `api.Object` how to return which action it was expired for, so we have a basis to compare the duration against the time that the transfer was attempted.

One open ❓ I'm thinking about is whether or not we should change the behavior for the `*api.Object.IsExpired` method to also take a direction so that it can compare against a specific action, and not all of them (as it currently does). This may not actually matter so much, since spec-compliant implementations of the LFS API will only send back the action that we're interested in.

The new error message is down below:

```
Git LFS: (0 of 1 files) 0 B / 29 B
    LFS: lfs/transfer: object "54899ec3690514f121a8f55729e9f802cde71091c3245966175a0bab6134573d" has expired at 2016-10-21 14:24:33.728774785 -0600 MDT, -4m55.024738112s ago
    error: failed to push some refs to 'http://127.0.0.1:57180/push_no_retry_expired_action'
```

--

cc @technoweenie @rubyist @sinbad @sschuberth 