### PR TITLE
README: set minimal required Git version to 1.8.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ preferences.
 
 [rel]: https://github.com/github/git-lfs/releases
 
-Note: Git LFS requires Git v1.8.2 or higher.
+Note: Git LFS requires Git v1.8.5 or higher.
 
 Once installed, you need to setup the global Git hooks for Git LFS. This only
 needs to be done once per machine.


### PR DESCRIPTION
Git 1.8.2 seems to be sufficent for Linux but not for macOS. 

Related change: 632f4881293d6974f169adce3a0f53b4e96393bb