### PR TITLE
'smudge --info' is deprecated in favor of 'ls-files'

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -217,7 +217,7 @@ var warningOnce sync.Once
 
 func legacyWarning() {
 	warningOnce.Do(func() {
-		fmt.Fprintln(os.Stderr, "WARNING: Git LFS is using a deprecated API, which will be removed in v1.5.0.")
+		fmt.Fprintln(os.Stderr, "WARNING: Git LFS is using a deprecated API, which will be removed in v2.0.")
 		fmt.Fprintln(os.Stderr, "         Consider enabling the latest API by running: `git config lfs.batch true`.")
 	})
 }

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -125,6 +126,8 @@ func pushCommand(cmd *cobra.Command, args []string) {
 
 	if useStdin {
 		requireStdin("Run this command from the Git pre-push hook, or leave the --stdin flag off.")
+		fmt.Fprintln(os.Stderr, "WARNING: 'git lfs push --stdin' is deprecated, and will be removed in v2.0.")
+		fmt.Fprintln(os.Stderr, "Run 'git lfs update' or ensure .git/hooks/pre-push uses 'git lfs pre-push'.")
 
 		// called from a pre-push hook!  Update the existing pre-push hook if it's
 		// one that git-lfs set.


### PR DESCRIPTION
This deprecates `git lfs smudge --info`, since `git lfs ls-files` provides us better info. 

```
$ git lfs pointer --file CHANGELOG.md | git lfs smudge -i
Git LFS pointer for CHANGELOG.md

WARNING: 'smudge --info' is deprecated and will be removed in v2.0
USE INSTEAD:
  $ git lfs pointer --file=path/to/file
  $ git lfs ls-files

20704 --
```

It also deprecates `git lfs push --stdin`, since `git lfs pre-push` exists.

```
$ echo hi | git lfs push origin master --stdin
WARNING: 'git lfs push --stdin' is deprecated, and will be removed in v2.0.
Run 'git lfs update' or ensure .git/hooks/pre-push uses 'git lfs pre-push'.
```