### PR TITLE
Allow usage of proxies even when contacting localhost

### DIFF
--- a/httputil/proxy.go
+++ b/httputil/proxy.go
@@ -97,19 +97,6 @@ func useProxy(no_proxy, addr string) bool {
 		return false
 	}
 
-	host, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		return false
-	}
-	if host == "localhost" {
-		return false
-	}
-	if ip := net.ParseIP(host); ip != nil {
-		if ip.IsLoopback() {
-			return false
-		}
-	}
-
 	addr = strings.ToLower(strings.TrimSpace(addr))
 	if hasPort(addr) {
 		addr = addr[:strings.LastIndex(addr, ":")]


### PR DESCRIPTION
Sometimes it makes sense to use a proxy even when the remote host is localhost
or 127.0.0.1. git-lfs in contrast to e.g. native git does not allow to use a
proxy when talking to localhost. Remove this special treatment of localhost
and react only on http_proxy or no_proxy env variables.

My use case: I wanted to debug/analyze network traffic from a git client to the
git server and the lfs server running on my developer machine. I set up
mitmproxy [1] as a proxy server running on localhost and I set http_proxy to
point to mitmproxy. I was able to see all the traffic between the client and
the local git server in mitmproxy but the the communication between the client
and the lfs server was hidden because git-lfs ignored the proxy settings
because the hostname was localhost.