### PR TITLE
filter_stream: Integration tests

### DIFF
--- a/test/test-filter-process.sh
+++ b/test/test-filter-process.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+if [ "$GIT_LFS_USE_LEGACY_FILTER" == "1" ]; then
+  echo "skip: $0 (filter process disabled)"
+  exit
+fi
+
+# HACK(taylor): git uses ".g<hash>" in the version name to signal that it is
+# from the "next" branch, which is the only (current) version of Git that has
+# support for the filter protocol.
+#
+# Once 2.11 is released, replace this with:
+#
+# ```
+# ensure_git_version_isnt $VERSION_LOWER "2.11.0"
+# ```
+if [ "1" -ne "$(git version | cut -d ' ' -f 3 | grep -c "g")" ]; then
+  echo "skip: $0 git version does not include support for filter protocol"
+  exit
+fi
+
+begin_test "filter process: checking out a branch"
+(
+  set -e
+
+  reponame="filter_process_checkout"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" repo
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  contents_a="contents_a"
+  contents_a_oid="$(calc_oid $contents_a)"
+  printf "$contents_a" > a.dat
+
+  git add a.dat
+  git commit -m "add a.dat"
+
+  git checkout -b b
+
+  contents_b="contents_b"
+  contents_b_oid="$(calc_oid $contents_b)"
+  printf "$contents_b" > b.dat
+
+  git add b.dat
+  git commit -m "add b.dat"
+
+  git push origin --all
+
+  pushd ..
+    git \
+      -c "filter.lfs.process=git-lfs filter" \
+      -c "filter.lfs.clean="\
+      -c "filter.lfs.smudge=" \
+      -c "filter.lfs.required=true" \
+      clone "$GITSERVER/$reponame" "$reponame-assert"
+
+    cd "$reponame-assert"
+
+    # Assert that we are on the "master" branch, and have a.dat
+    [ "master" = "$(git rev-parse --abbrev-ref HEAD)" ]
+    [ "$contents_a" = "$(cat a.dat)" ]
+    assert_pointer "master" "a.dat" "$contents_a_oid" 10
+
+    git checkout b
+
+    # Assert that we are on the "b" branch, and have b.dat
+    [ "b" = "$(git rev-parse --abbrev-ref HEAD)" ]
+    [ "$contents_b" = "$(cat b.dat)" ]
+    assert_pointer "b" "b.dat" "$contents_b_oid" 10
+  popd
+)
+end_test

--- a/test/test-filter-process.sh
+++ b/test/test-filter-process.sh
@@ -75,3 +75,32 @@ begin_test "filter process: checking out a branch"
   popd
 )
 end_test
+
+begin_test "filter process: adding a file"
+(
+  set -e
+
+  reponame="filter_process_add"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git config --local "filter.lfs.process" "git-lfs filter"
+  git config --local --unset "filter.lfs.clean"
+  git config --local --unset "filter.lfs.smudge"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  contents="contents"
+  contents_oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
+
+  git add a.dat
+
+  expected="$(pointer "$contents_oid" "${#contents}")"
+  got="$(git cat-file -p :a.dat)"
+
+  diff -u <(echo "$expected") <(echo "$got")
+)
+end_test

--- a/test/test-filter-process.sh
+++ b/test/test-filter-process.sh
@@ -84,10 +84,6 @@ begin_test "filter process: adding a file"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
-  git config --local "filter.lfs.process" "git-lfs filter"
-  git config --local --unset "filter.lfs.clean"
-  git config --local --unset "filter.lfs.smudge"
-
   git lfs track "*.dat"
   git add .gitattributes
   git commit -m "initial commit"


### PR DESCRIPTION
This pull request adds an integration test making sure the filter protocol works as expected, when it is enabled.

The test I added creates two files tracked with LFS on two separate branches, and asserts that on each branch, each one of the files:

- exists
- has the correct "smudged" contents
- has a valid LFS pointer underneath.

Currently, running the test is gated on the `$GIT_LFS_USE_LEGACY_FILTER` being enabled (`eq "1"`), and the installed version of Git including support for the filter process. Usually, this is done with:

```bash
ensure_git_version_isnt "$VERSION_LOWER" "2.11.0"
```

but since `2.11.0` isn't released yet, the best we can do is check that the version is a pre-release and contains a "g" in the patch number, like: `git version 2.10.1.710.g6539e97`. This is done by using the hack below, which should be removed once version 2.11.0 is released.

```bash
if [ "1" -ne "$(git version | cut -d ' ' -f 3 | grep -c "g")" ]; then
  echo "skip: $0 git version does not include support for filter protocol"
  exit
fi
```

One open question is how we should treat other existing integration tests once using the filter protocol is the blessed way to clean/smudge. I'm thinking we should ensure that our build matrix covers versions before/after 2.11, and then run the best clean/smudge mechanism we can on each. That way, all the tests will use filter protocol on the versions of Git that support it, and we'll still test the old behavior on machines that don't.

---

/cc @larsxschneider @technoweenie @rubyist @sinbad @sschuberth 