### PR TITLE
filter_stream: Make ObjectScanner behave like a Scanner

### DIFF
--- a/commands/command_filter.go
+++ b/commands/command_filter.go
@@ -132,8 +132,13 @@ func filterCommand(cmd *cobra.Command, args []string) {
 	lfs.InstallHooks(false)
 
 	s := git.NewObjectScanner(os.Stdin, os.Stdout)
-	s.Init()
+
+	if err := s.Init(); err != nil {
+		ExitWithError(err)
+	}
+
 	s.NegotiateCapabilities()
+
 	for {
 		request, data, err := s.ReadRequest()
 		if err != nil {

--- a/commands/command_filter.go
+++ b/commands/command_filter.go
@@ -141,7 +141,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 	}
 
 	for {
-		request, data, err := s.ReadRequest()
+		req, err := s.ReadRequest()
 		if err != nil {
 			break
 		}
@@ -150,11 +150,11 @@ func filterCommand(cmd *cobra.Command, args []string) {
 		// ReadRequest should return data as Reader instead of []byte ?!
 		// clean/smudge should also take a Writer instead of returning []byte
 		var outputData []byte
-		switch request["command"] {
+		switch req.Header["command"] {
 		case "clean":
-			outputData, _ = clean(bytes.NewReader(data), request["pathname"])
+			outputData, _ = clean(bytes.NewReader(req.Payload), req.Header["pathname"])
 		case "smudge":
-			outputData, _ = smudge(bytes.NewReader(data), request["pathname"])
+			outputData, _ = smudge(bytes.NewReader(req.Payload), req.Header["pathname"])
 		default:
 			fmt.Errorf("Unknown command %s", cmd)
 			break

--- a/commands/command_filter.go
+++ b/commands/command_filter.go
@@ -140,11 +140,8 @@ func filterCommand(cmd *cobra.Command, args []string) {
 		ExitWithError(err)
 	}
 
-	for {
-		req, err := s.ReadRequest()
-		if err != nil {
-			break
-		}
+	for s.Scan() {
+		req := s.Request()
 
 		// TODO:
 		// ReadRequest should return data as Reader instead of []byte ?!
@@ -161,6 +158,10 @@ func filterCommand(cmd *cobra.Command, args []string) {
 		}
 
 		s.WriteResponse(outputData)
+	}
+
+	if err := s.Err(); err != nil {
+		ExitWithError(err)
 	}
 }
 

--- a/commands/command_filter.go
+++ b/commands/command_filter.go
@@ -136,8 +136,9 @@ func filterCommand(cmd *cobra.Command, args []string) {
 	if err := s.Init(); err != nil {
 		ExitWithError(err)
 	}
-
-	s.NegotiateCapabilities()
+	if err := s.NegotiateCapabilities(); err != nil {
+		ExitWithError(err)
+	}
 
 	for {
 		request, data, err := s.ReadRequest()

--- a/commands/command_filter.go
+++ b/commands/command_filter.go
@@ -14,11 +14,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	// cleanFilterBufferCapacity is the desired capacity of the
+	// `*git.PacketWriter`'s internal buffer when the filter protocol
+	// dictates the "clean" command. 512 bytes is (in most cases) enough to
+	// hold an entire LFS pointer in memory.
+	cleanFilterBufferCapacity = 512
+
+	// smudgeFilterBufferCapacity is the desired capacity of the
+	// `*git.PacketWriter`'s internal buffer when the filter protocol
+	// dictates the "smudge" command.
+	smudgeFilterBufferCapacity = git.MaxPacketLength
+)
+
 var (
 	filterSmudgeSkip = false
 )
 
-func clean(reader io.Reader, fileName string) ([]byte, error) {
+func clean(to io.Writer, reader io.Reader, fileName string) error {
 	var cb progress.CopyCallback
 	var file *os.File
 	var fileSize int64
@@ -47,9 +60,11 @@ func clean(reader io.Reader, fileName string) ([]byte, error) {
 	}
 
 	if errors.IsCleanPointerError(err) {
-		// TODO: report errors differently!
-		// os.Stdout.Write(errors.GetContext(err, "bytes").([]byte))
-		return errors.GetContext(err, "bytes").([]byte), nil
+		// If the contents read from the working directory was _already_
+		// a pointer, we'll get a `CleanPointerError`, with the context
+		// containing the bytes that we should write back out to Git.
+		_, err = to.Write(errors.GetContext(err, "bytes").([]byte))
+		return err
 	}
 
 	if err != nil {
@@ -75,20 +90,32 @@ func clean(reader io.Reader, fileName string) ([]byte, error) {
 		Debug("Writing %s", mediafile)
 	}
 
-	return []byte(cleaned.Pointer.Encoded()), nil
+	_, err = cleaned.Pointer.Encode(to)
+	return err
 }
 
-func smudge(reader io.Reader, filename string) ([]byte, error) {
+func smudge(to io.Writer, reader io.Reader, filename string) error {
+	var pbuf bytes.Buffer
+	reader = io.TeeReader(reader, &pbuf)
+
 	ptr, err := lfs.DecodePointer(reader)
 	if err != nil {
-		// mr := io.MultiReader(b, reader)
-		// _, err := io.Copy(os.Stdout, mr)
-		// if err != nil {
-		// 	Panic(err, "Error writing data to stdout:")
-		// }
-		var content []byte
-		reader.Read(content)
-		return content, nil
+		// If we tried to decode a pointer out of the data given to us,
+		// and the file was _empty_, write out an empty file in
+		// response. This occurs because when the clean filter
+		// encounters an empty file, and writes out an empty file,
+		// instead of a pointer.
+		//
+		// TODO(taylor): figure out if there is more data on the reader,
+		// and buffer that as well.
+		if len(pbuf.Bytes()) == 0 {
+			if _, cerr := io.Copy(to, &pbuf); cerr != nil {
+				Panic(cerr, "Error writing data to stdout:")
+			}
+			return nil
+		}
+
+		return err
 	}
 
 	lfs.LinkOrCopyFromReference(ptr.Oid, ptr.Size)
@@ -105,8 +132,7 @@ func smudge(reader io.Reader, filename string) ([]byte, error) {
 		download = false
 	}
 
-	buf := new(bytes.Buffer)
-	err = ptr.Smudge(buf, filename, download, TransferManifest(), cb)
+	err = ptr.Smudge(to, filename, download, TransferManifest(), cb)
 	if file != nil {
 		file.Close()
 	}
@@ -121,10 +147,11 @@ func smudge(reader io.Reader, filename string) ([]byte, error) {
 			}
 		}
 
-		return []byte(ptr.Encoded()), nil
+		_, err = ptr.Encode(to)
+		return err
 	}
 
-	return buf.Bytes(), nil
+	return nil
 }
 
 func filterCommand(cmd *cobra.Command, args []string) {
@@ -140,27 +167,43 @@ func filterCommand(cmd *cobra.Command, args []string) {
 		ExitWithError(err)
 	}
 
+Scan:
 	for s.Scan() {
-		req := s.Request()
+		var err error
+		var w io.Writer
 
-		// TODO:
-		// ReadRequest should return data as Reader instead of []byte ?!
-		// clean/smudge should also take a Writer instead of returning []byte
-		var outputData []byte
-		switch req.Header["command"] {
-		case "clean":
-			outputData, _ = clean(bytes.NewReader(req.Payload), req.Header["pathname"])
-		case "smudge":
-			outputData, _ = smudge(bytes.NewReader(req.Payload), req.Header["pathname"])
-		default:
-			fmt.Errorf("Unknown command %s", cmd)
+		req := s.Request()
+		if req == nil {
 			break
 		}
+		s.WriteStatus("success")
 
-		s.WriteResponse(outputData)
+		switch req.Header["command"] {
+		case "clean":
+			w = git.NewPacketWriter(os.Stdout, cleanFilterBufferCapacity)
+			err = clean(w, req.Payload, req.Header["pathname"])
+		case "smudge":
+			w = git.NewPacketWriter(os.Stdout, smudgeFilterBufferCapacity)
+			err = smudge(w, req.Payload, req.Header["pathname"])
+		default:
+			fmt.Errorf("Unknown command %s", cmd)
+			break Scan
+		}
+
+		var status string
+		if _, ferr := w.Write(nil); ferr != nil {
+			status = "error"
+		} else {
+			if err != nil && err != io.EOF {
+				status = "error"
+			} else {
+				status = "success"
+			}
+		}
+		s.WriteStatus(status)
 	}
 
-	if err := s.Err(); err != nil {
+	if err := s.Err(); err != nil && err != io.EOF {
 		ExitWithError(err)
 	}
 }

--- a/git/git_filter_protocol.go
+++ b/git/git_filter_protocol.go
@@ -42,23 +42,23 @@ func (o *ObjectScanner) Init() error {
 
 	initMsg, err := o.p.readPacketText()
 	if err != nil {
-		return fmt.Errorf("Error: reading filter initialization failed with %s", err)
+		return fmt.Errorf("reading filter initialization failed with %s", err)
 	}
 	if initMsg != "git-filter-client" {
-		return fmt.Errorf("Error: invalid filter protocol welcome message: %s", initMsg)
+		return fmt.Errorf("invalid filter protocol welcome message: %s", initMsg)
 	}
 
 	supVers, err := o.p.readPacketList()
 	if err != nil {
-		return fmt.Errorf("Error: reading filter versions failed with %s", err)
+		return fmt.Errorf("reading filter versions failed with %s", err)
 	}
 	if !isStringInSlice(supVers, reqVer) {
-		return fmt.Errorf("Error: filter '%s' not supported (your Git supports: %s)", reqVer, supVers)
+		return fmt.Errorf("filter '%s' not supported (your Git supports: %s)", reqVer, supVers)
 	}
 
 	err = o.p.writePacketList([]string{"git-filter-server", reqVer})
 	if err != nil {
-		return fmt.Errorf("Error: writing filter initialization failed with %s", err)
+		return fmt.Errorf("writing filter initialization failed with %s", err)
 	}
 	return nil
 }

--- a/git/git_filter_protocol.go
+++ b/git/git_filter_protocol.go
@@ -67,17 +67,17 @@ func (o *ObjectScanner) NegotiateCapabilities() error {
 
 	supCaps, err := o.p.readPacketList()
 	if err != nil {
-		return fmt.Errorf("Error: reading filter capabilities failed with %s", err)
+		return fmt.Errorf("reading filter capabilities failed with %s", err)
 	}
 	for _, reqCap := range reqCaps {
 		if !isStringInSlice(supCaps, reqCap) {
-			return fmt.Errorf("Error: filter '%s' not supported (your Git supports: %s)", reqCap, supCaps)
+			return fmt.Errorf("filter '%s' not supported (your Git supports: %s)", reqCap, supCaps)
 		}
 	}
 
 	err = o.p.writePacketList(reqCaps)
 	if err != nil {
-		return fmt.Errorf("Error: writing filter capabilities failed with %s", err)
+		return fmt.Errorf("writing filter capabilities failed with %s", err)
 	}
 
 	return nil

--- a/git/git_filter_protocol.go
+++ b/git/git_filter_protocol.go
@@ -5,7 +5,6 @@ package git
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/rubyist/tracerx"
@@ -63,32 +62,25 @@ func (o *ObjectScanner) Init() error {
 	return nil
 }
 
-func (o *ObjectScanner) NegotiateCapabilities() bool {
+func (o *ObjectScanner) NegotiateCapabilities() error {
 	reqCaps := []string{"capability=clean", "capability=smudge"}
 
 	supCaps, err := o.p.readPacketList()
 	if err != nil {
-		fmt.Fprintf(os.Stderr,
-			"Error: reading filter capabilities failed with %s\n", err)
-		return false
+		return fmt.Errorf("Error: reading filter capabilities failed with %s", err)
 	}
 	for _, reqCap := range reqCaps {
 		if !isStringInSlice(supCaps, reqCap) {
-			fmt.Fprintf(os.Stderr,
-				"Error: filter '%s' not supported (your Git supports: %s)\n",
-				reqCap, supCaps)
-			return false
+			return fmt.Errorf("Error: filter '%s' not supported (your Git supports: %s)", reqCap, supCaps)
 		}
 	}
 
 	err = o.p.writePacketList(reqCaps)
 	if err != nil {
-		fmt.Fprintf(os.Stderr,
-			"Error: writing filter capabilities failed with %s\n", err)
-		return false
+		return fmt.Errorf("Error: writing filter capabilities failed with %s", err)
 	}
 
-	return true
+	return nil
 }
 
 func (o *ObjectScanner) ReadRequest() (map[string]string, []byte, error) {

--- a/git/git_filter_protocol.go
+++ b/git/git_filter_protocol.go
@@ -36,42 +36,31 @@ func NewObjectScanner(r io.Reader, w io.Writer) *ObjectScanner {
 	}
 }
 
-func (o *ObjectScanner) Init() bool {
+func (o *ObjectScanner) Init() error {
 	tracerx.Printf("Initialize filter")
 	reqVer := "version=2"
 
 	initMsg, err := o.p.readPacketText()
 	if err != nil {
-		fmt.Fprintf(os.Stderr,
-			"Error: reading filter initialization failed with %s\n", err)
-		return false
+		return fmt.Errorf("Error: reading filter initialization failed with %s", err)
 	}
 	if initMsg != "git-filter-client" {
-		fmt.Fprintf(os.Stderr,
-			"Error: invalid filter protocol welcome message: %s\n", initMsg)
-		return false
+		return fmt.Errorf("Error: invalid filter protocol welcome message: %s", initMsg)
 	}
 
 	supVers, err := o.p.readPacketList()
 	if err != nil {
-		fmt.Fprintf(os.Stderr,
-			"Error: reading filter versions failed with %s\n", err)
-		return false
+		return fmt.Errorf("Error: reading filter versions failed with %s", err)
 	}
 	if !isStringInSlice(supVers, reqVer) {
-		fmt.Fprintf(os.Stderr,
-			"Error: filter '%s' not supported (your Git supports: %s)\n",
-			reqVer, supVers)
-		return false
+		return fmt.Errorf("Error: filter '%s' not supported (your Git supports: %s)", reqVer, supVers)
 	}
 
 	err = o.p.writePacketList([]string{"git-filter-server", reqVer})
 	if err != nil {
-		fmt.Fprintf(os.Stderr,
-			"Error: writing filter initialization failed with %s\n", err)
-		return false
+		return fmt.Errorf("Error: writing filter initialization failed with %s", err)
 	}
-	return true
+	return nil
 }
 
 func (o *ObjectScanner) NegotiateCapabilities() bool {

--- a/git/git_filter_protocol.go
+++ b/git/git_filter_protocol.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/github/git-lfs/errors"
 	"github.com/rubyist/tracerx"
 )
 
@@ -44,7 +45,7 @@ func (o *ObjectScanner) Init() error {
 
 	initMsg, err := o.p.readPacketText()
 	if err != nil {
-		return fmt.Errorf("reading filter initialization failed with %s", err)
+		return errors.Wrap(err, "reading filter initialization")
 	}
 	if initMsg != "git-filter-client" {
 		return fmt.Errorf("invalid filter protocol welcome message: %s", initMsg)
@@ -52,7 +53,7 @@ func (o *ObjectScanner) Init() error {
 
 	supVers, err := o.p.readPacketList()
 	if err != nil {
-		return fmt.Errorf("reading filter versions failed with %s", err)
+		return errors.Wrap(err, "reading filter versions")
 	}
 	if !isStringInSlice(supVers, reqVer) {
 		return fmt.Errorf("filter '%s' not supported (your Git supports: %s)", reqVer, supVers)
@@ -60,7 +61,7 @@ func (o *ObjectScanner) Init() error {
 
 	err = o.p.writePacketList([]string{"git-filter-server", reqVer})
 	if err != nil {
-		return fmt.Errorf("writing filter initialization failed with %s", err)
+		return errors.Wrap(err, "writing filter initialization failed")
 	}
 	return nil
 }

--- a/git/object_scanner_test.go
+++ b/git/object_scanner_test.go
@@ -35,7 +35,7 @@ func TestObjectScannerRejectsUnrecognizedInitializationMessages(t *testing.T) {
 	err := os.Init()
 
 	require.NotNil(t, err)
-	assert.Equal(t, "Error: invalid filter protocol welcome message: git-filter-client-unknown", err.Error())
+	assert.Equal(t, "invalid filter protocol welcome message: git-filter-client-unknown", err.Error())
 	assert.Empty(t, to.Bytes())
 }
 
@@ -51,7 +51,7 @@ func TestObjectScannerRejectsUnsupportedFilters(t *testing.T) {
 	err := os.Init()
 
 	require.NotNil(t, err)
-	assert.Equal(t, "Error: filter 'version=2' not supported (your Git supports: [version=0])", err.Error())
+	assert.Equal(t, "filter 'version=2' not supported (your Git supports: [version=0])", err.Error())
 	assert.Empty(t, to.Bytes())
 }
 

--- a/git/object_scanner_test.go
+++ b/git/object_scanner_test.go
@@ -86,7 +86,7 @@ func TestObjectScannerDoesNotNegotitatesUnsupportedCapabilities(t *testing.T) {
 	err := os.NegotiateCapabilities()
 
 	require.NotNil(t, err)
-	assert.Equal(t, "Error: filter 'capability=clean' not supported (your Git supports: [capability=unsupported])", err.Error())
+	assert.Equal(t, "filter 'capability=clean' not supported (your Git supports: [capability=unsupported])", err.Error())
 	assert.Empty(t, to.Bytes())
 }
 

--- a/git/object_scanner_test.go
+++ b/git/object_scanner_test.go
@@ -64,9 +64,9 @@ func TestObjectScannerNegotitatesSupportedCapabilities(t *testing.T) {
 	}))
 
 	os := NewObjectScanner(&from, &to)
-	ok := os.NegotiateCapabilities()
+	err := os.NegotiateCapabilities()
 
-	assert.True(t, ok)
+	assert.Nil(t, err)
 
 	out, err := newProtocolRW(&to, nil).readPacketList()
 	assert.Nil(t, err)
@@ -83,9 +83,10 @@ func TestObjectScannerDoesNotNegotitatesUnsupportedCapabilities(t *testing.T) {
 	}))
 
 	os := NewObjectScanner(&from, &to)
-	ok := os.NegotiateCapabilities()
+	err := os.NegotiateCapabilities()
 
-	assert.False(t, ok)
+	require.NotNil(t, err)
+	assert.Equal(t, "Error: filter 'capability=clean' not supported (your Git supports: [capability=unsupported])", err.Error())
 	assert.Empty(t, to.Bytes())
 }
 

--- a/git/object_scanner_test.go
+++ b/git/object_scanner_test.go
@@ -16,9 +16,9 @@ func TestObjectScannerInitializesWithCorrectSupportedValues(t *testing.T) {
 	require.Nil(t, proto.writePacketList([]string{"version=2"}))
 
 	os := NewObjectScanner(&from, &to)
-	ok := os.Init()
+	err := os.Init()
 
-	assert.True(t, ok)
+	assert.Nil(t, err)
 
 	out, err := newProtocolRW(&to, nil).readPacketList()
 	assert.Nil(t, err)
@@ -32,9 +32,10 @@ func TestObjectScannerRejectsUnrecognizedInitializationMessages(t *testing.T) {
 	require.Nil(t, proto.writePacketText("git-filter-client-unknown"))
 
 	os := NewObjectScanner(&from, &to)
-	ok := os.Init()
+	err := os.Init()
 
-	assert.False(t, ok)
+	require.NotNil(t, err)
+	assert.Equal(t, "Error: invalid filter protocol welcome message: git-filter-client-unknown", err.Error())
 	assert.Empty(t, to.Bytes())
 }
 
@@ -47,9 +48,10 @@ func TestObjectScannerRejectsUnsupportedFilters(t *testing.T) {
 	require.Nil(t, proto.writePacketList([]string{"version=0"}))
 
 	os := NewObjectScanner(&from, &to)
-	ok := os.Init()
+	err := os.Init()
 
-	assert.False(t, ok)
+	require.NotNil(t, err)
+	assert.Equal(t, "Error: filter 'version=2' not supported (your Git supports: [version=0])", err.Error())
 	assert.Empty(t, to.Bytes())
 }
 

--- a/git/packet_reader.go
+++ b/git/packet_reader.go
@@ -1,0 +1,63 @@
+package git
+
+import (
+	"io"
+
+	"github.com/github/git-lfs/tools"
+)
+
+type packetReader struct {
+	proto *protocol
+
+	buf []byte
+}
+
+var _ io.Reader = new(packetReader)
+
+func (r *packetReader) Read(p []byte) (int, error) {
+	var n int
+
+	if len(r.buf) > 0 {
+		// If there is data in the buffer, shift as much out of it and
+		// into the given "p" as we can.
+		n = tools.MinInt(len(p), len(r.buf))
+
+		copy(p, r.buf[:n])
+		r.buf = r.buf[n:]
+	}
+
+	// Loop and grab as many packets as we can in a given "run", until we
+	// have either, a) overfilled the given buffer "p", or we have started
+	// to internally buffer in "r.buf".
+	for len(r.buf) == 0 {
+		chunk, err := r.proto.readPacket()
+		if err != nil {
+			return n, err
+		}
+
+		if len(chunk) == 0 {
+			// If we got an empty chunk, then we know that we have
+			// reached the end of processing for this particular
+			// packet, so let's terminate.
+
+			return n, io.EOF
+		}
+
+		// Figure out how much of the packet we can read into "p".
+		nn := tools.MinInt(len(chunk), len(p))
+
+		// Move that amount into "p", from where we left off.
+		copy(p[n:], chunk[:nn])
+		// And move the rest into the buffer.
+		r.buf = append(r.buf, chunk[nn:]...)
+
+		// Mark that we have read "nn" bytes into "p"
+		n += nn
+
+		if n >= len(p) {
+			break
+		}
+	}
+
+	return n, nil
+}

--- a/git/packet_reader_test.go
+++ b/git/packet_reader_test.go
@@ -1,0 +1,142 @@
+package git
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// writePackets
+func writePacket(w io.Writer, datas ...[]byte) {
+	for _, data := range datas {
+		io.WriteString(w, fmt.Sprintf("%04x", len(data)+4))
+		w.Write(data)
+
+	}
+	io.WriteString(w, fmt.Sprintf("%04x", 0))
+}
+
+func TestPacketReaderReadsSinglePacketsInOneCall(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("asdf"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	data, err := ioutil.ReadAll(pr)
+
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("asdf"), data)
+}
+
+func TestPacketReaderReadsManyPacketsInOneCall(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("first\n"), []byte("second"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	data, err := ioutil.ReadAll(pr)
+
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("first\nsecond"), data)
+}
+
+func TestPacketReaderReadsSinglePacketsInMultipleCallsWithUnevenBuffering(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("asdf"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	var p1 [3]byte
+	var p2 [1]byte
+
+	n1, e1 := pr.Read(p1[:])
+	assert.Equal(t, 3, n1)
+	assert.Equal(t, []byte("asd"), p1[:])
+	assert.Nil(t, e1)
+
+	n2, e2 := pr.Read(p2[:])
+	assert.Equal(t, 1, n2)
+	assert.Equal(t, []byte("f"), p2[:])
+	assert.Equal(t, io.EOF, e2)
+}
+
+func TestPacketReaderReadsManyPacketsInMultipleCallsWithUnevenBuffering(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("first"), []byte("second"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	var p1 [4]byte
+	var p2 [7]byte
+	var p3 []byte
+
+	n1, e1 := pr.Read(p1[:])
+	assert.Equal(t, 4, n1)
+	assert.Equal(t, []byte("firs"), p1[:])
+	assert.Nil(t, e1)
+
+	n2, e2 := pr.Read(p2[:])
+	assert.Equal(t, 7, n2)
+	assert.Equal(t, []byte("tsecond"), p2[:])
+	assert.Equal(t, nil, e2)
+
+	n3, e3 := pr.Read(p3[:])
+	assert.Equal(t, 0, n3)
+	assert.Empty(t, p3)
+	assert.Equal(t, io.EOF, e3)
+}
+
+func TestPacketReaderReadsSinglePacketsInMultipleCallsWithEvenBuffering(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("firstother"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	var p1 [5]byte
+	var p2 [5]byte
+
+	n1, e1 := pr.Read(p1[:])
+	assert.Equal(t, 5, n1)
+	assert.Equal(t, []byte("first"), p1[:])
+	assert.Nil(t, e1)
+
+	n2, e2 := pr.Read(p2[:])
+	assert.Equal(t, 5, n2)
+	assert.Equal(t, []byte("other"), p2[:])
+	assert.Equal(t, io.EOF, e2)
+}
+
+func TestPacketReaderReadsManyPacketsInMultipleCallsWithEvenBuffering(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("first"), []byte("other"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	var p1 [5]byte
+	var p2 [5]byte
+	var p3 []byte
+
+	n1, e1 := pr.Read(p1[:])
+	assert.Equal(t, 5, n1)
+	assert.Equal(t, []byte("first"), p1[:])
+	assert.Nil(t, e1)
+
+	n2, e2 := pr.Read(p2[:])
+	assert.Equal(t, 5, n2)
+	assert.Equal(t, []byte("other"), p2[:])
+	assert.Equal(t, nil, e2)
+
+	n3, e3 := pr.Read(p3)
+	assert.Equal(t, 0, n3)
+	assert.Equal(t, io.EOF, e3)
+}

--- a/git/packet_writer.go
+++ b/git/packet_writer.go
@@ -1,0 +1,124 @@
+package git
+
+import (
+	"io"
+
+	"github.com/github/git-lfs/tools"
+)
+
+type PacketWriter struct {
+	// buf is an internal buffer used to store data until enough has been
+	// collected to write a full packet, or the buffer was instructed to
+	// flush.
+	buf []byte
+	// proto is the place where packets get written.
+	proto *protocol
+}
+
+var _ io.Writer = new(PacketWriter)
+
+// NewPacketWriter returns a new *PacketWriter, which will write to the
+// underlying data stream "w". The internal buffer is initialized with the given
+// capacity, "c".
+//
+// If "w" is already a `*PacketWriter`, it will be returned as-is.
+func NewPacketWriter(w io.Writer, c int) *PacketWriter {
+	if pw, ok := w.(*PacketWriter); ok {
+		return pw
+	}
+
+	return &PacketWriter{
+		buf:   make([]byte, 0, c),
+		proto: newProtocolRW(nil, w),
+	}
+}
+
+// Write implements the io.Writer interface's `Write` method by providing a
+// packet-based backend to the given buffer "p".
+//
+// As many bytes are removed from "p" as possible and stored in an internal
+// buffer until the amount of data in the internal buffer is enough to write a
+// single packet. Once the internal buffer is full, a packet is written to the
+// underlying stream of data, and the process repeats.
+//
+// When the caller has no more data to write in the given chunk of packets, a
+// subsequent call to `Write(p []byte)` MUST be made with a nil slice, to flush
+// the remaining data in the buffer, and write the terminating bytes to the
+// underlying packet stream.
+//
+// Write returns the number of bytes in "p" accepted into the writer, which
+// _MAY_ be written to the underlying protocol stream, or may be written into
+// the internal buffer.
+//
+// If any error was encountered while either buffering or writing, that
+// error is returned, along with the number of bytes written to the underlying
+// protocol stream, as described above.
+func (w *PacketWriter) Write(p []byte) (int, error) {
+	var n int
+
+	if p == nil {
+		// If we got an empty sequence of bytes, let's flush the data
+		// stored in the buffer, and then write the a packet termination
+		// sequence.
+
+		if _, err := w.flush(); err != nil {
+			return 0, err
+		}
+
+		if err := w.proto.writeFlush(); err != nil {
+			return 0, err
+		}
+	}
+
+	for len(p) > 0 {
+		// While there is still data left to process in "p", grab as
+		// much of it as we can while not allowing the internal buffer
+		// to exceed the MaxPacketLength const.
+		m := tools.MinInt(len(p), MaxPacketLength-len(w.buf))
+
+		// Append on all of the data that we could into the internal
+		// buffer.
+		w.buf = append(w.buf, p[:m]...)
+		// Truncate "p" such that it no longer includes the data that we
+		// have in the internal buffer.
+		p = p[m:]
+
+		n = n + m
+
+		if len(w.buf) == MaxPacketLength {
+			// If we were able to grab an entire packet's worth of
+			// data, flush the buffer.
+
+			if _, err := w.flush(); err != nil {
+				return n, err
+			}
+
+		}
+	}
+
+	return n, nil
+}
+
+// flush writes any data in the internal buffer out to the underlying protocol
+// stream. If the amount of data in the internal buffer exceeds the
+// MaxPacketLength, the data will be written in multiple packets to accommodate.
+//
+// flush returns the number of bytes written to the underlying packet stream,
+// and any error that it encountered along the way.
+func (w *PacketWriter) flush() (int, error) {
+	var n int
+
+	for len(w.buf) > 0 {
+		if err := w.proto.writePacket(w.buf); err != nil {
+			return 0, err
+		}
+
+		m := tools.MinInt(len(w.buf), MaxPacketLength)
+
+		w.buf = w.buf[m:]
+
+		n = n + m
+	}
+
+	return n, nil
+}

--- a/git/packet_writer_test.go
+++ b/git/packet_writer_test.go
@@ -1,0 +1,108 @@
+package git
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPacketWriterWritesPacketsShorterThanMaxPacketSize(t *testing.T) {
+	var buf bytes.Buffer
+
+	w := NewPacketWriter(&buf, 0)
+	assertWriterWrite(t, w, []byte("Hello, world!"), 13)
+	assertWriterWrite(t, w, nil, 0)
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, []byte("Hello, world!"))
+	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterWritesPacketsEqualToMaxPacketLength(t *testing.T) {
+	big := make([]byte, MaxPacketLength)
+	for i, _ := range big {
+		big[i] = 1
+	}
+
+	// Make a copy so that we can drain the data inside of it
+	p := make([]byte, MaxPacketLength)
+	copy(p, big)
+
+	var buf bytes.Buffer
+
+	w := NewPacketWriter(&buf, 0)
+	assertWriterWrite(t, w, p, len(big))
+	assertWriterWrite(t, w, nil, 0)
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, big)
+	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterWritesMultiplePacketsLessThanMaxPacketLength(t *testing.T) {
+	var buf bytes.Buffer
+
+	w := NewPacketWriter(&buf, 0)
+	assertWriterWrite(t, w, []byte("first\n"), len("first\n"))
+	assertWriterWrite(t, w, []byte("second"), len("second"))
+	assertWriterWrite(t, w, nil, 0)
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, []byte("first\nsecond"))
+	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterWritesMultiplePacketsGreaterThanMaxPacketLength(t *testing.T) {
+	var buf bytes.Buffer
+
+	b1 := make([]byte, MaxPacketLength*3/4)
+	p1 := make([]byte, len(b1))
+	for i, _ := range b1 {
+		b1[i] = 1
+	}
+	copy(p1, b1)
+
+	b2 := make([]byte, MaxPacketLength*3/4)
+	p2 := make([]byte, len(b2))
+	for i, _ := range b2 {
+		b2[i] = 1
+	}
+	copy(p2, b1)
+
+	w := NewPacketWriter(&buf, 0)
+	assertWriterWrite(t, w, p1, len(p1))
+	assertWriterWrite(t, w, p2, len(p2))
+	assertWriterWrite(t, w, nil, 0)
+
+	// offs is how far into b2 we needed to buffer before writing an entire
+	// packet
+	offs := MaxPacketLength - len(b1)
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, append(b1, b2[:offs]...))
+	assertPacketRead(t, proto, b2[offs:])
+	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterDoesntWrapItself(t *testing.T) {
+	itself := &PacketWriter{}
+	nw := NewPacketWriter(itself, 0)
+
+	assert.Equal(t, itself, nw)
+}
+
+func assertWriterWrite(t *testing.T, w io.Writer, p []byte, plen int) {
+	n, err := w.Write(p)
+
+	assert.Nil(t, err)
+	assert.Equal(t, plen, n)
+}
+
+func assertPacketRead(t *testing.T, proto *protocol, expected []byte) {
+	got, err := proto.readPacket()
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, got)
+}

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -113,7 +113,7 @@ func DecodeFrom(reader io.Reader) ([]byte, *Pointer, error) {
 	written, err := reader.Read(buf)
 	output := buf[0:written]
 
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return output, nil, err
 	}
 

--- a/lfs/pointer_clean.go
+++ b/lfs/pointer_clean.go
@@ -82,8 +82,14 @@ func copyToTemp(reader io.Reader, fileSize int64, cb progress.CopyCallback) (oid
 		return
 	}
 
-	multi := io.MultiReader(bytes.NewReader(by), reader)
-	size, err = tools.CopyWithCallback(writer, multi, fileSize, cb)
+	var from io.Reader = bytes.NewReader(by)
+	if int64(len(by)) < fileSize {
+		// If there is still more data to be read from the file, tack on
+		// the original reader and continue the read from there.
+		from = io.MultiReader(from, reader)
+	}
+
+	size, err = tools.CopyWithCallback(writer, from, fileSize, cb)
 
 	if err != nil {
 		return

--- a/lfs/pointer_test.go
+++ b/lfs/pointer_test.go
@@ -3,7 +3,6 @@ package lfs
 import (
 	"bufio"
 	"bytes"
-	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -170,17 +169,10 @@ size 12345`
 
 func TestDecodeFromEmptyReader(t *testing.T) {
 	by, p, err := DecodeFrom(strings.NewReader(""))
-	if err != io.EOF {
-		t.Fatalf("unexpected error: %v", err)
-	}
 
-	if p != nil {
-		t.Fatalf("Unexpected pointer: %v", p)
-	}
-
-	if string(by) != "" {
-		t.Fatalf("unexpected result: '%s'", string(by))
-	}
+	assert.EqualError(t, err, "Pointer file error: invalid header")
+	assert.Nil(t, p)
+	assert.Empty(t, string(by))
 }
 
 func TestDecodeInvalid(t *testing.T) {

--- a/tools/math.go
+++ b/tools/math.go
@@ -1,0 +1,17 @@
+package tools
+
+func MinInt(a, b int) int {
+	if a < b {
+		return a
+	}
+
+	return b
+}
+
+func MaxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+
+	return b
+}

--- a/tools/math_test.go
+++ b/tools/math_test.go
@@ -1,0 +1,15 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func MinIntPicksTheSmallerInt(t *testing.T) {
+	assert.Equal(t, -1, MinInt(-1, 1))
+}
+
+func MaxIntPicksTheBiggertInt(t *testing.T) {
+	assert.Equal(t, 1, MaxInt(-1, 1))
+}


### PR DESCRIPTION
This pull-request cleans up the `ObjectScanner` API to better fit the scanner-pattern, an example of which can be found in [`bufio.Scanner`](https://golang.org/pkg/bufio/#Scanner).

Commit by commit, here's the breakdown:

1. https://github.com/github/git-lfs/commit/78e583e48e83f5c3889e58079f0242e9e1736aa1: instead of logging errors directly to `os.Stderr` and returning a `bool` from `Init()`, return those messages in `error`s.
2. https://github.com/github/git-lfs/commit/6728507d5e33e832083e97be1ec53b893795864a: cleanup the `"Error: "` prefixes from the messages, since that formatting will be handled by the `commands` package now.
3. https://github.com/github/git-lfs/commit/18ac2724fd84a76a95ed494a0b3c337974d78ba9, https://github.com/github/git-lfs/commit/b2e568f56d1efb533de01accdd58348e03aa0f65: Do the same thing to `NegotiateCapabilities()`, in the same order.
4. https://github.com/github/git-lfs/commit/c326fcb8c55ae654143d308bfb6a1e145fc1c8f1: Introduce the `*git.Request` type, to clean up the signature of the upcoming `Object()` function to return a type with a `Header` and `Payload` instead of adding more return types, i.e.,:

```go 
type Request struct {
        Header map[string]string
        Payload []byte
}

func (s *ObjectScanner) Object() *Request { ... }
```

instead of:

```go
func (s *ObjectScanner) Object() (map[string]string, []byte)
```

by giving them names, and a meaningful type, I think of that function below is a lot cleaner.

5. https://github.com/github/git-lfs/commit/a778118b384ed352ddf9158e945e688c6e7fbe8a: Implement the scanner itself.

The scanner ends of being a lot cleaner at the call site. Instead of looping forever, and then breaking out at different points in the body, the loop condition encapsulates all of those tiny other exit conditions in one.

The error gets handled once, outside of the loop, which is essentially what was happening in before when it was handled inside of the loop before breaking, now it's just clearer what is actually going on.

This idea was originally a suggestion from @rubyist way back in https://github.com/github/git-lfs/pull/1382#issuecomment-234579799, so credit where credit is due for a great idea!

---

/cc @technoweenie @larsxschneider @sinbad @rubyist @sschuberth 