### PR TITLE
filter_stream: provide io.Writer implementation

### DIFF
--- a/commands/command_filter.go
+++ b/commands/command_filter.go
@@ -131,8 +131,7 @@ func smudge(to io.Writer, reader io.Reader, filename string) error {
 		download = false
 	}
 
-	sbuf := new(bytes.Buffer)
-	err = ptr.Smudge(sbuf, filename, download, TransferManifest(), cb)
+	err = ptr.Smudge(to, filename, download, TransferManifest(), cb)
 	if file != nil {
 		file.Close()
 	}
@@ -151,8 +150,7 @@ func smudge(to io.Writer, reader io.Reader, filename string) error {
 		return err
 	}
 
-	_, err = ptr.Encode(to)
-	return err
+	return nil
 }
 
 func filterCommand(cmd *cobra.Command, args []string) {

--- a/commands/command_filter.go
+++ b/commands/command_filter.go
@@ -171,7 +171,13 @@ Scan:
 	for s.Scan() {
 		var err error
 
-		switch req := s.Request(); req.Header["command"] {
+		req := s.Request()
+		if req == nil {
+			break
+		}
+		s.WriteStatus("success")
+
+		switch req.Header["command"] {
 		case "clean":
 			err = clean(w, req.Payload, req.Header["pathname"])
 		case "smudge":

--- a/commands/command_filter.go
+++ b/commands/command_filter.go
@@ -59,12 +59,11 @@ func clean(to io.Writer, reader io.Reader, fileName string) error {
 	}
 
 	if errors.IsCleanPointerError(err) {
-		// TODO: report errors differently!
-		// os.Stdout.Write(errors.GetContext(err, "bytes").([]byte))
-		// return errors.GetContext(err, "bytes").([]byte), nil
-
-		// TODO(taylor): what does this mean?
-		return nil
+		// If the contents read from the working directory was _already_
+		// a pointer, we'll get a `CleanPointerError`, with the context
+		// containing the bytes that we should write back out to Git.
+		_, err = to.Write(errors.GetContext(err, "bytes").([]byte))
+		return err
 	}
 
 	if err != nil {

--- a/commands/command_filter.go
+++ b/commands/command_filter.go
@@ -18,7 +18,7 @@ var (
 	filterSmudgeSkip = false
 )
 
-func clean(reader io.Reader, fileName string) ([]byte, error) {
+func clean(to io.Writer, reader io.Reader, fileName string) error {
 	var cb progress.CopyCallback
 	var file *os.File
 	var fileSize int64
@@ -49,7 +49,10 @@ func clean(reader io.Reader, fileName string) ([]byte, error) {
 	if errors.IsCleanPointerError(err) {
 		// TODO: report errors differently!
 		// os.Stdout.Write(errors.GetContext(err, "bytes").([]byte))
-		return errors.GetContext(err, "bytes").([]byte), nil
+		// return errors.GetContext(err, "bytes").([]byte), nil
+
+		// TODO(taylor): what does this mean?
+		return nil
 	}
 
 	if err != nil {
@@ -75,10 +78,11 @@ func clean(reader io.Reader, fileName string) ([]byte, error) {
 		Debug("Writing %s", mediafile)
 	}
 
-	return []byte(cleaned.Pointer.Encoded()), nil
+	_, err = cleaned.Pointer.Encode(to)
+	return err
 }
 
-func smudge(reader io.Reader, filename string) ([]byte, error) {
+func smudge(to io.Writer, reader io.Reader, filename string) error {
 	var pbuf bytes.Buffer
 	reader = io.TeeReader(reader, &pbuf)
 
@@ -93,10 +97,13 @@ func smudge(reader io.Reader, filename string) ([]byte, error) {
 		// TODO(taylor): figure out if there is more data on the reader,
 		// and buffer that as well.
 		if len(pbuf.Bytes()) == 0 {
-			return pbuf.Bytes(), nil
+			if _, cerr := io.Copy(to, &pbuf); cerr != nil {
+				Panic(cerr, "Error writing data to stdout:")
+			}
+			return nil
 		}
 
-		return pbuf.Bytes(), err
+		return err
 	}
 
 	lfs.LinkOrCopyFromReference(ptr.Oid, ptr.Size)
@@ -113,8 +120,8 @@ func smudge(reader io.Reader, filename string) ([]byte, error) {
 		download = false
 	}
 
-	buf := new(bytes.Buffer)
-	err = ptr.Smudge(buf, filename, download, TransferManifest(), cb)
+	sbuf := new(bytes.Buffer)
+	err = ptr.Smudge(sbuf, filename, download, TransferManifest(), cb)
 	if file != nil {
 		file.Close()
 	}
@@ -129,10 +136,12 @@ func smudge(reader io.Reader, filename string) ([]byte, error) {
 			}
 		}
 
-		return []byte(ptr.Encoded()), nil
+		_, err = ptr.Encode(to)
+		return err
 	}
 
-	return buf.Bytes(), nil
+	_, err = ptr.Encode(to)
+	return err
 }
 
 func filterCommand(cmd *cobra.Command, args []string) {
@@ -140,6 +149,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 	lfs.InstallHooks(false)
 
 	s := git.NewObjectScanner(os.Stdin, os.Stdout)
+	w := git.NewPacketWriter(os.Stdout)
 
 	if err := s.Init(); err != nil {
 		ExitWithError(err)
@@ -150,29 +160,29 @@ func filterCommand(cmd *cobra.Command, args []string) {
 
 Scan:
 	for s.Scan() {
-		req := s.Request()
-
-		// TODO:
-		// clean/smudge should also take a Writer instead of returning []byte
-		var outputData []byte
 		var err error
 
-		switch req.Header["command"] {
+		switch req := s.Request(); req.Header["command"] {
 		case "clean":
-			outputData, err = clean(req.Payload, req.Header["pathname"])
+			err = clean(w, req.Payload, req.Header["pathname"])
 		case "smudge":
-			outputData, err = smudge(req.Payload, req.Header["pathname"])
+			err = smudge(w, req.Payload, req.Header["pathname"])
 		default:
 			fmt.Errorf("Unknown command %s", cmd)
 			break Scan
 		}
 
-		if err != nil && err != io.EOF {
-			s.WriteStatus("error")
-		} else {
-			s.WriteStatus("success")
-			s.WriteResponse(outputData)
+		if err == nil {
+			_, err = w.Write(nil)
 		}
+
+		var status string
+		if err != nil && err != io.EOF {
+			status = "error"
+		} else {
+			status = "success"
+		}
+		s.WriteStatus(status)
 	}
 
 	if err := s.Err(); err != nil && err != io.EOF {

--- a/commands/command_filter.go
+++ b/commands/command_filter.go
@@ -187,15 +187,15 @@ Scan:
 			break Scan
 		}
 
-		if err == nil {
-			_, err = w.Write(nil)
-		}
-
 		var status string
-		if err != nil && err != io.EOF {
+		if _, ferr := w.Write(nil); ferr != nil {
 			status = "error"
 		} else {
-			status = "success"
+			if err != nil && err != io.EOF {
+				status = "error"
+			} else {
+				status = "success"
+			}
 		}
 		s.WriteStatus(status)
 	}

--- a/commands/command_filter.go
+++ b/commands/command_filter.go
@@ -158,6 +158,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 	lfs.InstallHooks(false)
 
 	s := git.NewObjectScanner(os.Stdin, os.Stdout)
+	w := git.NewPacketWriter(os.Stdout, 0)
 
 	if err := s.Init(); err != nil {
 		ExitWithError(err)
@@ -169,14 +170,11 @@ func filterCommand(cmd *cobra.Command, args []string) {
 Scan:
 	for s.Scan() {
 		var err error
-		var w io.Writer
 
 		switch req := s.Request(); req.Header["command"] {
 		case "clean":
-			w = git.NewPacketWriter(os.Stdout, cleanFilterBufferCapacity)
 			err = clean(w, req.Payload, req.Header["pathname"])
 		case "smudge":
-			w = git.NewPacketWriter(os.Stdout, smudgeFilterBufferCapacity)
 			err = smudge(w, req.Payload, req.Header["pathname"])
 		default:
 			fmt.Errorf("Unknown command %s", cmd)

--- a/git/packet_writer.go
+++ b/git/packet_writer.go
@@ -1,0 +1,107 @@
+package git
+
+import (
+	"io"
+	"math"
+)
+
+type PacketWriter struct {
+	// buf is the internal buffer of bytes used to store data given in calls
+	// to Write that don't warrant a protocol write.
+	buf []byte
+	// proto is the place where packets get written.
+	proto *protocol
+}
+
+var _ io.Writer = new(PacketWriter)
+
+// Write implements the io.Writer interface's `Write` method by providing a
+// packet-based backend to the given buffer "p".
+//
+// As many bytes are removed from "p" as possible and stored in an internal
+// buffer until the amount of data in the internal buffer is enough to write a
+// single packet. Once the internal buffer is full, a packet is written to the
+// underlying stream of data, and the process repeats.
+//
+// When the caller has no more data to write in the given chunk of packets, a
+// subsequent call to `Write(p []byte)` MUST be made with an empty slice, to
+// flush the remaining data in the buffer, and write the terminating bytes to
+// the underlying packet stream.
+//
+// Write returns the number of bytes in "p" actually written to the underlying
+// protocol stream, not including the number of bytes written in those packets
+// headers. If any error was encountered while either buffering or writing, that
+// error is returned, along with the number of bytes written to the underlying
+// protocol stream, as described above.
+func (w *PacketWriter) Write(p []byte) (int, error) {
+	var n int
+
+	if len(p) == 0 {
+		// If we got an empty sequence of bytes, let's flush the data
+		// stored in the buffer, and then write the a packet termination
+		// sequence.
+
+		flushed, err := w.flush()
+		if err != nil {
+			return 0, err
+		}
+
+		n = n + flushed
+
+		if err = w.proto.writeFlush(); err != nil {
+			return n, err
+		}
+	}
+
+	for len(p) > 0 {
+		// While there is still data left to process in "p", grab as
+		// much of it as we can while not allowing the internal buffer
+		// to exceed the MaxPacketLength const.
+		m := int(math.Min(float64(len(p)), float64(MaxPacketLength-len(w.buf))))
+
+		// Append on all of the data that we could into the internal
+		// buffer.
+		w.buf = append(w.buf, p[:m]...)
+		// Truncate "p" such that it no longer includes the data that we
+		// have in the internal buffer.
+		p = p[m:]
+
+		if len(w.buf) == MaxPacketLength {
+			// If we were able to grab an entire packet's worth of
+			// data, flush the buffer.
+
+			flushed, err := w.flush()
+			if err != nil {
+				return n, err
+			}
+
+			n = n + flushed
+		}
+	}
+
+	return n, nil
+}
+
+// flush writes any data in the internal buffer out to the underlying protocol
+// stream. If the amount of data in the internal buffer exceeds the
+// MaxPacketLength, the data will be written in multiple packets to accommodate.
+//
+// flush returns the number of bytes written to the underlying packet stream,
+// and any error that it encountered along the way.
+func (w *PacketWriter) flush() (int, error) {
+	var n int
+
+	for len(w.buf) > 0 {
+		if err := w.proto.writePacket(w.buf); err != nil {
+			return 0, err
+		}
+
+		m := int(math.Min(float64(len(w.buf)), float64(MaxPacketLength)))
+
+		w.buf = w.buf[m:]
+
+		n = n + m
+	}
+
+	return n, nil
+}

--- a/git/packet_writer.go
+++ b/git/packet_writer.go
@@ -15,6 +15,18 @@ type PacketWriter struct {
 
 var _ io.Writer = new(PacketWriter)
 
+// NewPacketWriter returns a new *PacketWriter, which will write to teh
+// underlying data stream "w".
+//
+// If "w" is already a `*PacketWriter`, it will be returned as-is.
+func NewPacketWriter(w io.Writer) *PacketWriter {
+	if pw, ok := w.(*PacketWriter); ok {
+		return pw
+	}
+
+	return &PacketWriter{proto: newProtocolRW(nil, w)}
+}
+
 // Write implements the io.Writer interface's `Write` method by providing a
 // packet-based backend to the given buffer "p".
 //

--- a/git/packet_writer.go
+++ b/git/packet_writer.go
@@ -7,8 +7,9 @@ import (
 )
 
 type PacketWriter struct {
-	// buf is the internal buffer of bytes used to store data given in calls
-	// to Write that don't warrant a protocol write.
+	// buf is an internal buffer used to store data until enough has been
+	// collected to write a full packet, or the buffer was instructed to
+	// flush.
 	buf []byte
 	// proto is the place where packets get written.
 	proto *protocol

--- a/git/packet_writer.go
+++ b/git/packet_writer.go
@@ -37,9 +37,9 @@ func NewPacketWriter(w io.Writer) *PacketWriter {
 // underlying stream of data, and the process repeats.
 //
 // When the caller has no more data to write in the given chunk of packets, a
-// subsequent call to `Write(p []byte)` MUST be made with an empty slice, to
-// flush the remaining data in the buffer, and write the terminating bytes to
-// the underlying packet stream.
+// subsequent call to `Write(p []byte)` MUST be made with a nil slice, to flush
+// the remaining data in the buffer, and write the terminating bytes to the
+// underlying packet stream.
 //
 // Write returns the number of bytes in "p" actually written to the underlying
 // protocol stream, not including the number of bytes written in those packets
@@ -49,7 +49,7 @@ func NewPacketWriter(w io.Writer) *PacketWriter {
 func (w *PacketWriter) Write(p []byte) (int, error) {
 	var n int
 
-	if len(p) == 0 {
+	if p == nil {
 		// If we got an empty sequence of bytes, let's flush the data
 		// stored in the buffer, and then write the a packet termination
 		// sequence.

--- a/git/packet_writer.go
+++ b/git/packet_writer.go
@@ -16,16 +16,20 @@ type PacketWriter struct {
 
 var _ io.Writer = new(PacketWriter)
 
-// NewPacketWriter returns a new *PacketWriter, which will write to teh
-// underlying data stream "w".
+// NewPacketWriter returns a new *PacketWriter, which will write to the
+// underlying data stream "w". The internal buffer is initialized with the given
+// capacity, "c".
 //
 // If "w" is already a `*PacketWriter`, it will be returned as-is.
-func NewPacketWriter(w io.Writer) *PacketWriter {
+func NewPacketWriter(w io.Writer, c int) *PacketWriter {
 	if pw, ok := w.(*PacketWriter); ok {
 		return pw
 	}
 
-	return &PacketWriter{proto: newProtocolRW(nil, w)}
+	return &PacketWriter{
+		buf:   make([]byte, 0, c),
+		proto: newProtocolRW(nil, w),
+	}
 }
 
 // Write implements the io.Writer interface's `Write` method by providing a

--- a/git/packet_writer.go
+++ b/git/packet_writer.go
@@ -2,7 +2,8 @@ package git
 
 import (
 	"io"
-	"math"
+
+	"github.com/github/git-lfs/tools"
 )
 
 type PacketWriter struct {
@@ -69,7 +70,7 @@ func (w *PacketWriter) Write(p []byte) (int, error) {
 		// While there is still data left to process in "p", grab as
 		// much of it as we can while not allowing the internal buffer
 		// to exceed the MaxPacketLength const.
-		m := int(math.Min(float64(len(p)), float64(MaxPacketLength-len(w.buf))))
+		m := tools.MinInt(len(p), MaxPacketLength-len(w.buf))
 
 		// Append on all of the data that we could into the internal
 		// buffer.
@@ -108,7 +109,7 @@ func (w *PacketWriter) flush() (int, error) {
 			return 0, err
 		}
 
-		m := int(math.Min(float64(len(w.buf)), float64(MaxPacketLength)))
+		m := tools.MinInt(len(w.buf), MaxPacketLength)
 
 		w.buf = w.buf[m:]
 

--- a/git/packet_writer_test.go
+++ b/git/packet_writer_test.go
@@ -1,0 +1,101 @@
+package git
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPacketWriterWritesPacketsShorterThanMaxPacketSize(t *testing.T) {
+	var buf bytes.Buffer
+
+	w := &PacketWriter{proto: newProtocolRW(nil, &buf)}
+	assertWriterWrite(t, w, []byte("Hello, world!"), 0)
+	assertWriterWrite(t, w, []byte{}, len("Hello, world!"))
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, []byte("Hello, world!"))
+	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterWritesPacketsEqualToMaxPacketLength(t *testing.T) {
+	big := make([]byte, MaxPacketLength)
+	for i, _ := range big {
+		big[i] = 1
+	}
+
+	// Make a copy so that we can drain the data inside of it
+	p := make([]byte, MaxPacketLength)
+	copy(p, big)
+
+	var buf bytes.Buffer
+
+	w := &PacketWriter{proto: newProtocolRW(nil, &buf)}
+	assertWriterWrite(t, w, p, len(big))
+	assertWriterWrite(t, w, []byte{}, 0)
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, big)
+	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterWritesMultiplePacketsLessThanMaxPacketLength(t *testing.T) {
+	var buf bytes.Buffer
+
+	w := &PacketWriter{proto: newProtocolRW(nil, &buf)}
+	assertWriterWrite(t, w, []byte("first\n"), 0)
+	assertWriterWrite(t, w, []byte("second"), 0)
+	assertWriterWrite(t, w, []byte{}, len("first\nsecond"))
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, []byte("first\nsecond"))
+	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterWritesMultiplePacketsGreaterThanMaxPacketLength(t *testing.T) {
+	var buf bytes.Buffer
+
+	b1 := make([]byte, MaxPacketLength*3/4)
+	p1 := make([]byte, len(b1))
+	for i, _ := range b1 {
+		b1[i] = 1
+	}
+	copy(p1, b1)
+
+	b2 := make([]byte, MaxPacketLength*3/4)
+	p2 := make([]byte, len(b2))
+	for i, _ := range b2 {
+		b2[i] = 1
+	}
+	copy(p2, b1)
+
+	w := &PacketWriter{proto: newProtocolRW(nil, &buf)}
+	assertWriterWrite(t, w, p1, 0)
+	assertWriterWrite(t, w, p2, MaxPacketLength)
+	assertWriterWrite(t, w, []byte{}, (len(b1)+len(b2))-MaxPacketLength)
+
+	// offs is how far into b2 we needed to buffer before writing an entire
+	// packet
+	offs := MaxPacketLength - len(b1)
+
+	proto := newProtocolRW(&buf, nil)
+	assertPacketRead(t, proto, append(b1, b2[:offs]...))
+	assertPacketRead(t, proto, b2[offs:])
+	assertPacketRead(t, proto, nil)
+}
+
+func assertWriterWrite(t *testing.T, w io.Writer, p []byte, plen int) {
+	n, err := w.Write(p)
+
+	assert.Nil(t, err)
+	assert.Equal(t, plen, n)
+}
+
+func assertPacketRead(t *testing.T, proto *protocol, expected []byte) {
+	got, err := proto.readPacket()
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, got)
+}

--- a/git/packet_writer_test.go
+++ b/git/packet_writer_test.go
@@ -11,7 +11,7 @@ import (
 func TestPacketWriterWritesPacketsShorterThanMaxPacketSize(t *testing.T) {
 	var buf bytes.Buffer
 
-	w := &PacketWriter{proto: newProtocolRW(nil, &buf)}
+	w := NewPacketWriter(&buf)
 	assertWriterWrite(t, w, []byte("Hello, world!"), 0)
 	assertWriterWrite(t, w, []byte{}, len("Hello, world!"))
 
@@ -32,7 +32,7 @@ func TestPacketWriterWritesPacketsEqualToMaxPacketLength(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	w := &PacketWriter{proto: newProtocolRW(nil, &buf)}
+	w := NewPacketWriter(&buf)
 	assertWriterWrite(t, w, p, len(big))
 	assertWriterWrite(t, w, []byte{}, 0)
 
@@ -44,7 +44,7 @@ func TestPacketWriterWritesPacketsEqualToMaxPacketLength(t *testing.T) {
 func TestPacketWriterWritesMultiplePacketsLessThanMaxPacketLength(t *testing.T) {
 	var buf bytes.Buffer
 
-	w := &PacketWriter{proto: newProtocolRW(nil, &buf)}
+	w := NewPacketWriter(&buf)
 	assertWriterWrite(t, w, []byte("first\n"), 0)
 	assertWriterWrite(t, w, []byte("second"), 0)
 	assertWriterWrite(t, w, []byte{}, len("first\nsecond"))
@@ -71,7 +71,7 @@ func TestPacketWriterWritesMultiplePacketsGreaterThanMaxPacketLength(t *testing.
 	}
 	copy(p2, b1)
 
-	w := &PacketWriter{proto: newProtocolRW(nil, &buf)}
+	w := NewPacketWriter(&buf)
 	assertWriterWrite(t, w, p1, 0)
 	assertWriterWrite(t, w, p2, MaxPacketLength)
 	assertWriterWrite(t, w, []byte{}, (len(b1)+len(b2))-MaxPacketLength)
@@ -84,6 +84,13 @@ func TestPacketWriterWritesMultiplePacketsGreaterThanMaxPacketLength(t *testing.
 	assertPacketRead(t, proto, append(b1, b2[:offs]...))
 	assertPacketRead(t, proto, b2[offs:])
 	assertPacketRead(t, proto, nil)
+}
+
+func TestPacketWriterDoesntWrapItself(t *testing.T) {
+	itself := &PacketWriter{}
+	nw := NewPacketWriter(itself)
+
+	assert.Equal(t, itself, nw)
 }
 
 func assertWriterWrite(t *testing.T, w io.Writer, p []byte, plen int) {

--- a/git/packet_writer_test.go
+++ b/git/packet_writer_test.go
@@ -11,7 +11,7 @@ import (
 func TestPacketWriterWritesPacketsShorterThanMaxPacketSize(t *testing.T) {
 	var buf bytes.Buffer
 
-	w := NewPacketWriter(&buf)
+	w := NewPacketWriter(&buf, 0)
 	assertWriterWrite(t, w, []byte("Hello, world!"), 0)
 	assertWriterWrite(t, w, nil, len("Hello, world!"))
 
@@ -32,7 +32,7 @@ func TestPacketWriterWritesPacketsEqualToMaxPacketLength(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	w := NewPacketWriter(&buf)
+	w := NewPacketWriter(&buf, 0)
 	assertWriterWrite(t, w, p, len(big))
 	assertWriterWrite(t, w, nil, 0)
 
@@ -44,7 +44,7 @@ func TestPacketWriterWritesPacketsEqualToMaxPacketLength(t *testing.T) {
 func TestPacketWriterWritesMultiplePacketsLessThanMaxPacketLength(t *testing.T) {
 	var buf bytes.Buffer
 
-	w := NewPacketWriter(&buf)
+	w := NewPacketWriter(&buf, 0)
 	assertWriterWrite(t, w, []byte("first\n"), 0)
 	assertWriterWrite(t, w, []byte("second"), 0)
 	assertWriterWrite(t, w, nil, len("first\nsecond"))
@@ -71,7 +71,7 @@ func TestPacketWriterWritesMultiplePacketsGreaterThanMaxPacketLength(t *testing.
 	}
 	copy(p2, b1)
 
-	w := NewPacketWriter(&buf)
+	w := NewPacketWriter(&buf, 0)
 	assertWriterWrite(t, w, p1, 0)
 	assertWriterWrite(t, w, p2, MaxPacketLength)
 	assertWriterWrite(t, w, nil, (len(b1)+len(b2))-MaxPacketLength)
@@ -88,7 +88,7 @@ func TestPacketWriterWritesMultiplePacketsGreaterThanMaxPacketLength(t *testing.
 
 func TestPacketWriterDoesntWrapItself(t *testing.T) {
 	itself := &PacketWriter{}
-	nw := NewPacketWriter(itself)
+	nw := NewPacketWriter(itself, 0)
 
 	assert.Equal(t, itself, nw)
 }

--- a/git/packet_writer_test.go
+++ b/git/packet_writer_test.go
@@ -13,7 +13,7 @@ func TestPacketWriterWritesPacketsShorterThanMaxPacketSize(t *testing.T) {
 
 	w := NewPacketWriter(&buf)
 	assertWriterWrite(t, w, []byte("Hello, world!"), 0)
-	assertWriterWrite(t, w, []byte{}, len("Hello, world!"))
+	assertWriterWrite(t, w, nil, len("Hello, world!"))
 
 	proto := newProtocolRW(&buf, nil)
 	assertPacketRead(t, proto, []byte("Hello, world!"))
@@ -34,7 +34,7 @@ func TestPacketWriterWritesPacketsEqualToMaxPacketLength(t *testing.T) {
 
 	w := NewPacketWriter(&buf)
 	assertWriterWrite(t, w, p, len(big))
-	assertWriterWrite(t, w, []byte{}, 0)
+	assertWriterWrite(t, w, nil, 0)
 
 	proto := newProtocolRW(&buf, nil)
 	assertPacketRead(t, proto, big)
@@ -47,7 +47,7 @@ func TestPacketWriterWritesMultiplePacketsLessThanMaxPacketLength(t *testing.T) 
 	w := NewPacketWriter(&buf)
 	assertWriterWrite(t, w, []byte("first\n"), 0)
 	assertWriterWrite(t, w, []byte("second"), 0)
-	assertWriterWrite(t, w, []byte{}, len("first\nsecond"))
+	assertWriterWrite(t, w, nil, len("first\nsecond"))
 
 	proto := newProtocolRW(&buf, nil)
 	assertPacketRead(t, proto, []byte("first\nsecond"))
@@ -74,7 +74,7 @@ func TestPacketWriterWritesMultiplePacketsGreaterThanMaxPacketLength(t *testing.
 	w := NewPacketWriter(&buf)
 	assertWriterWrite(t, w, p1, 0)
 	assertWriterWrite(t, w, p2, MaxPacketLength)
-	assertWriterWrite(t, w, []byte{}, (len(b1)+len(b2))-MaxPacketLength)
+	assertWriterWrite(t, w, nil, (len(b1)+len(b2))-MaxPacketLength)
 
 	// offs is how far into b2 we needed to buffer before writing an entire
 	// packet

--- a/git/packet_writer_test.go
+++ b/git/packet_writer_test.go
@@ -12,8 +12,8 @@ func TestPacketWriterWritesPacketsShorterThanMaxPacketSize(t *testing.T) {
 	var buf bytes.Buffer
 
 	w := NewPacketWriter(&buf, 0)
-	assertWriterWrite(t, w, []byte("Hello, world!"), 0)
-	assertWriterWrite(t, w, nil, len("Hello, world!"))
+	assertWriterWrite(t, w, []byte("Hello, world!"), 13)
+	assertWriterWrite(t, w, nil, 0)
 
 	proto := newProtocolRW(&buf, nil)
 	assertPacketRead(t, proto, []byte("Hello, world!"))
@@ -45,9 +45,9 @@ func TestPacketWriterWritesMultiplePacketsLessThanMaxPacketLength(t *testing.T) 
 	var buf bytes.Buffer
 
 	w := NewPacketWriter(&buf, 0)
-	assertWriterWrite(t, w, []byte("first\n"), 0)
-	assertWriterWrite(t, w, []byte("second"), 0)
-	assertWriterWrite(t, w, nil, len("first\nsecond"))
+	assertWriterWrite(t, w, []byte("first\n"), len("first\n"))
+	assertWriterWrite(t, w, []byte("second"), len("second"))
+	assertWriterWrite(t, w, nil, 0)
 
 	proto := newProtocolRW(&buf, nil)
 	assertPacketRead(t, proto, []byte("first\nsecond"))
@@ -72,9 +72,9 @@ func TestPacketWriterWritesMultiplePacketsGreaterThanMaxPacketLength(t *testing.
 	copy(p2, b1)
 
 	w := NewPacketWriter(&buf, 0)
-	assertWriterWrite(t, w, p1, 0)
-	assertWriterWrite(t, w, p2, MaxPacketLength)
-	assertWriterWrite(t, w, nil, (len(b1)+len(b2))-MaxPacketLength)
+	assertWriterWrite(t, w, p1, len(p1))
+	assertWriterWrite(t, w, p2, len(p2))
+	assertWriterWrite(t, w, nil, 0)
 
 	// offs is how far into b2 we needed to buffer before writing an entire
 	// packet


### PR DESCRIPTION
This pull-request provides an implementation of the `io.Writer` interface capable of writing packets using the Git "pktline" format to an underlying datastream.

Here's a 🔎  at some the different parts of this PR:

1. https://github.com/github/git-lfs/commit/5723bb8c016d422fa098fcdaaf1dd15e146c3e42: implement the `PacketWriter` type and add an exhaustive set of unit tests.
2. https://github.com/github/git-lfs/commit/8ab75794997d64c92dc7649abb216ce33e32fbe4: add public constructor `NewPacketWriter` which takes any `io.Writer` and returns a `*PacketWriter` wrapping that underneath. If the given writer is itself already a `*PacketWriter`, it returns that wholesale to avoid re-wrapping.
3. https://github.com/github/git-lfs/commit/a90c16285bc98ae8f7e71fea832494eeabb0caf2: Use the `io.Writer` in the `clean`/`smudge` implementation in `commands/commands_filter.go`.
4. https://github.com/github/git-lfs/commit/5e72db6a3541b21d9bbb1981e09a981a8827f26f: A quick bit of 💅  to use the new `tools.MinInt` func instead of casting `int`s to `float64`s and relying on (potentially) inaccurate results from `math.Min`.

In terms of the implementation of the `io.Writer` itself, here's a quick tour:

- Since the pktline protocol expects us to write as much data as we can in a single packet (as many bytes as we can up to and including `MaxPacketLength`), we have an internal buffer that is written to until we have ingested enough data to fill a single packet. 
- To avoid leaving data in the buffer at the end of writing a chunk of data, calling `w.Write(nil)` is a special-case signaling to write the `0000` flush packet.
- `Write(p []byte)` reports only the amount of _data_ (not including the 4-byte headers) _actually_ written to the stream. This means that `Write()` with less data than `MaxPacketLength` will return `(0, nil)`, unless there was enough data in the buffer to cause a packet to be written.
- `Write` is smart enough to write multiple packets if the given buffer "p" holds more information than a single packet can hold. It will buffer extra data that does not fit past the first `n` packets.

---

/cc @technoweenie @larsxschneider @sinbad @rubyist @sschuberth 