### PR TITLE
filter_stream: Protocol unit tests

### DIFF
--- a/git/filter_protocol.go
+++ b/git/filter_protocol.go
@@ -1,0 +1,114 @@
+package git
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+type protocol struct {
+	r *bufio.Reader
+	w *bufio.Writer
+}
+
+func newProtocolRW(r io.Reader, w io.Writer) *protocol {
+	return &protocol{
+		r: bufio.NewReader(r),
+		w: bufio.NewWriter(w),
+	}
+}
+
+func (p *protocol) readPacket() ([]byte, error) {
+	pktLenHex, err := ioutil.ReadAll(io.LimitReader(p.r, 4))
+	if err != nil || len(pktLenHex) != 4 { // TODO check pktLenHex length
+		return nil, err
+	}
+
+	pktLen, err := strconv.ParseInt(string(pktLenHex), 16, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	if pktLen == 0 {
+		return nil, nil
+	}
+	if pktLen <= 4 {
+		return nil, errors.New("Invalid packet length.")
+	}
+
+	return ioutil.ReadAll(io.LimitReader(p.r, pktLen-4))
+}
+
+func (p *protocol) readPacketText() (string, error) {
+	data, err := p.readPacket()
+	return strings.TrimSuffix(string(data), "\n"), err
+}
+
+func (p *protocol) readPacketList() ([]string, error) {
+	var list []string
+	for {
+		data, err := p.readPacketText()
+		if err != nil {
+			return nil, err
+		}
+
+		if len(data) == 0 {
+			break
+		}
+
+		list = append(list, data)
+	}
+
+	return list, nil
+}
+
+func (p *protocol) writePacket(data []byte) error {
+	if len(data) > MaxPacketLength {
+		return errors.New("Packet length exceeds maximal length")
+	}
+
+	if _, err := p.w.WriteString(fmt.Sprintf("%04x", len(data)+4)); err != nil {
+		return err
+	}
+
+	if _, err := p.w.Write(data); err != nil {
+		return err
+	}
+
+	if err := p.w.Flush(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *protocol) writeFlush() error {
+	if _, err := p.w.WriteString(fmt.Sprintf("%04x", 0)); err != nil {
+		return err
+	}
+
+	if err := p.w.Flush(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *protocol) writePacketText(data string) error {
+	//TODO: there is probably a more efficient way to do this. worth it?
+	return p.writePacket([]byte(data + "\n"))
+}
+
+func (p *protocol) writePacketList(list []string) error {
+	for _, i := range list {
+		if err := p.writePacketText(i); err != nil {
+			return err
+		}
+	}
+
+	return p.writeFlush()
+}

--- a/git/filter_protocol_test.go
+++ b/git/filter_protocol_test.go
@@ -1,0 +1,211 @@
+package git
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type PacketReadTestCase struct {
+	In []byte
+
+	Payload []byte
+	Err     string
+}
+
+func (c *PacketReadTestCase) Assert(t *testing.T) {
+	buf := bytes.NewReader(c.In)
+	rw := newProtocolRW(buf, nil)
+
+	pkt, err := rw.readPacket()
+
+	if len(c.Payload) > 0 {
+		assert.Equal(t, c.Payload, pkt)
+	} else {
+		assert.Empty(t, pkt)
+	}
+
+	if len(c.Err) > 0 {
+		require.NotNil(t, err)
+		assert.Equal(t, c.Err, err.Error())
+	} else {
+		assert.Nil(t, err)
+	}
+}
+
+func TestFilterProtocolReadsWholePackets(t *testing.T) {
+	tc := &PacketReadTestCase{
+		In: []byte{
+			0x30, 0x30, 0x30, 0x38, // 0008 (hex. length)
+			0x1, 0x2, 0x3, 0x4, // payload
+		},
+		Payload: []byte{0x1, 0x2, 0x3, 0x4},
+	}
+
+	tc.Assert(t)
+}
+
+func TestFilterProtocolDiscardsPacketsWithIncorrectLength(t *testing.T) {
+	tc := &PacketReadTestCase{
+		In: []byte{
+			0x30, 0x30, 0x30, 0x34, // 0004 (hex. length)
+			// No body
+		},
+		Err: "Invalid packet length.",
+	}
+
+	tc.Assert(t)
+}
+
+func TestFilterProtocolDiscardsPacketsWithUnparseableLength(t *testing.T) {
+	tc := &PacketReadTestCase{
+		In: []byte{
+			0xff, 0xff, 0xff, 0xff, // ÿÿÿÿ (invalid hex. length)
+			// No body
+		},
+		Err: "strconv.ParseInt: parsing \"\\xff\\xff\\xff\\xff\": invalid syntax",
+	}
+
+	tc.Assert(t)
+}
+
+func TestFilterProtocolDiscardsPacketsWithLengthZero(t *testing.T) {
+	tc := &PacketReadTestCase{
+		In: []byte{
+			0x30, 0x30, 0x30, 0x30, // 0000 (hex. length)
+			// Empty body
+		},
+	}
+
+	tc.Assert(t)
+}
+
+func TestFilterProtocolReadsTextWithNewline(t *testing.T) {
+	rw := newProtocolRW(bytes.NewReader([]byte{
+		0x30, 0x30, 0x30, 0x39, // 0009 (hex. length)
+		0x61, 0x62, 0x63, 0x64, 0xa,
+		// Empty body
+	}), nil)
+
+	str, err := rw.readPacketText()
+
+	assert.Nil(t, err)
+	assert.Equal(t, "abcd", str)
+}
+
+func TestFilterProtocolReadsTextWithoutNewline(t *testing.T) {
+	rw := newProtocolRW(bytes.NewReader([]byte{
+		0x30, 0x30, 0x30, 0x38, // 0009 (hex. length)
+		0x61, 0x62, 0x63, 0x64,
+	}), nil)
+
+	str, err := rw.readPacketText()
+
+	assert.Nil(t, err)
+	assert.Equal(t, "abcd", str)
+}
+
+func TestFilterProtocolReadsTextWithErr(t *testing.T) {
+	rw := newProtocolRW(bytes.NewReader([]byte{
+		0x30, 0x30, 0x30, 0x34, // 0004 (hex. length)
+		// No body
+	}), nil)
+
+	str, err := rw.readPacketText()
+
+	require.NotNil(t, err)
+	assert.Equal(t, "Invalid packet length.", err.Error())
+	assert.Equal(t, "", str)
+}
+
+func TestFilterProtocolAppendsPacketLists(t *testing.T) {
+	rw := newProtocolRW(bytes.NewReader([]byte{
+		0x30, 0x30, 0x30, 0x38, // 0009 (hex. length)
+		0x61, 0x62, 0x63, 0x64, // "abcd"
+
+		0x30, 0x30, 0x30, 0x38, // 0008 (hex. length)
+		0x65, 0x66, 0x67, 0x68, // "efgh"
+
+		0x30, 0x30, 0x30, 0x30, // 0000 (hex. length)
+	}), nil)
+
+	str, err := rw.readPacketList()
+
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"abcd", "efgh"}, str)
+}
+
+func TestFilterProtocolAppendsPacketListsAndReturnsErrs(t *testing.T) {
+	rw := newProtocolRW(bytes.NewReader([]byte{
+		0x30, 0x30, 0x30, 0x38, // 0009 (hex. length)
+		0x61, 0x62, 0x63, 0x64, // "abcd"
+
+		0x30, 0x30, 0x30, 0x34, // 0004 (hex. length)
+		// No body
+	}), nil)
+
+	str, err := rw.readPacketList()
+
+	require.NotNil(t, err)
+	assert.Equal(t, "Invalid packet length.", err.Error())
+	assert.Empty(t, str)
+}
+
+func TestFilterProtocolWritesPackets(t *testing.T) {
+	var buf bytes.Buffer
+
+	rw := newProtocolRW(nil, &buf)
+	err := rw.writePacket([]byte{
+		0x1, 0x2, 0x3, 0x4,
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{
+		0x30, 0x30, 0x30, 0x38, // 0008 (hex. length)
+		0x1, 0x2, 0x3, 0x4, // payload
+	}, buf.Bytes())
+}
+
+func TestFilterProtocolDoesNotWritePacketsExceedingMaxLength(t *testing.T) {
+	var buf bytes.Buffer
+
+	rw := newProtocolRW(nil, &buf)
+	err := rw.writePacket(make([]byte, MaxPacketLength+1))
+
+	require.NotNil(t, err)
+	assert.Equal(t, "Packet length exceeds maximal length", err.Error())
+	assert.Empty(t, buf.Bytes())
+}
+
+func TestFilterProtocolWritesPacketText(t *testing.T) {
+	var buf bytes.Buffer
+
+	rw := newProtocolRW(nil, &buf)
+	err := rw.writePacketText("abcd")
+
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{
+		0x30, 0x30, 0x30, 0x39, // 0009 (hex. length)
+		0x61, 0x62, 0x63, 0x64, 0xa, // "abcd\n" (payload)
+	}, buf.Bytes())
+}
+
+func TestFilterProtocolWritesPacketLists(t *testing.T) {
+	var buf bytes.Buffer
+
+	rw := newProtocolRW(nil, &buf)
+	err := rw.writePacketList([]string{"foo", "bar"})
+
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{
+		0x30, 0x30, 0x30, 0x38, // 0008 (hex. length)
+		0x66, 0x6f, 0x6f, 0xa, // "foo\n" (payload)
+
+		0x30, 0x30, 0x30, 0x38, // 0008 (hex. length)
+		0x62, 0x61, 0x72, 0xa, // "bar\n" (payload)
+
+		0x30, 0x30, 0x30, 0x30, // 0000 (hex. length)
+	}, buf.Bytes())
+}

--- a/git/filter_protocol_test.go
+++ b/git/filter_protocol_test.go
@@ -168,6 +168,16 @@ func TestFilterProtocolWritesPackets(t *testing.T) {
 	}, buf.Bytes())
 }
 
+func TestFilterProtocolWritesPacketsEqualToMaxLength(t *testing.T) {
+	var buf bytes.Buffer
+
+	rw := newProtocolRW(nil, &buf)
+	err := rw.writePacket(make([]byte, MaxPacketLength))
+
+	assert.Nil(t, err)
+	assert.Equal(t, 4+MaxPacketLength, len(buf.Bytes()))
+}
+
 func TestFilterProtocolDoesNotWritePacketsExceedingMaxLength(t *testing.T) {
 	var buf bytes.Buffer
 

--- a/git/git_filter_protocol.go
+++ b/git/git_filter_protocol.go
@@ -3,20 +3,16 @@
 package git
 
 import (
-	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
-	"strconv"
 	"strings"
 
-	"github.com/github/git-lfs/errors"
 	"github.com/rubyist/tracerx"
 )
 
 const (
-	MaxPacketLenght = 65516
+	MaxPacketLength = 65516
 )
 
 // Private function copied from "github.com/xeipuuv/gojsonschema/utils.go"
@@ -31,109 +27,20 @@ func isStringInSlice(s []string, what string) bool {
 }
 
 type ObjectScanner struct {
-	r *bufio.Reader
-	w *bufio.Writer
+	p *protocol
 }
 
 func NewObjectScanner(r io.Reader, w io.Writer) *ObjectScanner {
 	return &ObjectScanner{
-		r: bufio.NewReader(r),
-		w: bufio.NewWriter(w),
+		p: newProtocolRW(r, w),
 	}
-}
-
-func (o *ObjectScanner) readPacket() ([]byte, error) {
-	pktLenHex, err := ioutil.ReadAll(io.LimitReader(o.r, 4))
-	if err != nil || len(pktLenHex) != 4 { // TODO check pktLenHex length
-		return nil, err
-	}
-	pktLen, err := strconv.ParseInt(string(pktLenHex), 16, 0)
-	if err != nil {
-		return nil, err
-	}
-	if pktLen == 0 {
-		return nil, nil
-	} else if pktLen <= 4 {
-		return nil, errors.New("Invalid packet length.")
-	}
-	return ioutil.ReadAll(io.LimitReader(o.r, pktLen-4))
-}
-
-func (o *ObjectScanner) readPacketText() (string, error) {
-	data, err := o.readPacket()
-	return strings.TrimSuffix(string(data), "\n"), err
-}
-
-func (o *ObjectScanner) readPacketList() ([]string, error) {
-	var list []string
-	for {
-		data, err := o.readPacketText()
-		if err != nil {
-			return nil, err
-		}
-		if len(data) == 0 {
-			break
-		}
-		list = append(list, data)
-	}
-	return list, nil
-}
-
-func (o *ObjectScanner) writePacket(data []byte) error {
-	if len(data) > MaxPacketLenght {
-		return errors.New("Packet length exceeds maximal length")
-	}
-	_, err := o.w.WriteString(fmt.Sprintf("%04x", len(data)+4))
-	if err != nil {
-		return err
-	}
-	_, err = o.w.Write(data)
-	if err != nil {
-		return err
-	}
-	err = o.w.Flush()
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (o *ObjectScanner) writeFlush() error {
-	_, err := o.w.WriteString(fmt.Sprintf("%04x", 0))
-	if err != nil {
-		return err
-	}
-	err = o.w.Flush()
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (o *ObjectScanner) writePacketText(data string) error {
-	//TODO: there is probably a more efficient way to do this. worth it?
-	return o.writePacket([]byte(data + "\n"))
-}
-
-func (o *ObjectScanner) writePacketList(list []string) error {
-	for _, i := range list {
-		err := o.writePacketText(i)
-		if err != nil {
-			return err
-		}
-	}
-	return o.writeFlush()
-}
-
-func (o *ObjectScanner) writeStatus(status string) error {
-	return o.writePacketList([]string{"status=" + status})
 }
 
 func (o *ObjectScanner) Init() bool {
 	tracerx.Printf("Initialize filter")
 	reqVer := "version=2"
 
-	initMsg, err := o.readPacketText()
+	initMsg, err := o.p.readPacketText()
 	if err != nil {
 		fmt.Fprintf(os.Stderr,
 			"Error: reading filter initialization failed with %s\n", err)
@@ -145,7 +52,7 @@ func (o *ObjectScanner) Init() bool {
 		return false
 	}
 
-	supVers, err := o.readPacketList()
+	supVers, err := o.p.readPacketList()
 	if err != nil {
 		fmt.Fprintf(os.Stderr,
 			"Error: reading filter versions failed with %s\n", err)
@@ -158,7 +65,7 @@ func (o *ObjectScanner) Init() bool {
 		return false
 	}
 
-	err = o.writePacketList([]string{"git-filter-server", reqVer})
+	err = o.p.writePacketList([]string{"git-filter-server", reqVer})
 	if err != nil {
 		fmt.Fprintf(os.Stderr,
 			"Error: writing filter initialization failed with %s\n", err)
@@ -170,7 +77,7 @@ func (o *ObjectScanner) Init() bool {
 func (o *ObjectScanner) NegotiateCapabilities() bool {
 	reqCaps := []string{"capability=clean", "capability=smudge"}
 
-	supCaps, err := o.readPacketList()
+	supCaps, err := o.p.readPacketList()
 	if err != nil {
 		fmt.Fprintf(os.Stderr,
 			"Error: reading filter capabilities failed with %s\n", err)
@@ -185,7 +92,7 @@ func (o *ObjectScanner) NegotiateCapabilities() bool {
 		}
 	}
 
-	err = o.writePacketList(reqCaps)
+	err = o.p.writePacketList(reqCaps)
 	if err != nil {
 		fmt.Fprintf(os.Stderr,
 			"Error: writing filter capabilities failed with %s\n", err)
@@ -198,7 +105,7 @@ func (o *ObjectScanner) NegotiateCapabilities() bool {
 func (o *ObjectScanner) ReadRequest() (map[string]string, []byte, error) {
 	tracerx.Printf("Process filter command.")
 
-	requestList, err := o.readPacketList()
+	requestList, err := o.p.readPacketList()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -211,7 +118,7 @@ func (o *ObjectScanner) ReadRequest() (map[string]string, []byte, error) {
 
 	var data []byte
 	for {
-		chunk, err := o.readPacket()
+		chunk, err := o.p.readPacket()
 		if err != nil {
 			// TODO: should we check the err of this call, to?!
 			o.writeStatus("error")
@@ -230,12 +137,12 @@ func (o *ObjectScanner) WriteResponse(outputData []byte) error {
 	for {
 		chunkSize := len(outputData)
 		if chunkSize == 0 {
-			o.writeFlush()
+			o.p.writeFlush()
 			break
-		} else if chunkSize > MaxPacketLenght {
-			chunkSize = MaxPacketLenght // TODO check packets with the exact size
+		} else if chunkSize > MaxPacketLength {
+			chunkSize = MaxPacketLength // TODO check packets with the exact size
 		}
-		err := o.writePacket(outputData[:chunkSize])
+		err := o.p.writePacket(outputData[:chunkSize])
 		if err != nil {
 			// TODO: should we check the err of this call, to?!
 			o.writeStatus("error")
@@ -245,4 +152,8 @@ func (o *ObjectScanner) WriteResponse(outputData []byte) error {
 	}
 	o.writeStatus("success")
 	return nil
+}
+
+func (o *ObjectScanner) writeStatus(status string) error {
+	return o.p.writePacketList([]string{"status=" + status})
 }

--- a/git/object_scanner_test.go
+++ b/git/object_scanner_test.go
@@ -1,0 +1,230 @@
+package git
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObjectScannerInitializesWithCorrectSupportedValues(t *testing.T) {
+	var from, to bytes.Buffer
+
+	proto := newProtocolRW(nil, &from)
+	require.Nil(t, proto.writePacketText("git-filter-client"))
+	require.Nil(t, proto.writePacketList([]string{"version=2"}))
+
+	os := NewObjectScanner(&from, &to)
+	ok := os.Init()
+
+	assert.True(t, ok)
+
+	out, err := newProtocolRW(&to, nil).readPacketList()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"git-filter-server", "version=2"}, out)
+}
+
+func TestObjectScannerRejectsUnrecognizedInitializationMessages(t *testing.T) {
+	var from, to bytes.Buffer
+
+	proto := newProtocolRW(nil, &from)
+	require.Nil(t, proto.writePacketText("git-filter-client-unknown"))
+
+	os := NewObjectScanner(&from, &to)
+	ok := os.Init()
+
+	assert.False(t, ok)
+	assert.Empty(t, to.Bytes())
+}
+
+func TestObjectScannerRejectsUnsupportedFilters(t *testing.T) {
+	var from, to bytes.Buffer
+
+	proto := newProtocolRW(nil, &from)
+	require.Nil(t, proto.writePacketText("git-filter-client"))
+	// Write an unsupported version
+	require.Nil(t, proto.writePacketList([]string{"version=0"}))
+
+	os := NewObjectScanner(&from, &to)
+	ok := os.Init()
+
+	assert.False(t, ok)
+	assert.Empty(t, to.Bytes())
+}
+
+func TestObjectScannerNegotitatesSupportedCapabilities(t *testing.T) {
+	var from, to bytes.Buffer
+
+	proto := newProtocolRW(nil, &from)
+	require.Nil(t, proto.writePacketList([]string{
+		"capability=clean", "capability=smudge",
+	}))
+
+	os := NewObjectScanner(&from, &to)
+	ok := os.NegotiateCapabilities()
+
+	assert.True(t, ok)
+
+	out, err := newProtocolRW(&to, nil).readPacketList()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"capability=clean", "capability=smudge"}, out)
+}
+
+func TestObjectScannerDoesNotNegotitatesUnsupportedCapabilities(t *testing.T) {
+	var from, to bytes.Buffer
+
+	proto := newProtocolRW(nil, &from)
+	// Write an unsupported capability
+	require.Nil(t, proto.writePacketList([]string{
+		"capability=unsupported",
+	}))
+
+	os := NewObjectScanner(&from, &to)
+	ok := os.NegotiateCapabilities()
+
+	assert.False(t, ok)
+	assert.Empty(t, to.Bytes())
+}
+
+func TestObjectScannerReadsRequestHeadersAndPayload(t *testing.T) {
+	var from, to bytes.Buffer
+
+	proto := newProtocolRW(nil, &from)
+	// Headers
+	require.Nil(t, proto.writePacketList([]string{
+		"foo=bar", "other=woot",
+	}))
+	// Multi-line packet
+	require.Nil(t, proto.writePacketText("first"))
+	require.Nil(t, proto.writePacketText("second"))
+
+	headers, payload, err := NewObjectScanner(&from, &to).ReadRequest()
+
+	assert.Nil(t, err)
+	assert.Equal(t, headers["foo"], "bar")
+	assert.Equal(t, headers["other"], "woot")
+	assert.Equal(t, []byte("first\nsecond\n"), payload)
+
+	resp, err := newProtocolRW(&to, nil).readPacketList()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"status=success"}, resp)
+}
+
+func TestObjectScannerRejectsInvalidHeaderPackets(t *testing.T) {
+	var from bytes.Buffer
+
+	proto := newProtocolRW(nil, &from)
+	// (Invalid) headers
+	require.Nil(t, proto.writePacket([]byte{}))
+
+	headers, payload, err := NewObjectScanner(&from, nil).ReadRequest()
+
+	require.NotNil(t, err)
+	assert.Equal(t, "Invalid packet length.", err.Error())
+
+	assert.Nil(t, headers)
+	assert.Empty(t, payload)
+}
+
+func TestObjectScannerRejectsInvalidPayloadPackets(t *testing.T) {
+	var from, to bytes.Buffer
+
+	proto := newProtocolRW(nil, &from)
+	// Headers
+	require.Nil(t, proto.writePacketList([]string{
+		"foo=bar", "other=woot",
+	}))
+	// Multi-line (invalid) packet
+	require.Nil(t, proto.writePacketText("first"))
+	require.Nil(t, proto.writePacketText("second"))
+	require.Nil(t, proto.writePacket([]byte{})) // <-
+
+	headers, payload, err := NewObjectScanner(&from, &to).ReadRequest()
+
+	require.NotNil(t, err)
+	assert.Equal(t, "Invalid packet length.", err.Error())
+	assert.Nil(t, headers)
+	assert.Empty(t, payload)
+
+	resp, err := newProtocolRW(&to, nil).readPacketList()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"status=error"}, resp)
+}
+
+func TestObjectScannerWritesResponsesInOneChunk(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := NewObjectScanner(nil, &buf).WriteResponse([]byte(
+		"hello world",
+	))
+
+	assert.Nil(t, err)
+
+	proto := newProtocolRW(&buf, nil)
+
+	payload, err := proto.readPacket()
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("hello world"), payload)
+
+	// read terminating packet
+	_, err = proto.readPacket()
+	assert.Nil(t, err)
+
+	status, err := proto.readPacketList()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"status=success"}, status)
+}
+
+func TestObjectScannerWritesEmptyResponses(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := NewObjectScanner(nil, &buf).WriteResponse([]byte{})
+
+	assert.Nil(t, err)
+
+	proto := newProtocolRW(&buf, nil)
+
+	payload, err := proto.readPacket()
+	assert.Nil(t, err)
+	assert.Empty(t, payload)
+
+	status, err := proto.readPacketList()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"status=success"}, status)
+}
+
+func TestObjectScannerWritesResponsesInMultipleChunks(t *testing.T) {
+	payload := make([]byte, MaxPacketLength*2)
+	for i := 0; i < 2; i++ {
+		for j := 0; j < MaxPacketLength; j++ {
+			payload[(i*MaxPacketLength)+j] = byte(i)
+		}
+	}
+
+	var buf bytes.Buffer
+
+	err := NewObjectScanner(nil, &buf).WriteResponse(payload)
+	assert.Nil(t, err)
+
+	proto := newProtocolRW(&buf, nil)
+
+	for i := 0; i < 2; i++ {
+		pkt, err := proto.readPacket()
+		assert.Nil(t, err)
+
+		part := make([]byte, MaxPacketLength)
+		for j := 0; j < len(part); j++ {
+			part[j] = byte(i)
+		}
+
+		assert.Equal(t, part, pkt)
+	}
+
+	// read empty packet after flushing
+	_, err = proto.readPacket()
+
+	status, err := proto.readPacketList()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"status=success"}, status)
+}

--- a/git/object_scanner_test.go
+++ b/git/object_scanner_test.go
@@ -98,6 +98,8 @@ func TestObjectScannerReadsRequestHeadersAndPayload(t *testing.T) {
 	// Multi-line packet
 	require.Nil(t, proto.writePacketText("first"))
 	require.Nil(t, proto.writePacketText("second"))
+	_, err := from.Write([]byte{0x30, 0x30, 0x30, 0x30}) // flush packet
+	assert.Nil(t, err)
 
 	headers, payload, err := NewObjectScanner(&from, &to).ReadRequest()
 

--- a/git/packet_reader.go
+++ b/git/packet_reader.go
@@ -1,0 +1,63 @@
+package git
+
+import (
+	"io"
+
+	"github.com/github/git-lfs/tools"
+)
+
+type packetReader struct {
+	proto *protocol
+
+	buf []byte
+}
+
+var _ io.Reader = new(packetReader)
+
+func (r *packetReader) Read(p []byte) (int, error) {
+	var n int
+
+	if len(r.buf) > 0 {
+		// If there is data in the buffer, shift as much out of it and
+		// into the given "p" as we can.
+		n = tools.MinInt(len(p), len(r.buf))
+
+		copy(p, r.buf[:n])
+		r.buf = r.buf[n:]
+	}
+
+	// Loop and grab as many packets as we can in a given "run", until we
+	// have either, a) overfilled the given buffer "p", or we have started
+	// to internally buffer in "r.buf".
+	for len(r.buf) == 0 {
+		chunk, err := r.proto.readPacket()
+		if err != nil {
+			return n, err
+		}
+
+		if len(chunk) == 0 {
+			// If we got an empty chunk, then we know that we have
+			// reached the end of processing for this particular
+			// packet, so let's terminate.
+
+			return n, io.EOF
+		}
+
+		// Figure out how much of the packet we can read into "p".
+		nn := tools.MinInt(len(chunk), len(p))
+
+		// Move that amount into "p", from where we left off.
+		copy(p[n:], chunk[:nn])
+		// And move the rest into the buffer.
+		r.buf = append(r.buf, chunk[nn:]...)
+
+		// Mark that we have read "nn" bytes into "p"
+		n += nn
+
+		if n >= len(p) {
+			break
+		}
+	}
+
+	return n, nil
+}

--- a/git/packet_reader_test.go
+++ b/git/packet_reader_test.go
@@ -1,0 +1,142 @@
+package git
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// writePackets
+func writePacket(w io.Writer, datas ...[]byte) {
+	for _, data := range datas {
+		io.WriteString(w, fmt.Sprintf("%04x", len(data)+4))
+		w.Write(data)
+
+	}
+	io.WriteString(w, fmt.Sprintf("%04x", 0))
+}
+
+func TestPacketReaderReadsSinglePacketsInOneCall(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("asdf"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	data, err := ioutil.ReadAll(pr)
+
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("asdf"), data)
+}
+
+func TestPacketReaderReadsManyPacketsInOneCall(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("first\n"), []byte("second"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	data, err := ioutil.ReadAll(pr)
+
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("first\nsecond"), data)
+}
+
+func TestPacketReaderReadsSinglePacketsInMultipleCallsWithUnevenBuffering(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("asdf"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	var p1 [3]byte
+	var p2 [1]byte
+
+	n1, e1 := pr.Read(p1[:])
+	assert.Equal(t, 3, n1)
+	assert.Equal(t, []byte("asd"), p1[:])
+	assert.Nil(t, e1)
+
+	n2, e2 := pr.Read(p2[:])
+	assert.Equal(t, 1, n2)
+	assert.Equal(t, []byte("f"), p2[:])
+	assert.Equal(t, io.EOF, e2)
+}
+
+func TestPacketReaderReadsManyPacketsInMultipleCallsWithUnevenBuffering(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("first"), []byte("second"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	var p1 [4]byte
+	var p2 [7]byte
+	var p3 []byte
+
+	n1, e1 := pr.Read(p1[:])
+	assert.Equal(t, 4, n1)
+	assert.Equal(t, []byte("firs"), p1[:])
+	assert.Nil(t, e1)
+
+	n2, e2 := pr.Read(p2[:])
+	assert.Equal(t, 7, n2)
+	assert.Equal(t, []byte("tsecond"), p2[:])
+	assert.Equal(t, nil, e2)
+
+	n3, e3 := pr.Read(p3[:])
+	assert.Equal(t, 0, n3)
+	assert.Empty(t, p3)
+	assert.Equal(t, io.EOF, e3)
+}
+
+func TestPacketReaderReadsSinglePacketsInMultipleCallsWithEvenBuffering(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("firstother"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	var p1 [5]byte
+	var p2 [5]byte
+
+	n1, e1 := pr.Read(p1[:])
+	assert.Equal(t, 5, n1)
+	assert.Equal(t, []byte("first"), p1[:])
+	assert.Nil(t, e1)
+
+	n2, e2 := pr.Read(p2[:])
+	assert.Equal(t, 5, n2)
+	assert.Equal(t, []byte("other"), p2[:])
+	assert.Equal(t, io.EOF, e2)
+}
+
+func TestPacketReaderReadsManyPacketsInMultipleCallsWithEvenBuffering(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("first"), []byte("other"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	var p1 [5]byte
+	var p2 [5]byte
+	var p3 []byte
+
+	n1, e1 := pr.Read(p1[:])
+	assert.Equal(t, 5, n1)
+	assert.Equal(t, []byte("first"), p1[:])
+	assert.Nil(t, e1)
+
+	n2, e2 := pr.Read(p2[:])
+	assert.Equal(t, 5, n2)
+	assert.Equal(t, []byte("other"), p2[:])
+	assert.Equal(t, nil, e2)
+
+	n3, e3 := pr.Read(p3)
+	assert.Equal(t, 0, n3)
+	assert.Equal(t, io.EOF, e3)
+}

--- a/git/packet_writer.go
+++ b/git/packet_writer.go
@@ -1,0 +1,124 @@
+package git
+
+import (
+	"io"
+
+	"github.com/github/git-lfs/tools"
+)
+
+type PacketWriter struct {
+	// buf is an internal buffer used to store data until enough has been
+	// collected to write a full packet, or the buffer was instructed to
+	// flush.
+	buf []byte
+	// proto is the place where packets get written.
+	proto *protocol
+}
+
+var _ io.Writer = new(PacketWriter)
+
+// NewPacketWriter returns a new *PacketWriter, which will write to the
+// underlying data stream "w". The internal buffer is initialized with the given
+// capacity, "c".
+//
+// If "w" is already a `*PacketWriter`, it will be returned as-is.
+func NewPacketWriter(w io.Writer, c int) *PacketWriter {
+	if pw, ok := w.(*PacketWriter); ok {
+		return pw
+	}
+
+	return &PacketWriter{
+		buf:   make([]byte, 0, c),
+		proto: newProtocolRW(nil, w),
+	}
+}
+
+// Write implements the io.Writer interface's `Write` method by providing a
+// packet-based backend to the given buffer "p".
+//
+// As many bytes are removed from "p" as possible and stored in an internal
+// buffer until the amount of data in the internal buffer is enough to write a
+// single packet. Once the internal buffer is full, a packet is written to the
+// underlying stream of data, and the process repeats.
+//
+// When the caller has no more data to write in the given chunk of packets, a
+// subsequent call to `Write(p []byte)` MUST be made with a nil slice, to flush
+// the remaining data in the buffer, and write the terminating bytes to the
+// underlying packet stream.
+//
+// Write returns the number of bytes in "p" accepted into the writer, which
+// _MAY_ be written to the underlying protocol stream, or may be written into
+// the internal buffer.
+//
+// If any error was encountered while either buffering or writing, that
+// error is returned, along with the number of bytes written to the underlying
+// protocol stream, as described above.
+func (w *PacketWriter) Write(p []byte) (int, error) {
+	var n int
+
+	if p == nil {
+		// If we got an empty sequence of bytes, let's flush the data
+		// stored in the buffer, and then write the a packet termination
+		// sequence.
+
+		if _, err := w.flush(); err != nil {
+			return 0, err
+		}
+
+		if err := w.proto.writeFlush(); err != nil {
+			return 0, err
+		}
+	}
+
+	for len(p) > 0 {
+		// While there is still data left to process in "p", grab as
+		// much of it as we can while not allowing the internal buffer
+		// to exceed the MaxPacketLength const.
+		m := tools.MinInt(len(p), MaxPacketLength-len(w.buf))
+
+		// Append on all of the data that we could into the internal
+		// buffer.
+		w.buf = append(w.buf, p[:m]...)
+		// Truncate "p" such that it no longer includes the data that we
+		// have in the internal buffer.
+		p = p[m:]
+
+		n = n + m
+
+		if len(w.buf) == MaxPacketLength {
+			// If we were able to grab an entire packet's worth of
+			// data, flush the buffer.
+
+			if _, err := w.flush(); err != nil {
+				return n, err
+			}
+
+		}
+	}
+
+	return n, nil
+}
+
+// flush writes any data in the internal buffer out to the underlying protocol
+// stream. If the amount of data in the internal buffer exceeds the
+// MaxPacketLength, the data will be written in multiple packets to accommodate.
+//
+// flush returns the number of bytes written to the underlying packet stream,
+// and any error that it encountered along the way.
+func (w *PacketWriter) flush() (int, error) {
+	var n int
+
+	for len(w.buf) > 0 {
+		if err := w.proto.writePacket(w.buf); err != nil {
+			return 0, err
+		}
+
+		m := tools.MinInt(len(w.buf), MaxPacketLength)
+
+		w.buf = w.buf[m:]
+
+		n = n + m
+	}
+
+	return n, nil
+}

--- a/git/packet_writer_test.go
+++ b/git/packet_writer_test.go
@@ -1,0 +1,108 @@
+package git
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPacketWriterWritesPacketsShorterThanMaxPacketSize(t *testing.T) {
+	var buf bytes.Buffer
+
+	w := NewPacketWriter(&buf, 0)
+	assertWriterWrite(t, w, []byte("Hello, world!"), 13)
+	assertWriterWrite(t, w, nil, 0)
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, []byte("Hello, world!"))
+	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterWritesPacketsEqualToMaxPacketLength(t *testing.T) {
+	big := make([]byte, MaxPacketLength)
+	for i, _ := range big {
+		big[i] = 1
+	}
+
+	// Make a copy so that we can drain the data inside of it
+	p := make([]byte, MaxPacketLength)
+	copy(p, big)
+
+	var buf bytes.Buffer
+
+	w := NewPacketWriter(&buf, 0)
+	assertWriterWrite(t, w, p, len(big))
+	assertWriterWrite(t, w, nil, 0)
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, big)
+	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterWritesMultiplePacketsLessThanMaxPacketLength(t *testing.T) {
+	var buf bytes.Buffer
+
+	w := NewPacketWriter(&buf, 0)
+	assertWriterWrite(t, w, []byte("first\n"), len("first\n"))
+	assertWriterWrite(t, w, []byte("second"), len("second"))
+	assertWriterWrite(t, w, nil, 0)
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, []byte("first\nsecond"))
+	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterWritesMultiplePacketsGreaterThanMaxPacketLength(t *testing.T) {
+	var buf bytes.Buffer
+
+	b1 := make([]byte, MaxPacketLength*3/4)
+	p1 := make([]byte, len(b1))
+	for i, _ := range b1 {
+		b1[i] = 1
+	}
+	copy(p1, b1)
+
+	b2 := make([]byte, MaxPacketLength*3/4)
+	p2 := make([]byte, len(b2))
+	for i, _ := range b2 {
+		b2[i] = 1
+	}
+	copy(p2, b1)
+
+	w := NewPacketWriter(&buf, 0)
+	assertWriterWrite(t, w, p1, len(p1))
+	assertWriterWrite(t, w, p2, len(p2))
+	assertWriterWrite(t, w, nil, 0)
+
+	// offs is how far into b2 we needed to buffer before writing an entire
+	// packet
+	offs := MaxPacketLength - len(b1)
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, append(b1, b2[:offs]...))
+	assertPacketRead(t, proto, b2[offs:])
+	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterDoesntWrapItself(t *testing.T) {
+	itself := &PacketWriter{}
+	nw := NewPacketWriter(itself, 0)
+
+	assert.Equal(t, itself, nw)
+}
+
+func assertWriterWrite(t *testing.T, w io.Writer, p []byte, plen int) {
+	n, err := w.Write(p)
+
+	assert.Nil(t, err)
+	assert.Equal(t, plen, n)
+}
+
+func assertPacketRead(t *testing.T, proto *protocol, expected []byte) {
+	got, err := proto.readPacket()
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, got)
+}

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -113,7 +113,7 @@ func DecodeFrom(reader io.Reader) ([]byte, *Pointer, error) {
 	written, err := reader.Read(buf)
 	output := buf[0:written]
 
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return output, nil, err
 	}
 

--- a/lfs/pointer_clean.go
+++ b/lfs/pointer_clean.go
@@ -82,8 +82,14 @@ func copyToTemp(reader io.Reader, fileSize int64, cb progress.CopyCallback) (oid
 		return
 	}
 
-	multi := io.MultiReader(bytes.NewReader(by), reader)
-	size, err = tools.CopyWithCallback(writer, multi, fileSize, cb)
+	var from io.Reader = bytes.NewReader(by)
+	if int64(len(by)) < fileSize {
+		// If there is still more data to be read from the file, tack on
+		// the original reader and continue the read from there.
+		from = io.MultiReader(from, reader)
+	}
+
+	size, err = tools.CopyWithCallback(writer, from, fileSize, cb)
 
 	if err != nil {
 		return

--- a/lfs/pointer_test.go
+++ b/lfs/pointer_test.go
@@ -3,7 +3,6 @@ package lfs
 import (
 	"bufio"
 	"bytes"
-	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -170,17 +169,10 @@ size 12345`
 
 func TestDecodeFromEmptyReader(t *testing.T) {
 	by, p, err := DecodeFrom(strings.NewReader(""))
-	if err != io.EOF {
-		t.Fatalf("unexpected error: %v", err)
-	}
 
-	if p != nil {
-		t.Fatalf("Unexpected pointer: %v", p)
-	}
-
-	if string(by) != "" {
-		t.Fatalf("unexpected result: '%s'", string(by))
-	}
+	assert.EqualError(t, err, "Pointer file error: invalid header")
+	assert.Nil(t, p)
+	assert.Empty(t, string(by))
 }
 
 func TestDecodeInvalid(t *testing.T) {

--- a/tools/math.go
+++ b/tools/math.go
@@ -1,0 +1,17 @@
+package tools
+
+func MinInt(a, b int) int {
+	if a < b {
+		return a
+	}
+
+	return b
+}
+
+func MaxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+
+	return b
+}

--- a/tools/math_test.go
+++ b/tools/math_test.go
@@ -1,0 +1,15 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func MinIntPicksTheSmallerInt(t *testing.T) {
+	assert.Equal(t, -1, MinInt(-1, 1))
+}
+
+func MaxIntPicksTheBiggertInt(t *testing.T) {
+	assert.Equal(t, 1, MaxInt(-1, 1))
+}


### PR DESCRIPTION
This pull-request adds unit tests ensuring that the Go implementation of the filter protocol is correct.

This PR contains a fair number of changes, so here's the breakdown:

1. https://github.com/github/git-lfs/commit/8bc726dc87d4763d083c4c958842f48c34db6362: Split the high-level protocol (reading requests, writing responses) from the low-level protocol (reading/writing packets, length headers, chunking large packets, etc). This was done so that the unit tests at each "strata" of the protocol could be easily separated, and it hides the underlying implementation of the protocol from the higher-level use cases.
2. https://github.com/github/git-lfs/commit/17f9ead05c0cf3fa81f3d5bbf55a7121b11359bb: add some unit tests for the low-level protocol.
3. https://github.com/github/git-lfs/commit/31d04161d90fc522bcb76e00566eda006979c595: add some unit tests for the high-level protocol.

Though I should have done this sooner, my plan going forward is to rename these types in a future PR to more accurately reflect what they're used for. The `ObjectScanner` type will actually implement the scanner pattern in a future PR in this series, so that name may end up staying the same.

---

/cc @technoweenie @larsxschneider @sinbad @rubyist @sschuberth 