### PR TITLE
travis-ci: test GitLFS with ancient Git version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,22 +11,23 @@ env:
   global:
     - GIT_LFS_TEST_DIR="$HOME/git-lfs-tests"
     - GIT_SOURCE_REPO="https://github.com/git/git.git"
-    - GIT_SOURCE_BRANCH="next"
+    - GIT_EARLIEST_SUPPORTED_VERSION="v1.8.5"
+    - GIT_LATEST_SOURCE_BRANCH="master"
 
 matrix:
   fast_finish: true
   include:
-    - env: git-from-source
+    - env: git-latest-master-from-source
       os: linux
       before_script:
         - >
           git clone $GIT_SOURCE_REPO git-source;
           cd git-source;
-          git checkout $GIT_SOURCE_BRANCH;
+          git checkout $GIT_LATEST_SOURCE_BRANCH;
           make --jobs=2;
           make install;
           cd ..;
-    - env: git-from-source
+    - env: git-latest-master-from-source
       os: osx
       before_script:
         - >
@@ -36,7 +37,31 @@ matrix:
           brew link --force gettext;
           git clone $GIT_SOURCE_REPO git-source;
           cd git-source;
-          git checkout $GIT_SOURCE_BRANCH;
+          git checkout $GIT_LATEST_SOURCE_BRANCH;
+          make --jobs=2;
+          make install;
+          cd ..;
+    - env: git-earliest-supported-version-from-source
+      os: linux
+      before_script:
+        - >
+          git clone $GIT_SOURCE_REPO git-source;
+          cd git-source;
+          git checkout $GIT_EARLIEST_SUPPORTED_VERSION;
+          make --jobs=2;
+          make install;
+          cd ..;
+    - env: git-earliest-supported-version-from-source
+      os: osx
+      before_script:
+        - >
+          export NO_OPENSSL=YesPlease;
+          export APPLE_COMMON_CRYPTO=YesPlease;
+          brew install gettext;
+          brew link --force gettext;
+          git clone $GIT_SOURCE_REPO git-source;
+          cd git-source;
+          git checkout $GIT_EARLIEST_SUPPORTED_VERSION;
           make --jobs=2;
           make install;
           cd ..;


### PR DESCRIPTION
According to @technoweenie GitLFS should work with Git 1.8.2 or later:
https://github.com/github/git-lfs/issues/410#issuecomment-112976174

Git 1.8.2 is sufficient for Linux but macOS seems to require at least
Git 1.8.5 to run all integration tests. On Git 1.8.2 "test: pull" and
"test: pull with raw remote url" fail on macOS.

Details: https://travis-ci.org/github/git-lfs/jobs/174177362