### PR TITLE
filter_stream: provide io.Reader implementation

### DIFF
--- a/commands/command_filter.go
+++ b/commands/command_filter.go
@@ -161,7 +161,6 @@ Scan:
 
 		if err != nil {
 			s.WriteStatus("error")
-
 		} else {
 			s.WriteStatus("success")
 			s.WriteResponse(outputData)

--- a/commands/command_filter.go
+++ b/commands/command_filter.go
@@ -79,16 +79,12 @@ func clean(reader io.Reader, fileName string) ([]byte, error) {
 }
 
 func smudge(reader io.Reader, filename string) ([]byte, error) {
+	var pbuf bytes.Buffer
+	reader = io.TeeReader(reader, &pbuf)
+
 	ptr, err := lfs.DecodePointer(reader)
 	if err != nil {
-		// mr := io.MultiReader(b, reader)
-		// _, err := io.Copy(os.Stdout, mr)
-		// if err != nil {
-		// 	Panic(err, "Error writing data to stdout:")
-		// }
-		var content []byte
-		reader.Read(content)
-		return content, nil
+		return pbuf.Bytes(), err
 	}
 
 	lfs.LinkOrCopyFromReference(ptr.Oid, ptr.Size)

--- a/commands/command_filter.go
+++ b/commands/command_filter.go
@@ -14,11 +14,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	// cleanFilterBufferCapacity is the desired capacity of the
+	// `*git.PacketWriter`'s internal buffer when the filter protocol
+	// dictates the "clean" command. 512 bytes is (in most cases) enough to
+	// hold an entire LFS pointer in memory.
+	cleanFilterBufferCapacity = 512
+
+	// smudgeFilterBufferCapacity is the desired capacity of the
+	// `*git.PacketWriter`'s internal buffer when the filter protocol
+	// dictates the "smudge" command.
+	smudgeFilterBufferCapacity = git.MaxPacketLength
+)
+
 var (
 	filterSmudgeSkip = false
 )
 
-func clean(reader io.Reader, fileName string) ([]byte, error) {
+func clean(to io.Writer, reader io.Reader, fileName string) error {
 	var cb progress.CopyCallback
 	var file *os.File
 	var fileSize int64
@@ -47,9 +60,11 @@ func clean(reader io.Reader, fileName string) ([]byte, error) {
 	}
 
 	if errors.IsCleanPointerError(err) {
-		// TODO: report errors differently!
-		// os.Stdout.Write(errors.GetContext(err, "bytes").([]byte))
-		return errors.GetContext(err, "bytes").([]byte), nil
+		// If the contents read from the working directory was _already_
+		// a pointer, we'll get a `CleanPointerError`, with the context
+		// containing the bytes that we should write back out to Git.
+		_, err = to.Write(errors.GetContext(err, "bytes").([]byte))
+		return err
 	}
 
 	if err != nil {
@@ -75,10 +90,11 @@ func clean(reader io.Reader, fileName string) ([]byte, error) {
 		Debug("Writing %s", mediafile)
 	}
 
-	return []byte(cleaned.Pointer.Encoded()), nil
+	_, err = cleaned.Pointer.Encode(to)
+	return err
 }
 
-func smudge(reader io.Reader, filename string) ([]byte, error) {
+func smudge(to io.Writer, reader io.Reader, filename string) error {
 	var pbuf bytes.Buffer
 	reader = io.TeeReader(reader, &pbuf)
 
@@ -93,10 +109,13 @@ func smudge(reader io.Reader, filename string) ([]byte, error) {
 		// TODO(taylor): figure out if there is more data on the reader,
 		// and buffer that as well.
 		if len(pbuf.Bytes()) == 0 {
-			return pbuf.Bytes(), nil
+			if _, cerr := io.Copy(to, &pbuf); cerr != nil {
+				Panic(cerr, "Error writing data to stdout:")
+			}
+			return nil
 		}
 
-		return pbuf.Bytes(), err
+		return err
 	}
 
 	lfs.LinkOrCopyFromReference(ptr.Oid, ptr.Size)
@@ -113,8 +132,7 @@ func smudge(reader io.Reader, filename string) ([]byte, error) {
 		download = false
 	}
 
-	buf := new(bytes.Buffer)
-	err = ptr.Smudge(buf, filename, download, TransferManifest(), cb)
+	err = ptr.Smudge(to, filename, download, TransferManifest(), cb)
 	if file != nil {
 		file.Close()
 	}
@@ -129,10 +147,11 @@ func smudge(reader io.Reader, filename string) ([]byte, error) {
 			}
 		}
 
-		return []byte(ptr.Encoded()), nil
+		_, err = ptr.Encode(to)
+		return err
 	}
 
-	return buf.Bytes(), nil
+	return nil
 }
 
 func filterCommand(cmd *cobra.Command, args []string) {
@@ -150,29 +169,38 @@ func filterCommand(cmd *cobra.Command, args []string) {
 
 Scan:
 	for s.Scan() {
-		req := s.Request()
-
-		// TODO:
-		// clean/smudge should also take a Writer instead of returning []byte
-		var outputData []byte
 		var err error
+		var w io.Writer
+
+		req := s.Request()
+		if req == nil {
+			break
+		}
+		s.WriteStatus("success")
 
 		switch req.Header["command"] {
 		case "clean":
-			outputData, err = clean(req.Payload, req.Header["pathname"])
+			w = git.NewPacketWriter(os.Stdout, cleanFilterBufferCapacity)
+			err = clean(w, req.Payload, req.Header["pathname"])
 		case "smudge":
-			outputData, err = smudge(req.Payload, req.Header["pathname"])
+			w = git.NewPacketWriter(os.Stdout, smudgeFilterBufferCapacity)
+			err = smudge(w, req.Payload, req.Header["pathname"])
 		default:
 			fmt.Errorf("Unknown command %s", cmd)
 			break Scan
 		}
 
-		if err != nil && err != io.EOF {
-			s.WriteStatus("error")
+		var status string
+		if _, ferr := w.Write(nil); ferr != nil {
+			status = "error"
 		} else {
-			s.WriteStatus("success")
-			s.WriteResponse(outputData)
+			if err != nil && err != io.EOF {
+				status = "error"
+			} else {
+				status = "success"
+			}
 		}
+		s.WriteStatus(status)
 	}
 
 	if err := s.Err(); err != nil && err != io.EOF {

--- a/commands/command_filter.go
+++ b/commands/command_filter.go
@@ -163,7 +163,7 @@ Scan:
 		}
 	}
 
-	if err := s.Err(); err != nil {
+	if err := s.Err(); err != nil && err != io.EOF {
 		ExitWithError(err)
 	}
 }

--- a/git/git_filter_protocol.go
+++ b/git/git_filter_protocol.go
@@ -119,7 +119,7 @@ func (o *ObjectScanner) WriteResponse(outputData []byte) error {
 		}
 		err := o.p.writePacket(outputData[:chunkSize])
 		if err != nil {
-			if werr := o.writeStatus("error"); werr != nil {
+			if werr := o.WriteStatus("error"); werr != nil {
 				return werr
 			}
 
@@ -128,7 +128,7 @@ func (o *ObjectScanner) WriteResponse(outputData []byte) error {
 		outputData = outputData[chunkSize:]
 	}
 
-	return o.writeStatus("success")
+	return o.WriteStatus("success")
 }
 
 func (o *ObjectScanner) readRequest() (*Request, error) {
@@ -151,7 +151,7 @@ func (o *ObjectScanner) readRequest() (*Request, error) {
 	for {
 		chunk, err := o.p.readPacket()
 		if err != nil {
-			if werr := o.writeStatus("error"); werr != nil {
+			if werr := o.WriteStatus("error"); werr != nil {
 				return nil, werr
 			}
 
@@ -163,13 +163,13 @@ func (o *ObjectScanner) readRequest() (*Request, error) {
 		req.Payload = append(req.Payload, chunk...) // probably more efficient way?!
 	}
 
-	if err := o.writeStatus("success"); err != nil {
+	if err := o.WriteStatus("success"); err != nil {
 		return nil, err
 	}
 
 	return req, nil
 }
 
-func (o *ObjectScanner) writeStatus(status string) error {
+func (o *ObjectScanner) WriteStatus(status string) error {
 	return o.p.writePacketList([]string{"status=" + status})
 }

--- a/git/git_filter_protocol.go
+++ b/git/git_filter_protocol.go
@@ -89,7 +89,7 @@ func (o *ObjectScanner) NegotiateCapabilities() error {
 
 type Request struct {
 	Header  map[string]string
-	Payload []byte
+	Payload io.Reader
 }
 
 func (o *ObjectScanner) Scan() bool {
@@ -140,31 +140,13 @@ func (o *ObjectScanner) readRequest() (*Request, error) {
 	}
 
 	req := &Request{
-		Header: make(map[string]string),
+		Header:  make(map[string]string),
+		Payload: &packetReader{proto: o.p},
 	}
 
 	for _, pair := range requestList {
 		v := strings.Split(pair, "=")
 		req.Header[v[0]] = v[1]
-	}
-
-	for {
-		chunk, err := o.p.readPacket()
-		if err != nil {
-			if werr := o.WriteStatus("error"); werr != nil {
-				return nil, werr
-			}
-
-			return nil, err
-		}
-		if len(chunk) == 0 {
-			break
-		}
-		req.Payload = append(req.Payload, chunk...) // probably more efficient way?!
-	}
-
-	if err := o.WriteStatus("success"); err != nil {
-		return nil, err
 	}
 
 	return req, nil

--- a/git/packet_reader.go
+++ b/git/packet_reader.go
@@ -1,0 +1,62 @@
+package git
+
+import (
+	"io"
+	"math"
+)
+
+type packetReader struct {
+	proto *protocol
+
+	buf []byte
+}
+
+var _ io.Reader = new(packetReader)
+
+func (r *packetReader) Read(p []byte) (int, error) {
+	var n int
+
+	if len(r.buf) > 0 {
+		// If there is data in the buffer, shift as much out of it and
+		// into the given "p" as we can.
+		n = int(math.Min(float64(len(p)), float64(len(r.buf))))
+
+		copy(p, r.buf[:n])
+		r.buf = r.buf[n:]
+	}
+
+	// Loop and grab as many packets as we can in a given "run", until we
+	// have either, a) overfilled the given buffer "p", or we have started
+	// to internally buffer in "r.buf".
+	for len(r.buf) == 0 {
+		chunk, err := r.proto.readPacket()
+		if err != nil {
+			return n, err
+		}
+
+		if len(chunk) == 0 {
+			// If we got an empty chunk, then we know that we have
+			// reached the end of processing for this particular
+			// packet, so let's terminate.
+
+			return n, io.EOF
+		}
+
+		// Figure out how much of the packet we can read into "p".
+		nn := int(math.Min(float64(len(chunk)), float64(len(p))))
+
+		// Move that amount into "p", from where we left off.
+		copy(p[n:], chunk[:nn])
+		// And move the rest into the buffer.
+		r.buf = append(r.buf, chunk[nn:]...)
+
+		// Mark that we have read "nn" bytes into "p"
+		n += nn
+
+		if n >= len(p) {
+			break
+		}
+	}
+
+	return n, nil
+}

--- a/git/packet_reader.go
+++ b/git/packet_reader.go
@@ -2,7 +2,8 @@ package git
 
 import (
 	"io"
-	"math"
+
+	"github.com/github/git-lfs/tools"
 )
 
 type packetReader struct {
@@ -19,7 +20,7 @@ func (r *packetReader) Read(p []byte) (int, error) {
 	if len(r.buf) > 0 {
 		// If there is data in the buffer, shift as much out of it and
 		// into the given "p" as we can.
-		n = int(math.Min(float64(len(p)), float64(len(r.buf))))
+		n = tools.MinInt(len(p), len(r.buf))
 
 		copy(p, r.buf[:n])
 		r.buf = r.buf[n:]
@@ -43,7 +44,7 @@ func (r *packetReader) Read(p []byte) (int, error) {
 		}
 
 		// Figure out how much of the packet we can read into "p".
-		nn := int(math.Min(float64(len(chunk)), float64(len(p))))
+		nn := tools.MinInt(len(chunk), len(p))
 
 		// Move that amount into "p", from where we left off.
 		copy(p[n:], chunk[:nn])

--- a/git/packet_reader_test.go
+++ b/git/packet_reader_test.go
@@ -1,0 +1,142 @@
+package git
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// writePackets
+func writePacket(w io.Writer, datas ...[]byte) {
+	for _, data := range datas {
+		io.WriteString(w, fmt.Sprintf("%04x", len(data)+4))
+		w.Write(data)
+
+	}
+	io.WriteString(w, fmt.Sprintf("%04x", 0))
+}
+
+func TestPacketReaderReadsSinglePacketsInOneCall(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("asdf"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	data, err := ioutil.ReadAll(pr)
+
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("asdf"), data)
+}
+
+func TestPacketReaderReadsManyPacketsInOneCall(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("first\n"), []byte("second"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	data, err := ioutil.ReadAll(pr)
+
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("first\nsecond"), data)
+}
+
+func TestPacketReaderReadsSinglePacketsInMultipleCallsWithUnevenBuffering(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("asdf"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	var p1 [3]byte
+	var p2 [1]byte
+
+	n1, e1 := pr.Read(p1[:])
+	assert.Equal(t, 3, n1)
+	assert.Equal(t, []byte("asd"), p1[:])
+	assert.Nil(t, e1)
+
+	n2, e2 := pr.Read(p2[:])
+	assert.Equal(t, 1, n2)
+	assert.Equal(t, []byte("f"), p2[:])
+	assert.Equal(t, io.EOF, e2)
+}
+
+func TestPacketReaderReadsManyPacketsInMultipleCallsWithUnevenBuffering(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("first"), []byte("second"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	var p1 [4]byte
+	var p2 [7]byte
+	var p3 []byte
+
+	n1, e1 := pr.Read(p1[:])
+	assert.Equal(t, 4, n1)
+	assert.Equal(t, []byte("firs"), p1[:])
+	assert.Nil(t, e1)
+
+	n2, e2 := pr.Read(p2[:])
+	assert.Equal(t, 7, n2)
+	assert.Equal(t, []byte("tsecond"), p2[:])
+	assert.Equal(t, nil, e2)
+
+	n3, e3 := pr.Read(p3[:])
+	assert.Equal(t, 0, n3)
+	assert.Empty(t, p3)
+	assert.Equal(t, io.EOF, e3)
+}
+
+func TestPacketReaderReadsSinglePacketsInMultipleCallsWithEvenBuffering(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("firstother"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	var p1 [5]byte
+	var p2 [5]byte
+
+	n1, e1 := pr.Read(p1[:])
+	assert.Equal(t, 5, n1)
+	assert.Equal(t, []byte("first"), p1[:])
+	assert.Nil(t, e1)
+
+	n2, e2 := pr.Read(p2[:])
+	assert.Equal(t, 5, n2)
+	assert.Equal(t, []byte("other"), p2[:])
+	assert.Equal(t, io.EOF, e2)
+}
+
+func TestPacketReaderReadsManyPacketsInMultipleCallsWithEvenBuffering(t *testing.T) {
+	var buf bytes.Buffer
+
+	writePacket(&buf, []byte("first"), []byte("other"))
+
+	pr := &packetReader{proto: newProtocolRW(&buf, nil)}
+
+	var p1 [5]byte
+	var p2 [5]byte
+	var p3 []byte
+
+	n1, e1 := pr.Read(p1[:])
+	assert.Equal(t, 5, n1)
+	assert.Equal(t, []byte("first"), p1[:])
+	assert.Nil(t, e1)
+
+	n2, e2 := pr.Read(p2[:])
+	assert.Equal(t, 5, n2)
+	assert.Equal(t, []byte("other"), p2[:])
+	assert.Equal(t, nil, e2)
+
+	n3, e3 := pr.Read(p3)
+	assert.Equal(t, 0, n3)
+	assert.Equal(t, io.EOF, e3)
+}

--- a/git/packet_writer.go
+++ b/git/packet_writer.go
@@ -1,0 +1,124 @@
+package git
+
+import (
+	"io"
+
+	"github.com/github/git-lfs/tools"
+)
+
+type PacketWriter struct {
+	// buf is an internal buffer used to store data until enough has been
+	// collected to write a full packet, or the buffer was instructed to
+	// flush.
+	buf []byte
+	// proto is the place where packets get written.
+	proto *protocol
+}
+
+var _ io.Writer = new(PacketWriter)
+
+// NewPacketWriter returns a new *PacketWriter, which will write to the
+// underlying data stream "w". The internal buffer is initialized with the given
+// capacity, "c".
+//
+// If "w" is already a `*PacketWriter`, it will be returned as-is.
+func NewPacketWriter(w io.Writer, c int) *PacketWriter {
+	if pw, ok := w.(*PacketWriter); ok {
+		return pw
+	}
+
+	return &PacketWriter{
+		buf:   make([]byte, 0, c),
+		proto: newProtocolRW(nil, w),
+	}
+}
+
+// Write implements the io.Writer interface's `Write` method by providing a
+// packet-based backend to the given buffer "p".
+//
+// As many bytes are removed from "p" as possible and stored in an internal
+// buffer until the amount of data in the internal buffer is enough to write a
+// single packet. Once the internal buffer is full, a packet is written to the
+// underlying stream of data, and the process repeats.
+//
+// When the caller has no more data to write in the given chunk of packets, a
+// subsequent call to `Write(p []byte)` MUST be made with a nil slice, to flush
+// the remaining data in the buffer, and write the terminating bytes to the
+// underlying packet stream.
+//
+// Write returns the number of bytes in "p" accepted into the writer, which
+// _MAY_ be written to the underlying protocol stream, or may be written into
+// the internal buffer.
+//
+// If any error was encountered while either buffering or writing, that
+// error is returned, along with the number of bytes written to the underlying
+// protocol stream, as described above.
+func (w *PacketWriter) Write(p []byte) (int, error) {
+	var n int
+
+	if p == nil {
+		// If we got an empty sequence of bytes, let's flush the data
+		// stored in the buffer, and then write the a packet termination
+		// sequence.
+
+		if _, err := w.flush(); err != nil {
+			return 0, err
+		}
+
+		if err := w.proto.writeFlush(); err != nil {
+			return 0, err
+		}
+	}
+
+	for len(p) > 0 {
+		// While there is still data left to process in "p", grab as
+		// much of it as we can while not allowing the internal buffer
+		// to exceed the MaxPacketLength const.
+		m := tools.MinInt(len(p), MaxPacketLength-len(w.buf))
+
+		// Append on all of the data that we could into the internal
+		// buffer.
+		w.buf = append(w.buf, p[:m]...)
+		// Truncate "p" such that it no longer includes the data that we
+		// have in the internal buffer.
+		p = p[m:]
+
+		n = n + m
+
+		if len(w.buf) == MaxPacketLength {
+			// If we were able to grab an entire packet's worth of
+			// data, flush the buffer.
+
+			if _, err := w.flush(); err != nil {
+				return n, err
+			}
+
+		}
+	}
+
+	return n, nil
+}
+
+// flush writes any data in the internal buffer out to the underlying protocol
+// stream. If the amount of data in the internal buffer exceeds the
+// MaxPacketLength, the data will be written in multiple packets to accommodate.
+//
+// flush returns the number of bytes written to the underlying packet stream,
+// and any error that it encountered along the way.
+func (w *PacketWriter) flush() (int, error) {
+	var n int
+
+	for len(w.buf) > 0 {
+		if err := w.proto.writePacket(w.buf); err != nil {
+			return 0, err
+		}
+
+		m := tools.MinInt(len(w.buf), MaxPacketLength)
+
+		w.buf = w.buf[m:]
+
+		n = n + m
+	}
+
+	return n, nil
+}

--- a/git/packet_writer_test.go
+++ b/git/packet_writer_test.go
@@ -1,0 +1,108 @@
+package git
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPacketWriterWritesPacketsShorterThanMaxPacketSize(t *testing.T) {
+	var buf bytes.Buffer
+
+	w := NewPacketWriter(&buf, 0)
+	assertWriterWrite(t, w, []byte("Hello, world!"), 13)
+	assertWriterWrite(t, w, nil, 0)
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, []byte("Hello, world!"))
+	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterWritesPacketsEqualToMaxPacketLength(t *testing.T) {
+	big := make([]byte, MaxPacketLength)
+	for i, _ := range big {
+		big[i] = 1
+	}
+
+	// Make a copy so that we can drain the data inside of it
+	p := make([]byte, MaxPacketLength)
+	copy(p, big)
+
+	var buf bytes.Buffer
+
+	w := NewPacketWriter(&buf, 0)
+	assertWriterWrite(t, w, p, len(big))
+	assertWriterWrite(t, w, nil, 0)
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, big)
+	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterWritesMultiplePacketsLessThanMaxPacketLength(t *testing.T) {
+	var buf bytes.Buffer
+
+	w := NewPacketWriter(&buf, 0)
+	assertWriterWrite(t, w, []byte("first\n"), len("first\n"))
+	assertWriterWrite(t, w, []byte("second"), len("second"))
+	assertWriterWrite(t, w, nil, 0)
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, []byte("first\nsecond"))
+	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterWritesMultiplePacketsGreaterThanMaxPacketLength(t *testing.T) {
+	var buf bytes.Buffer
+
+	b1 := make([]byte, MaxPacketLength*3/4)
+	p1 := make([]byte, len(b1))
+	for i, _ := range b1 {
+		b1[i] = 1
+	}
+	copy(p1, b1)
+
+	b2 := make([]byte, MaxPacketLength*3/4)
+	p2 := make([]byte, len(b2))
+	for i, _ := range b2 {
+		b2[i] = 1
+	}
+	copy(p2, b1)
+
+	w := NewPacketWriter(&buf, 0)
+	assertWriterWrite(t, w, p1, len(p1))
+	assertWriterWrite(t, w, p2, len(p2))
+	assertWriterWrite(t, w, nil, 0)
+
+	// offs is how far into b2 we needed to buffer before writing an entire
+	// packet
+	offs := MaxPacketLength - len(b1)
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, append(b1, b2[:offs]...))
+	assertPacketRead(t, proto, b2[offs:])
+	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterDoesntWrapItself(t *testing.T) {
+	itself := &PacketWriter{}
+	nw := NewPacketWriter(itself, 0)
+
+	assert.Equal(t, itself, nw)
+}
+
+func assertWriterWrite(t *testing.T, w io.Writer, p []byte, plen int) {
+	n, err := w.Write(p)
+
+	assert.Nil(t, err)
+	assert.Equal(t, plen, n)
+}
+
+func assertPacketRead(t *testing.T, proto *protocol, expected []byte) {
+	got, err := proto.readPacket()
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, got)
+}

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -113,7 +113,7 @@ func DecodeFrom(reader io.Reader) ([]byte, *Pointer, error) {
 	written, err := reader.Read(buf)
 	output := buf[0:written]
 
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return output, nil, err
 	}
 

--- a/lfs/pointer_clean.go
+++ b/lfs/pointer_clean.go
@@ -82,8 +82,14 @@ func copyToTemp(reader io.Reader, fileSize int64, cb progress.CopyCallback) (oid
 		return
 	}
 
-	multi := io.MultiReader(bytes.NewReader(by), reader)
-	size, err = tools.CopyWithCallback(writer, multi, fileSize, cb)
+	var from io.Reader = bytes.NewReader(by)
+	if int64(len(by)) < fileSize {
+		// If there is still more data to be read from the file, tack on
+		// the original reader and continue the read from there.
+		from = io.MultiReader(from, reader)
+	}
+
+	size, err = tools.CopyWithCallback(writer, from, fileSize, cb)
 
 	if err != nil {
 		return

--- a/lfs/pointer_test.go
+++ b/lfs/pointer_test.go
@@ -3,7 +3,6 @@ package lfs
 import (
 	"bufio"
 	"bytes"
-	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -170,17 +169,10 @@ size 12345`
 
 func TestDecodeFromEmptyReader(t *testing.T) {
 	by, p, err := DecodeFrom(strings.NewReader(""))
-	if err != io.EOF {
-		t.Fatalf("unexpected error: %v", err)
-	}
 
-	if p != nil {
-		t.Fatalf("Unexpected pointer: %v", p)
-	}
-
-	if string(by) != "" {
-		t.Fatalf("unexpected result: '%s'", string(by))
-	}
+	assert.EqualError(t, err, "Pointer file error: invalid header")
+	assert.Nil(t, p)
+	assert.Empty(t, string(by))
 }
 
 func TestDecodeInvalid(t *testing.T) {

--- a/tools/math.go
+++ b/tools/math.go
@@ -1,0 +1,17 @@
+package tools
+
+func MinInt(a, b int) int {
+	if a < b {
+		return a
+	}
+
+	return b
+}
+
+func MaxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+
+	return b
+}

--- a/tools/math_test.go
+++ b/tools/math_test.go
@@ -1,0 +1,15 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func MinIntPicksTheSmallerInt(t *testing.T) {
+	assert.Equal(t, -1, MinInt(-1, 1))
+}
+
+func MaxIntPicksTheBiggertInt(t *testing.T) {
+	assert.Equal(t, 1, MaxInt(-1, 1))
+}


### PR DESCRIPTION
This pull-request provides an implementation of the `io.Reader` interface that can read data encoded with the protocol used for filter process communication.

This provides a huge savings on memory usage when cleaning files, as the shasum of the contents can be calculated as data is streamed in, and then discarded.

This pull request is implemented in three parts:

- https://github.com/github/git-lfs/commit/4524d1221efc54d82f4a409208e0d83a56a1c78e: Implement the underlying `PacketReader`.
- https://github.com/github/git-lfs/commit/d23c0445f4580d6b82345ae3613bf47ecaff482a: Make the `WriteStatus` method public since reading packets no longer reports success/error statuses, and this responsibility will be delegated to the caller in the following commit...
- https://github.com/github/git-lfs/commit/2db63047c028811deeab1b8462e44251304164ca: use an `io.Reader` as the `Payload` field of a request, instead of buffering the data upfront.

Some notes on the implementation:

- There is no "offset" encoded into where the reader starts and stops. This means that a given packet run must be _completely_ consumed before the next one is read. The code as it currently stands within this branch, does obey that rule as the synchronization is done with the loop condition, `scanner.Scan()`.
- The implementation is safe to call with buffers shorter or longer than the packet that is being read. Any data that wont fit into the current given buffer will be sent to an internal buffer, and subsequent calls to `Read(p []byte)` will read first from the internal buffer until the internal buffer is drained.
- An `io.EOF` is returned on the first call to `Read()` _after_ all of the data has been consumed. This is done to avoid a complicated implementation dealing with peeking bytes to see if more data is incoming. Luckily, the Go documentation allows for this (meaning things like `io.Copy`, etc will respect it):

> An instance of this general case is that a Reader returning a non-zero number of bytes at the end of the input stream may return either err == EOF or err == nil. The next Read should return 0, EOF.

(See: https://golang.org/pkg/io#Reader).

---

/cc @larsxschneider @technoweenie @sinbad @rubyist @sschuberth 