### PR TITLE
Remove `AllGitConfig()`

### DIFF
--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -20,7 +20,7 @@ func updateCommand(cmd *cobra.Command, args []string) {
 	requireInRepo()
 
 	lfsAccessRE := regexp.MustCompile(`\Alfs\.(.*)\.access\z`)
-	for key, value := range cfg.AllGitConfig() {
+	for key, value := range cfg.Git.All() {
 		matches := lfsAccessRE.FindStringSubmatch(key)
 		if len(matches) < 2 {
 			continue

--- a/config/config.go
+++ b/config/config.go
@@ -57,8 +57,6 @@ type Configuration struct {
 	// configuration.
 	Git Environment
 
-	gitConfig map[string]string
-
 	CurrentRemote   string
 	NtlmSession     ntlm.ClientSession
 	envVars         map[string]string
@@ -106,9 +104,8 @@ type Values struct {
 // This method should only be used during testing.
 func NewFrom(v Values) *Configuration {
 	return &Configuration{
-		Os:        EnvironmentOf(mapFetcher(v.Os)),
-		Git:       EnvironmentOf(mapFetcher(v.Git)),
-		gitConfig: v.Git,
+		Os:  EnvironmentOf(mapFetcher(v.Os)),
+		Git: EnvironmentOf(mapFetcher(v.Git)),
 
 		envVars: make(map[string]string, 0),
 	}
@@ -349,16 +346,10 @@ func (c *Configuration) SetEndpointAccess(e Endpoint, authType string) {
 	switch authType {
 	case "", "none":
 		git.Config.UnsetLocalKey("", key)
-
-		c.loading.Lock()
 		c.Git.Del(key)
-		c.loading.Unlock()
 	default:
 		git.Config.SetLocal("", key, authType)
-
-		c.loading.Lock()
-		c.gitConfig[strings.ToLower(key)] = authType
-		c.loading.Unlock()
+		c.Git.Set(key, authType)
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -351,7 +351,7 @@ func (c *Configuration) SetEndpointAccess(e Endpoint, authType string) {
 		git.Config.UnsetLocalKey("", key)
 
 		c.loading.Lock()
-		delete(c.gitConfig, strings.ToLower(key))
+		c.Git.Del(key)
 		c.loading.Unlock()
 	default:
 		git.Config.SetLocal("", key, authType)

--- a/config/config.go
+++ b/config/config.go
@@ -421,12 +421,6 @@ func (c *Configuration) SortedExtensions() ([]Extension, error) {
 	return SortExtensions(c.Extensions())
 }
 
-func (c *Configuration) AllGitConfig() map[string]string {
-	c.loadGitConfig()
-
-	return c.gitConfig
-}
-
 func (c *Configuration) urlAliases() map[string]string {
 	c.urlAliasMu.Lock()
 	defer c.urlAliasMu.Unlock()
@@ -435,7 +429,7 @@ func (c *Configuration) urlAliases() map[string]string {
 		c.urlAliasesMap = make(map[string]string)
 		prefix := "url."
 		suffix := ".insteadof"
-		for gitkey, gitval := range c.AllGitConfig() {
+		for gitkey, gitval := range c.Git.All() {
 			if strings.HasPrefix(gitkey, prefix) && strings.HasSuffix(gitkey, suffix) {
 				if _, ok := c.urlAliasesMap[gitval]; ok {
 					fmt.Fprintf(os.Stderr, "WARNING: Multiple 'url.*.insteadof' keys with the same alias: %q\n", gitval)

--- a/config/config.go
+++ b/config/config.go
@@ -346,10 +346,10 @@ func (c *Configuration) SetEndpointAccess(e Endpoint, authType string) {
 	switch authType {
 	case "", "none":
 		git.Config.UnsetLocalKey("", key)
-		c.Git.Del(key)
+		c.Git.del(key)
 	default:
 		git.Config.SetLocal("", key, authType)
-		c.Git.Set(key, authType)
+		c.Git.set(key, authType)
 	}
 }
 

--- a/config/environment.go
+++ b/config/environment.go
@@ -39,6 +39,7 @@ type Environment interface {
 	Int(key string, def int) (val int)
 
 	All() map[string]string
+	Set(key, value string)
 	Del(key string)
 }
 
@@ -89,6 +90,10 @@ func (e *environment) Int(key string, def int) (val int) {
 
 func (e *environment) All() map[string]string {
 	return e.Fetcher.All()
+}
+
+func (e *environment) Set(key, value string) {
+	e.Fetcher.Set(key, value)
 }
 
 func (e *environment) Del(key string) {

--- a/config/environment.go
+++ b/config/environment.go
@@ -38,7 +38,10 @@ type Environment interface {
 	// then it will be returned wholesale.
 	Int(key string, def int) (val int)
 
+	// All returns a copy of all the key/value pairs for the current environment.
 	All() map[string]string
+
+	// deprecated, don't use
 	set(key, value string)
 	del(key string)
 }

--- a/config/environment.go
+++ b/config/environment.go
@@ -39,6 +39,7 @@ type Environment interface {
 	Int(key string, def int) (val int)
 
 	All() map[string]string
+	Del(key string)
 }
 
 type environment struct {
@@ -88,4 +89,8 @@ func (e *environment) Int(key string, def int) (val int) {
 
 func (e *environment) All() map[string]string {
 	return e.Fetcher.All()
+}
+
+func (e *environment) Del(key string) {
+	e.Fetcher.Del(key)
 }

--- a/config/environment.go
+++ b/config/environment.go
@@ -37,6 +37,8 @@ type Environment interface {
 	// Otherwise, if the value was converted `string -> int` successfully,
 	// then it will be returned wholesale.
 	Int(key string, def int) (val int)
+
+	All() map[string]string
 }
 
 type environment struct {
@@ -82,4 +84,8 @@ func (e *environment) Int(key string, def int) (val int) {
 	}
 
 	return i
+}
+
+func (e *environment) All() map[string]string {
+	return e.Fetcher.All()
 }

--- a/config/environment.go
+++ b/config/environment.go
@@ -39,8 +39,8 @@ type Environment interface {
 	Int(key string, def int) (val int)
 
 	All() map[string]string
-	Set(key, value string)
-	Del(key string)
+	set(key, value string)
+	del(key string)
 }
 
 type environment struct {
@@ -92,10 +92,10 @@ func (e *environment) All() map[string]string {
 	return e.Fetcher.All()
 }
 
-func (e *environment) Set(key, value string) {
-	e.Fetcher.Set(key, value)
+func (e *environment) set(key, value string) {
+	e.Fetcher.set(key, value)
 }
 
-func (e *environment) Del(key string) {
-	e.Fetcher.Del(key)
+func (e *environment) del(key string) {
+	e.Fetcher.del(key)
 }

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -8,6 +8,8 @@ type Fetcher interface {
 	// determining if the key exists.
 	Get(key string) (val string, ok bool)
 
+	Set(key, value string)
+
 	All() map[string]string
 
 	Del(key string)

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -8,9 +8,9 @@ type Fetcher interface {
 	// determining if the key exists.
 	Get(key string) (val string, ok bool)
 
-	Set(key, value string)
-
 	All() map[string]string
 
-	Del(key string)
+	set(key, value string)
+
+	del(key string)
 }

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -7,4 +7,6 @@ type Fetcher interface {
 	// Get returns the string value associated with a given key and a bool
 	// determining if the key exists.
 	Get(key string) (val string, ok bool)
+
+	All() map[string]string
 }

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -9,4 +9,6 @@ type Fetcher interface {
 	Get(key string) (val string, ok bool)
 
 	All() map[string]string
+
+	Del(key string)
 }

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -8,9 +8,10 @@ type Fetcher interface {
 	// determining if the key exists.
 	Get(key string) (val string, ok bool)
 
+	// All returns a copy of all the key/value pairs for the current environment.
 	All() map[string]string
 
+	// deprecated, don't use
 	set(key, value string)
-
 	del(key string)
 }

--- a/config/git_environment.go
+++ b/config/git_environment.go
@@ -43,6 +43,12 @@ func (g *gitEnvironment) All() map[string]string {
 	return g.git.All()
 }
 
+func (g *gitEnvironment) Del(key string) {
+	g.loadGitConfig()
+
+	g.git.Del(key)
+}
+
 // loadGitConfig reads and parses the .gitconfig by calling ReadGitConfig. It
 // also sets values on the configuration instance `g.config`.
 //

--- a/config/git_environment.go
+++ b/config/git_environment.go
@@ -43,16 +43,16 @@ func (g *gitEnvironment) All() map[string]string {
 	return g.git.All()
 }
 
-func (g *gitEnvironment) Set(key, value string) {
+func (g *gitEnvironment) set(key, value string) {
 	g.loadGitConfig()
 
-	g.git.Set(key, value)
+	g.git.set(key, value)
 }
 
-func (g *gitEnvironment) Del(key string) {
+func (g *gitEnvironment) del(key string) {
 	g.loadGitConfig()
 
-	g.git.Del(key)
+	g.git.del(key)
 }
 
 // loadGitConfig reads and parses the .gitconfig by calling ReadGitConfig. It

--- a/config/git_environment.go
+++ b/config/git_environment.go
@@ -37,6 +37,7 @@ func (g *gitEnvironment) Int(key string, def int) (val int) {
 	return g.git.Int(key, def)
 }
 
+// All returns a copy of all the key/value pairs for the current git config.
 func (g *gitEnvironment) All() map[string]string {
 	g.loadGitConfig()
 

--- a/config/git_environment.go
+++ b/config/git_environment.go
@@ -43,6 +43,12 @@ func (g *gitEnvironment) All() map[string]string {
 	return g.git.All()
 }
 
+func (g *gitEnvironment) Set(key, value string) {
+	g.loadGitConfig()
+
+	g.git.Set(key, value)
+}
+
 func (g *gitEnvironment) Del(key string) {
 	g.loadGitConfig()
 
@@ -68,7 +74,6 @@ func (g *gitEnvironment) loadGitConfig() bool {
 
 	g.git = EnvironmentOf(gf)
 
-	g.config.gitConfig = gf.vals // XXX TERRIBLE
 	g.config.extensions = extensions
 
 	g.config.remotes = make([]string, 0, len(uniqRemotes))

--- a/config/git_environment.go
+++ b/config/git_environment.go
@@ -37,6 +37,12 @@ func (g *gitEnvironment) Int(key string, def int) (val int) {
 	return g.git.Int(key, def)
 }
 
+func (g *gitEnvironment) All() map[string]string {
+	g.loadGitConfig()
+
+	return g.git.All()
+}
+
 // loadGitConfig reads and parses the .gitconfig by calling ReadGitConfig. It
 // also sets values on the configuration instance `g.config`.
 //

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -126,6 +126,19 @@ func (g *GitFetcher) Get(key string) (val string, ok bool) {
 	return
 }
 
+func (g *GitFetcher) All() map[string]string {
+	newmap := make(map[string]string)
+
+	g.vmu.RLock()
+	defer g.vmu.RUnlock()
+
+	for key, value := range g.vals {
+		newmap[key] = value
+	}
+
+	return newmap
+}
+
 func getGitConfigs() (sources []*GitConfig) {
 	if lfsconfig := getFileGitConfig(".lfsconfig"); lfsconfig != nil {
 		sources = append(sources, lfsconfig)

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -139,15 +139,15 @@ func (g *GitFetcher) All() map[string]string {
 	return newmap
 }
 
-func (g *GitFetcher) Set(key, value string) {
-	g.vmu.RLock()
-	defer g.vmu.RUnlock()
+func (g *GitFetcher) set(key, value string) {
+	g.vmu.Lock()
+	defer g.vmu.Unlock()
 	g.vals[strings.ToLower(key)] = value
 }
 
-func (g *GitFetcher) Del(key string) {
-	g.vmu.RLock()
-	defer g.vmu.RUnlock()
+func (g *GitFetcher) del(key string) {
+	g.vmu.Lock()
+	defer g.vmu.Unlock()
 	delete(g.vals, strings.ToLower(key))
 }
 

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -139,6 +139,12 @@ func (g *GitFetcher) All() map[string]string {
 	return newmap
 }
 
+func (g *GitFetcher) Set(key, value string) {
+	g.vmu.RLock()
+	defer g.vmu.RUnlock()
+	g.vals[strings.ToLower(key)] = value
+}
+
 func (g *GitFetcher) Del(key string) {
 	g.vmu.RLock()
 	defer g.vmu.RUnlock()

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -139,6 +139,12 @@ func (g *GitFetcher) All() map[string]string {
 	return newmap
 }
 
+func (g *GitFetcher) Del(key string) {
+	g.vmu.RLock()
+	defer g.vmu.RUnlock()
+	delete(g.vals, strings.ToLower(key))
+}
+
 func getGitConfigs() (sources []*GitConfig) {
 	if lfsconfig := getFileGitConfig(".lfsconfig"); lfsconfig != nil {
 		sources = append(sources, lfsconfig)

--- a/config/map_fetcher.go
+++ b/config/map_fetcher.go
@@ -22,6 +22,10 @@ func (m mapFetcher) All() map[string]string {
 	return newmap
 }
 
+func (m mapFetcher) Set(key, value string) {
+	m[key] = value
+}
+
 func (m mapFetcher) Del(key string) {
 	delete(m, key)
 }

--- a/config/map_fetcher.go
+++ b/config/map_fetcher.go
@@ -13,3 +13,11 @@ func (m mapFetcher) Get(key string) (val string, ok bool) {
 	val, ok = m[key]
 	return
 }
+
+func (m mapFetcher) All() map[string]string {
+	newmap := make(map[string]string)
+	for key, value := range m {
+		newmap[key] = value
+	}
+	return newmap
+}

--- a/config/map_fetcher.go
+++ b/config/map_fetcher.go
@@ -21,3 +21,7 @@ func (m mapFetcher) All() map[string]string {
 	}
 	return newmap
 }
+
+func (m mapFetcher) Del(key string) {
+	delete(m, key)
+}

--- a/config/map_fetcher.go
+++ b/config/map_fetcher.go
@@ -22,10 +22,10 @@ func (m mapFetcher) All() map[string]string {
 	return newmap
 }
 
-func (m mapFetcher) Set(key, value string) {
+func (m mapFetcher) set(key, value string) {
 	m[key] = value
 }
 
-func (m mapFetcher) Del(key string) {
+func (m mapFetcher) del(key string) {
 	delete(m, key)
 }

--- a/config/os_fetcher.go
+++ b/config/os_fetcher.go
@@ -53,3 +53,7 @@ func (o *OsFetcher) Get(key string) (val string, ok bool) {
 
 	return v, ok
 }
+
+func (o *OsFetcher) All() map[string]string {
+	return nil
+}

--- a/config/os_fetcher.go
+++ b/config/os_fetcher.go
@@ -57,3 +57,5 @@ func (o *OsFetcher) Get(key string) (val string, ok bool) {
 func (o *OsFetcher) All() map[string]string {
 	return nil
 }
+
+func (o *OsFetcher) Del(key string) {}

--- a/config/os_fetcher.go
+++ b/config/os_fetcher.go
@@ -58,6 +58,10 @@ func (o *OsFetcher) All() map[string]string {
 	return nil
 }
 
-func (o *OsFetcher) Set(key, value string) {}
+func (o *OsFetcher) set(key, value string) {
+	panic("cannot modify OS ENV keys")
+}
 
-func (o *OsFetcher) Del(key string) {}
+func (o *OsFetcher) del(key string) {
+	panic("cannot modify OS ENV keys")
+}

--- a/config/os_fetcher.go
+++ b/config/os_fetcher.go
@@ -58,4 +58,6 @@ func (o *OsFetcher) All() map[string]string {
 	return nil
 }
 
+func (o *OsFetcher) Set(key, value string) {}
+
 func (o *OsFetcher) Del(key string) {}

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -61,7 +61,7 @@ func testServerApi(cmd *cobra.Command, args []string) {
 	}
 
 	// Force loading of config before we alter it
-	config.Config.AllGitConfig()
+	config.Config.Git.All()
 
 	// Configure the endpoint manually
 	var endp config.Endpoint

--- a/transfer/custom.go
+++ b/transfer/custom.go
@@ -349,7 +349,7 @@ func newCustomAdapter(name string, dir Direction, path, args string, concurrent 
 // Initialise custom adapters based on current config
 func configureCustomAdapters(cfg *config.Configuration, m *Manifest) {
 	pathRegex := regexp.MustCompile(`lfs.customtransfer.([^.]+).path`)
-	for k, v := range cfg.AllGitConfig() {
+	for k, v := range cfg.Git.All() {
 		match := pathRegex.FindStringSubmatch(k)
 		if match == nil {
 			continue


### PR DESCRIPTION
I thought it'd be cool to decouple some things from a `*config.Configuration`, specifically `cfg.Endpoint()`. When converting a raw url to an `Endpoint`, [`config.NewEndpointWithConfig()`](https://github.com/github/git-lfs/blob/a45eaee6fa35993763f87aa7611586faea08dfd5/config/endpoint.go#L54-L56) calls [`ReplaceUrlAlias()`](https://github.com/github/git-lfs/blob/a45eaee6fa35993763f87aa7611586faea08dfd5/config/config.go#L451-L454), which [calls `AllGitConfig()` inside `urlAliases()`](https://github.com/github/git-lfs/blob/a45eaee6fa35993763f87aa7611586faea08dfd5/config/config.go#L430-L438).

This PR adds `All()` to the `config.Environment` interface. But, it also had to add `Del(key string)` and `Set(key, value string)` because of a single spot that modifies that internal `gitConfig` map. I'm not crazy about it, but I think it's better than dealing with that `gitConfig`.

One thought I had was specififying a `MutableEnvironment` interface:

```golang
type Environment interface {
	Get(key string) (val string, ok bool)
	Bool(key string, def bool) (val bool)
	Int(key string, def int) (val int)
	All() map[string]string
}

type MutableEnvironment interface {
	Set(key, value string)
	Del(key string)
}

type Configuration struct {
	Os Environment
	Git Environment
	mutableGit MutableEnvironment
// ...
```

They would need to point to the same data so that changes in `SetEndpointAccess()` affect `Git.Get()` calls elsewhere, but it could be some extra hassle to ensure callers don't start adding `Set()` and `Delete()` calls on `Environment` objects.

* [x] add `MutableEnvironment`?
* [x] Rename Fetcher?
* [x] Docs for all exported funcs